### PR TITLE
refactor(web-react): upstream shared dataviz number and scale helpers 

### DIFF
--- a/datahub-web-react/package.json
+++ b/datahub-web-react/package.json
@@ -50,6 +50,7 @@
         "@visx/axis": "^3.1.0",
         "@visx/curve": "^3.0.0",
         "@visx/gradient": "^3.3.0",
+        "@visx/grid": "^3.5.0",
         "@visx/group": "^3.0.0",
         "@visx/hierarchy": "^3.0.0",
         "@visx/legend": "^3.2.0",

--- a/datahub-web-react/src/app/dataviz/ChartCard.tsx
+++ b/datahub-web-react/src/app/dataviz/ChartCard.tsx
@@ -1,0 +1,63 @@
+// Ported verbatim from the cloud fork. Swapping to @components would diverge this
+// convergence port, so the antd import is kept and the two repos migrate together.
+// eslint-disable-next-line rulesdir/no-antd-imports
+import { Typography } from 'antd';
+import React from 'react';
+import styled from 'styled-components';
+
+import { ANTD_GRAY } from '@app/entity/shared/constants';
+import InfoTooltip from '@app/sharedV2/icons/InfoTooltip';
+
+const Card = styled.div`
+    display: flex;
+    flex-direction: column;
+    padding: 1rem;
+    background-color: white;
+    box-shadow: 0px 3px 6px 0px ${ANTD_GRAY[5]};
+    border-radius: 8px;
+
+    text {
+        fill: ${ANTD_GRAY[8]};
+        font-weight: 400 !important;
+    }
+`;
+
+const Header = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+`;
+
+const Body = styled.div`
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+`;
+
+const Heading = styled(Typography.Text)`
+    display: flex;
+    gap: 8px;
+    font-size: 14px;
+    font-weight: 600;
+    color: ${ANTD_GRAY[8]};
+    min-width: 300px;
+`;
+
+interface Props {
+    title: string;
+    titleInfo?: string;
+    chart: React.ReactElement;
+    flex?: number;
+}
+
+export const ChartCard = ({ title, titleInfo, chart, flex = 1 }: Props) => (
+    <Card style={{ flex }}>
+        <Header>
+            <Heading>
+                {title} {titleInfo && <InfoTooltip content={titleInfo} />}
+            </Heading>
+        </Header>
+        <Body>{chart}</Body>
+    </Card>
+);

--- a/datahub-web-react/src/app/dataviz/Legend.tsx
+++ b/datahub-web-react/src/app/dataviz/Legend.tsx
@@ -1,0 +1,30 @@
+import { LegendItem, LegendLabel, LegendOrdinal } from '@visx/legend';
+import React from 'react';
+
+interface Props {
+    scale: any;
+}
+
+export const Legend = ({ scale }: Props) => {
+    return (
+        <LegendOrdinal scale={scale}>
+            {(labels) => (
+                <div style={{ display: 'flex', flexDirection: 'row' }}>
+                    {labels.map((label) => (
+                        <LegendItem
+                            key={`legend-quantile-${label.text}-${label.value}-${Math.random() * 2024}`}
+                            margin="0 20px 0 0"
+                        >
+                            <svg width={8} height={8}>
+                                <rect fill={label.value} width={8} height={8} />
+                            </svg>
+                            <LegendLabel align="left" margin="0 0 0 5px">
+                                {label.text}
+                            </LegendLabel>
+                        </LegendItem>
+                    ))}
+                </div>
+            )}
+        </LegendOrdinal>
+    );
+};

--- a/datahub-web-react/src/app/dataviz/bar/BarChart.tsx
+++ b/datahub-web-react/src/app/dataviz/bar/BarChart.tsx
@@ -1,0 +1,111 @@
+import { ParentSize } from '@visx/responsive';
+import { Axis, BarSeries, BarStack, Grid, XYChart } from '@visx/xychart';
+import React from 'react';
+import { useTheme } from 'styled-components';
+
+import { Legend } from '@app/dataviz/Legend';
+import { ChartWrapper } from '@app/dataviz/components';
+import { abbreviateNumber } from '@app/dataviz/utils';
+import dayjs from '@utils/dayjs';
+
+export const BarChart = <Data extends object, DataKeys>({
+    data,
+    dataKeys,
+    xAccessor,
+    yAccessor,
+    colorAccessor,
+    tickFormat = 'MMM D',
+    yAxisLabel,
+}: {
+    data: any;
+    dataKeys: DataKeys;
+    xAccessor: (d: Data) => string;
+    yAccessor: (d: any, key: string) => string;
+    colorAccessor: (d: string) => string;
+    tickFormat?: string;
+    yAxisLabel?: string;
+}) => {
+    const theme = useTheme();
+    if (!Array.isArray(dataKeys)) throw new Error('Datakeys must be an array');
+
+    const multipleData = dataKeys.length > 1;
+    const margin = { top: 20, right: 20, bottom: 30, left: 60 };
+    const tickCount = Math.max(1, Math.min(data.length, 10));
+
+    return (
+        <ChartWrapper>
+            <ParentSize>
+                {({ width }) => {
+                    if (!width) return null;
+
+                    return (
+                        <>
+                            <XYChart
+                                width={width}
+                                height={255}
+                                xScale={{ type: 'band', nice: true, invert: true, paddingInner: 0.3 }}
+                                yScale={{ type: 'linear' }}
+                                margin={margin}
+                                captureEvents={false}
+                            >
+                                <Grid
+                                    columns={false}
+                                    numTicks={tickCount}
+                                    lineStyle={{ stroke: theme.colors.border }}
+                                />
+                                {multipleData ? (
+                                    <BarStack>
+                                        {dataKeys
+                                            .slice()
+                                            .reverse()
+                                            .map((dK) => (
+                                                <BarSeries
+                                                    key={dK}
+                                                    dataKey={dK}
+                                                    data={data}
+                                                    xAccessor={xAccessor}
+                                                    yAccessor={(d) => yAccessor(d, dK)}
+                                                    colorAccessor={() => colorAccessor(dK)}
+                                                />
+                                            ))}
+                                    </BarStack>
+                                ) : (
+                                    <BarSeries
+                                        dataKey={dataKeys[0]}
+                                        data={data}
+                                        xAccessor={xAccessor}
+                                        yAccessor={(d) => yAccessor(d, dataKeys[0])}
+                                        colorAccessor={() => colorAccessor(dataKeys[0])}
+                                        radiusTop
+                                    />
+                                )}
+                                <Axis
+                                    orientation="bottom"
+                                    numTicks={Math.round(width / 100)}
+                                    tickFormat={(d) => dayjs(d).format(tickFormat)}
+                                    hideAxisLine
+                                />
+                                {/* Left Axis is for COUNT/NUMBER values only */}
+                                <Axis
+                                    orientation="left"
+                                    label={yAxisLabel}
+                                    labelOffset={20}
+                                    numTicks={tickCount}
+                                    tickLineProps={{ strokeWidth: 1 }}
+                                    tickFormat={(value) => (Number.isInteger(value) ? value : '')}
+                                    tickComponent={({ x, y, formattedValue }) => (
+                                        <text x={x} y={y} dy={3} dx={-3} fontSize="10" textAnchor="end">
+                                            <tspan>{abbreviateNumber(formattedValue)}</tspan>
+                                        </text>
+                                    )}
+                                    hideAxisLine
+                                />
+                            </XYChart>
+                            <Legend scale={colorAccessor} />
+                        </>
+                    );
+                }}
+            </ParentSize>
+        </ChartWrapper>
+    );
+};

--- a/datahub-web-react/src/app/dataviz/bar/HorizontalBarChart.tsx
+++ b/datahub-web-react/src/app/dataviz/bar/HorizontalBarChart.tsx
@@ -1,0 +1,154 @@
+/* eslint-disable @typescript-eslint/dot-notation, no-param-reassign */
+import { AxisLeft } from '@visx/axis';
+import { ParentSize } from '@visx/responsive';
+import { scaleBand, scaleLinear } from '@visx/scale';
+import { Bar, BarStackHorizontal } from '@visx/shape';
+import { Grid, XYChart } from '@visx/xychart';
+import React from 'react';
+
+import { Legend } from '@app/dataviz/Legend';
+import { ChartWrapper } from '@app/dataviz/components';
+import { COMPLETED_COLOR, IN_PROGRESS_COLOR, NOT_STARTED_COLOR } from '@app/dataviz/constants';
+
+export const HorizontalBarChart = <Data extends object, DataKeys>({
+    data,
+    dataKeys,
+    yAccessor,
+    colorAccessor,
+}: {
+    data: Data[];
+    dataKeys: DataKeys;
+    yAccessor: (d: Data) => string;
+    colorAccessor: (d: string) => string;
+}) => {
+    if (!data || !data.length || !dataKeys) return null;
+    if (!Array.isArray(dataKeys)) throw new Error('Datakeys must be an array');
+
+    const totals = data.reduce((allTotals, currentDate) => {
+        const total = dataKeys.reduce((dailyTotal, k) => {
+            dailyTotal += Number(currentDate[k]);
+            return dailyTotal;
+        }, 0);
+        allTotals.push(total);
+        return allTotals;
+    }, [] as number[]);
+
+    const xScale = scaleLinear<number>({
+        domain: [0, Math.max(...totals)],
+        nice: true,
+    });
+
+    const yScale = scaleBand<string>({
+        domain: data.map(yAccessor),
+        padding: 0.2,
+    });
+
+    return (
+        <ChartWrapper>
+            <ParentSize>
+                {({ width: parentWidth }) => {
+                    if (!parentWidth) return null;
+
+                    const margin = { top: 20, right: 0, bottom: 0, left: 120 };
+                    const baseHeight = data.length < 2 ? 180 : 280;
+                    const xMax = parentWidth - margin.left - margin.right;
+                    const yMax = baseHeight - margin.top - margin.bottom;
+
+                    xScale.rangeRound([0, xMax]);
+                    yScale.rangeRound([yMax, 0]);
+
+                    return (
+                        <>
+                            <XYChart
+                                width={parentWidth}
+                                height={baseHeight}
+                                margin={margin}
+                                xScale={{ type: 'linear' }}
+                                yScale={{ type: 'band', paddingInner: 0.3 }}
+                                captureEvents={false}
+                            >
+                                <Grid numTicks={5} lineStyle={{ stroke: '#EAEAEA' }} rows={false} />
+
+                                <BarStackHorizontal
+                                    data={data}
+                                    keys={dataKeys.slice().reverse()}
+                                    width={parentWidth}
+                                    height={baseHeight}
+                                    y={yAccessor}
+                                    xScale={xScale}
+                                    yScale={yScale}
+                                    color={colorAccessor}
+                                >
+                                    {(barStacks) =>
+                                        barStacks.map((barStack) =>
+                                            barStack.bars.map((bar) => {
+                                                // Use the bar color to determine which label to display for Doc Initiatives
+                                                let label = null;
+                                                if (bar.color === COMPLETED_COLOR) label = bar.bar.data['Completed'];
+                                                if (bar.color === IN_PROGRESS_COLOR)
+                                                    label = bar.bar.data['In Progress'];
+                                                if (bar.color === NOT_STARTED_COLOR)
+                                                    label = bar.bar.data['Not Started'];
+
+                                                if (label === '0') return null;
+
+                                                const { x, y, width, height } = bar;
+                                                const { left } = margin;
+
+                                                const newX = x + left + 10;
+                                                const barWidth = width + 5;
+
+                                                let textX = barWidth <= 20 ? newX + barWidth - 5 : newX + barWidth - 15;
+                                                if (barWidth > 300) textX = newX + barWidth - 20;
+
+                                                return (
+                                                    <g key={`barstack-horizontal-${barStack.index}-${bar.index}`}>
+                                                        <Bar
+                                                            x={newX}
+                                                            y={y}
+                                                            width={barWidth}
+                                                            height={height}
+                                                            fill={bar.color}
+                                                        />
+                                                        {label && (
+                                                            <text
+                                                                className="horizontalBarChartInlineLabel"
+                                                                x={textX}
+                                                                y={y + height / 2}
+                                                                dy=".33em"
+                                                                textAnchor="end"
+                                                                fontSize={11}
+                                                            >
+                                                                {label}
+                                                            </text>
+                                                        )}
+                                                    </g>
+                                                );
+                                            }),
+                                        )
+                                    }
+                                </BarStackHorizontal>
+                                <AxisLeft
+                                    hideAxisLine
+                                    scale={yScale}
+                                    tickLabelProps={{
+                                        fontSize: 11,
+                                        textAnchor: 'end',
+                                        dy: '0.33em',
+                                        x: margin.left,
+                                        width: 135,
+                                    }}
+                                    tickLineProps={{
+                                        x1: margin.left + 5,
+                                        x2: margin.left + 10,
+                                    }}
+                                />
+                            </XYChart>
+                            <Legend scale={colorAccessor} />
+                        </>
+                    );
+                }}
+            </ParentSize>
+        </ChartWrapper>
+    );
+};

--- a/datahub-web-react/src/app/dataviz/bar/HorizontalFullBarChart.tsx
+++ b/datahub-web-react/src/app/dataviz/bar/HorizontalFullBarChart.tsx
@@ -1,0 +1,154 @@
+/* eslint-disable @typescript-eslint/dot-notation, no-param-reassign */
+import { AxisLeft } from '@visx/axis';
+import { ParentSize } from '@visx/responsive';
+import { scaleBand, scaleLinear } from '@visx/scale';
+import { Bar, BarStackHorizontal } from '@visx/shape';
+import { Grid, XYChart } from '@visx/xychart';
+import React from 'react';
+
+import { Legend } from '@app/dataviz/Legend';
+import { ChartWrapper } from '@app/dataviz/components';
+import { COMPLETED_COLOR, IN_PROGRESS_COLOR, NOT_STARTED_COLOR } from '@app/dataviz/constants';
+
+export const HorizontalFullBarChart = <Data extends object, DataKeys>({
+    data,
+    dataKeys,
+    yAccessor,
+    colorAccessor,
+}: {
+    data: Data[];
+    dataKeys: DataKeys;
+    yAccessor: (d: Data) => string;
+    colorAccessor: (d: string) => string;
+}) => {
+    if (!data || !data.length || !dataKeys) return null;
+    if (!Array.isArray(dataKeys)) throw new Error('Datakeys must be an array');
+
+    const totals = data.reduce((allTotals, currentDate) => {
+        const total = dataKeys.reduce((dailyTotal, k) => {
+            dailyTotal += Number(currentDate[k]);
+            return dailyTotal;
+        }, 0);
+        allTotals.push(total);
+        return allTotals;
+    }, [] as number[]);
+
+    const xScale = scaleLinear<number>({
+        domain: [0, Math.max(...totals)],
+        nice: true,
+    });
+
+    const yScale = scaleBand<string>({
+        domain: data.map(yAccessor),
+        padding: 0.2,
+    });
+
+    return (
+        <ChartWrapper>
+            <ParentSize>
+                {({ width: parentWidth }) => {
+                    if (!parentWidth) return null;
+
+                    const margin = { top: 20, right: 0, bottom: 0, left: 120 };
+                    const baseHeight = 280;
+                    const calculatedHeight = data.length > 4 ? baseHeight + data.length * 10 : baseHeight;
+                    const xMax = parentWidth - margin.left - margin.right;
+                    const yMax = calculatedHeight - margin.top - margin.bottom;
+
+                    xScale.rangeRound([0, xMax]);
+                    yScale.rangeRound([yMax, 0]);
+
+                    return (
+                        <>
+                            <XYChart
+                                width={parentWidth}
+                                height={calculatedHeight}
+                                margin={margin}
+                                xScale={{ type: 'linear' }}
+                                yScale={{ type: 'band', paddingInner: 0.3 }}
+                                captureEvents={false}
+                            >
+                                <Grid numTicks={5} lineStyle={{ stroke: '#EAEAEA' }} rows={false} />
+
+                                <BarStackHorizontal
+                                    data={data}
+                                    keys={dataKeys.slice().reverse()}
+                                    width={parentWidth}
+                                    y={yAccessor}
+                                    xScale={xScale}
+                                    yScale={yScale}
+                                    color={colorAccessor}
+                                >
+                                    {(barStacks) =>
+                                        barStacks.map((barStack) =>
+                                            barStack.bars.map((bar) => {
+                                                // Use the bar color to determine which label to display for Doc Initiatives
+                                                let label = null;
+                                                if (bar.color === COMPLETED_COLOR) label = bar.bar.data['Completed'];
+                                                if (bar.color === IN_PROGRESS_COLOR)
+                                                    label = bar.bar.data['In Progress'];
+                                                if (bar.color === NOT_STARTED_COLOR)
+                                                    label = bar.bar.data['Not Started'];
+
+                                                if (label === '0') return null;
+
+                                                const { x, y, width, height } = bar;
+                                                const { left } = margin;
+
+                                                const newX = x + left + 10;
+                                                const barWidth = width + 5;
+
+                                                let textX = barWidth <= 20 ? newX + barWidth - 5 : newX + barWidth - 10;
+                                                if (barWidth > 300) textX = newX + barWidth - 20;
+
+                                                return (
+                                                    <g key={`barstack-horizontal-${barStack.index}-${bar.index}`}>
+                                                        <Bar
+                                                            x={newX}
+                                                            y={y}
+                                                            width={barWidth}
+                                                            height={height}
+                                                            fill={bar.color}
+                                                        />
+                                                        {label && (
+                                                            <text
+                                                                className="horizontalBarChartInlineLabel"
+                                                                x={textX}
+                                                                y={y + height / 2}
+                                                                dy=".33em"
+                                                                textAnchor="end"
+                                                                fontSize={11}
+                                                            >
+                                                                {label}
+                                                            </text>
+                                                        )}
+                                                    </g>
+                                                );
+                                            }),
+                                        )
+                                    }
+                                </BarStackHorizontal>
+                                <AxisLeft
+                                    hideAxisLine
+                                    scale={yScale}
+                                    tickLabelProps={{
+                                        fontSize: 11,
+                                        textAnchor: 'end',
+                                        dy: '0.33em',
+                                        x: margin.left,
+                                        width: 135,
+                                    }}
+                                    tickLineProps={{
+                                        x1: margin.left + 5,
+                                        x2: margin.left + 10,
+                                    }}
+                                />
+                            </XYChart>
+                            <Legend scale={colorAccessor} />
+                        </>
+                    );
+                }}
+            </ParentSize>
+        </ChartWrapper>
+    );
+};

--- a/datahub-web-react/src/app/dataviz/candle/CandleStick.tsx
+++ b/datahub-web-react/src/app/dataviz/candle/CandleStick.tsx
@@ -1,0 +1,94 @@
+import { GlyphCircle, GlyphDiamond } from '@visx/glyph';
+import { GlyphCircleProps } from '@visx/glyph/lib/glyphs/GlyphCircle';
+import { GlyphDiamondProps } from '@visx/glyph/lib/glyphs/GlyphDiamond';
+import { Group } from '@visx/group';
+import { Bar } from '@visx/shape';
+import { BarProps } from '@visx/shape/lib/shapes/Bar';
+import { AddSVGProps } from '@visx/shape/lib/types';
+import React from 'react';
+
+type DiamondProps = GlyphDiamondProps<any> & Omit<React.SVGProps<SVGPathElement>, keyof GlyphDiamondProps<any>>;
+type CircleProps = GlyphCircleProps<any> & Omit<React.SVGProps<SVGPathElement>, keyof GlyphCircleProps<any>>;
+type CandleBarProps = AddSVGProps<BarProps, SVGRectElement>;
+
+type Props = {
+    parentChartHeight: number;
+    candleHeight: number;
+    barWidth: number;
+    shapeSize: number;
+    leftOffset: number;
+    color: string;
+    shape:
+        | {
+              type: 'diamond';
+              extraProps?: DiamondProps;
+          }
+        | {
+              type: 'circle';
+              extraProps?: CircleProps;
+          };
+    markerOverlapPx?: number;
+    extraBarProps?: CandleBarProps;
+    opacity?: number;
+    wrapper?: (children: JSX.Element) => JSX.Element;
+    showWarningOverlay?: boolean;
+};
+export const CandleStick = ({
+    parentChartHeight,
+    candleHeight,
+    barWidth,
+    shapeSize,
+    leftOffset,
+    color,
+    shape,
+    wrapper,
+    opacity,
+    markerOverlapPx,
+    extraBarProps,
+    showWarningOverlay,
+}: Props) => {
+    const yOffset = parentChartHeight - candleHeight;
+
+    const shapeProps: DiamondProps | CircleProps = {
+        top: yOffset,
+        left: leftOffset,
+        fill: color,
+        stroke: 'white',
+        strokeWidth: (markerOverlapPx ?? 1) > 1 ? 1 / (markerOverlapPx ?? 1) : 1,
+        filter: markerOverlapPx ? undefined : 'drop-shadow(0px 1px 2.5px rgb(0 0 0 / 0.1))',
+        size: shapeSize,
+        ...shape.extraProps,
+    };
+    const barProps: CandleBarProps = {
+        height: candleHeight,
+        width: barWidth,
+        x: leftOffset - barWidth / 2,
+        y: yOffset,
+        fill: color,
+        stroke: 'white',
+        strokeWidth: (markerOverlapPx ?? 1) > 1 ? 1 / (markerOverlapPx ?? 1) : 1,
+        ...extraBarProps,
+    };
+
+    const candleGroup = (
+        <Group opacity={opacity}>
+            <Bar {...barProps} />
+            {shape.type === 'diamond' ? <GlyphDiamond {...shapeProps} /> : <GlyphCircle {...shapeProps} />}
+            {/* For Smart Assertions: '!' icon overlaps if this has been marked as a false positive or false negative */}
+            {showWarningOverlay ? (
+                // Downloaded from phosphor icons
+                <svg
+                    x={leftOffset - shapeSize / 20}
+                    y={yOffset - shapeSize / 20}
+                    width={shapeSize / 10}
+                    height={shapeSize / 10}
+                    fill="white"
+                    viewBox="0 0 256 256"
+                >
+                    <path d="M144,200a16,16,0,1,1-16-16A16,16,0,0,1,144,200Zm-16-40a8,8,0,0,0,8-8V48a8,8,0,0,0-16,0V152A8,8,0,0,0,128,160Z" />
+                </svg>
+            ) : null}
+        </Group>
+    );
+    return wrapper ? wrapper(candleGroup) : candleGroup;
+};

--- a/datahub-web-react/src/app/dataviz/components.ts
+++ b/datahub-web-react/src/app/dataviz/components.ts
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+export const ChartWrapper = styled.div`
+    width: 100%;
+    height: 100%;
+    position: relative;
+
+    .horizontalBarChartTick {
+        foreignObject {
+            text-align: right;
+        }
+    }
+
+    .horizontalBarChartInlineLabel {
+        fill: #fff;
+        font-weight: 600;
+        font-family: 'Manrope', sans-serif;
+    }
+
+    .visx-axis-label {
+        font-weight: 600 !important;
+        font-family: 'Manrope', sans-serif !important;
+    }
+`;

--- a/datahub-web-react/src/app/dataviz/constants.ts
+++ b/datahub-web-react/src/app/dataviz/constants.ts
@@ -1,0 +1,3 @@
+export const COMPLETED_COLOR = '#20D3BD';
+export const IN_PROGRESS_COLOR = '#7532A4';
+export const NOT_STARTED_COLOR = '#1677FF';

--- a/datahub-web-react/src/app/dataviz/donut/Donut.tsx
+++ b/datahub-web-react/src/app/dataviz/donut/Donut.tsx
@@ -1,0 +1,78 @@
+import { Group } from '@visx/group';
+import { Pie } from '@visx/shape';
+import React, { useMemo } from 'react';
+import { useTheme } from 'styled-components';
+
+type Props = {
+    /** Progress value, 0–100. */
+    value: number;
+    /** Outer diameter in pixels. */
+    size?: number;
+    /** Ring thickness in pixels. */
+    thickness?: number;
+    /** Optional content rendered in the center. Defaults to `${value}%`. */
+    children?: React.ReactNode;
+    /** Accessible label for the donut. */
+    ariaLabel?: string;
+};
+
+const DEFAULT_SIZE = 96;
+const DEFAULT_THICKNESS = 10;
+
+export function Donut({ value, size = DEFAULT_SIZE, thickness = DEFAULT_THICKNESS, children, ariaLabel }: Props) {
+    const theme = useTheme();
+    const gradientId = useMemo(() => `donut-gradient-${Math.random().toString(36).slice(2, 10)}`, []);
+    const radius = size / 2;
+    const safeValue = Math.max(0, Math.min(100, value));
+
+    const arcs = [
+        { key: 'value', value: safeValue, fill: `url(#${gradientId})` },
+        { key: 'rest', value: 100 - safeValue, fill: theme.colors.bgSurface },
+    ];
+
+    return (
+        <svg
+            width={size}
+            height={size}
+            role="img"
+            aria-label={ariaLabel ?? `${Math.round(safeValue)} percent`}
+            style={{ overflow: 'visible' }}
+        >
+            <defs>
+                <linearGradient id={gradientId} x1={size} y1={0} x2={0} y2={0} gradientUnits="userSpaceOnUse">
+                    <stop offset="0%" stopColor={theme.colors.iconBrand} />
+                    <stop offset="100%" stopColor={theme.colors.borderBrand} />
+                </linearGradient>
+            </defs>
+            <Group top={radius} left={radius}>
+                <Pie
+                    data={arcs}
+                    pieValue={(d) => d.value}
+                    outerRadius={radius}
+                    innerRadius={radius - thickness}
+                    cornerRadius={3}
+                    padAngle={safeValue > 0 && safeValue < 100 ? 0.01 : 0}
+                >
+                    {(pie) =>
+                        pie.arcs.map((arc) => (
+                            <path key={arc.data.key} d={pie.path(arc) ?? undefined} fill={arc.data.fill} />
+                        ))
+                    }
+                </Pie>
+            </Group>
+            <foreignObject x={0} y={0} width={size} height={size}>
+                <div
+                    style={{
+                        width: size,
+                        height: size,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                    }}
+                >
+                    {children ?? `${Math.round(safeValue)}%`}
+                </div>
+            </foreignObject>
+        </svg>
+    );
+}

--- a/datahub-web-react/src/app/dataviz/index.ts
+++ b/datahub-web-react/src/app/dataviz/index.ts
@@ -1,0 +1,7 @@
+export * from './ChartCard';
+export * from './bar/BarChart';
+export * from './bar/HorizontalBarChart';
+export * from './bar/HorizontalFullBarChart';
+export * from './donut/Donut';
+export * from './progress/ProgressBar';
+export * from './scatter/ScatterPlot';

--- a/datahub-web-react/src/app/dataviz/line/SimpleLineChart.tsx
+++ b/datahub-web-react/src/app/dataviz/line/SimpleLineChart.tsx
@@ -1,0 +1,81 @@
+import { curveCatmullRom } from '@visx/curve';
+import { MarkerCircle } from '@visx/marker';
+import { ParentSize } from '@visx/responsive';
+import { scaleLinear, scaleTime } from '@visx/scale';
+import { LinePath } from '@visx/shape';
+import { extent, max } from '@visx/vendor/d3-array';
+import React from 'react';
+
+import { ChartWrapper } from '@app/dataviz/components';
+
+/* eslint-disable rulesdir/no-hardcoded-colors -- decorative SVG sparkline brand gradient; these specific
+   chart colors have no semantic theme-token equivalent */
+const GRADIENT_START_COLOR = '#20D3BD';
+const GRADIENT_END_COLOR = '#9F33CC';
+const MARKER_STROKE_COLOR = '#fff';
+/* eslint-enable rulesdir/no-hardcoded-colors */
+
+interface Props {
+    data: any;
+}
+
+type Data = {
+    date: string;
+    value: number;
+};
+
+export const SimpleLineChart = ({ data }: Props) => {
+    const getDate = (d: Data) => new Date(d.date);
+    const getValue = (d: Data) => d.value;
+
+    const markerEnd = 'url(#marker-circle)';
+
+    return (
+        <ChartWrapper>
+            <ParentSize>
+                {({ width }) => {
+                    if (!width) return null;
+
+                    const height = 20;
+
+                    const xScale = scaleTime<number>({
+                        range: [0, width - 10],
+                        domain: extent(data, getDate) as [Date, Date],
+                    });
+
+                    const yScale = scaleLinear<number>({
+                        range: [height / 2, 5],
+                        domain: [0, (max(data, getValue) || 0) as number],
+                        nice: true,
+                    });
+
+                    return (
+                        <svg width={width} height={height}>
+                            <defs>
+                                <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                                    <stop offset="0%" stopColor={GRADIENT_START_COLOR} />
+                                    <stop offset="100%" stopColor={GRADIENT_END_COLOR} />
+                                </linearGradient>
+                            </defs>
+                            <MarkerCircle
+                                id="marker-circle"
+                                fill={GRADIENT_END_COLOR}
+                                stroke={MARKER_STROKE_COLOR}
+                                strokeWidth={2}
+                                size={3}
+                            />
+                            <LinePath
+                                data={data}
+                                x={(d: Data) => xScale(getDate(d))}
+                                y={(d: Data) => yScale(getValue(d))}
+                                curve={curveCatmullRom}
+                                markerEnd={markerEnd}
+                                stroke={GRADIENT_END_COLOR}
+                            />
+                        </svg>
+                    );
+                }}
+            </ParentSize>
+        </ChartWrapper>
+    );
+};

--- a/datahub-web-react/src/app/dataviz/progress/ProgressBar.tsx
+++ b/datahub-web-react/src/app/dataviz/progress/ProgressBar.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import styled, { DefaultTheme } from 'styled-components';
+
+export type ProgressBarVariant = 'brand' | 'success' | 'warning' | 'error';
+
+/**
+ * When `'auto'`, the variant is derived from value:
+ *   <50 → error (red), <75 → warning (yellow), >=75 → success (green).
+ *
+ * Brand (violet) is never used in `'auto'` — pass `variant="brand"` (or omit
+ * `variant`, since brand is the default) to opt into the violet gradient.
+ */
+export type ProgressBarVariantOrAuto = ProgressBarVariant | 'auto';
+
+type Props = {
+    /** Progress value, 0–100. */
+    value: number;
+    /** Color variant for the fill gradient. Defaults to 'brand'. */
+    variant?: ProgressBarVariantOrAuto;
+    /** Optional left-aligned label rendered above the bar. */
+    leftLabel?: React.ReactNode;
+    /** Optional right-aligned label rendered above the bar. */
+    rightLabel?: React.ReactNode;
+    /** Optional helper text rendered below the bar. */
+    subtext?: React.ReactNode;
+    /** Bar thickness in pixels. Defaults to 6. */
+    thickness?: number;
+    /** Accessible label for the progress bar. */
+    ariaLabel?: string;
+};
+
+function gradientStops(theme: DefaultTheme, variant: ProgressBarVariant): [string, string] {
+    switch (variant) {
+        case 'success':
+            return [theme.colors.iconSuccess, theme.colors.borderSuccess];
+        case 'warning':
+            return [theme.colors.iconWarning, theme.colors.borderWarning];
+        case 'error':
+            return [theme.colors.iconError, theme.colors.borderError];
+        case 'brand':
+        default:
+            return [theme.colors.iconBrand, theme.colors.borderBrand];
+    }
+}
+
+function resolveVariant(variant: ProgressBarVariantOrAuto, value: number): ProgressBarVariant {
+    if (variant !== 'auto') return variant;
+    if (value < 50) return 'error';
+    if (value < 75) return 'warning';
+    return 'success';
+}
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    width: 100%;
+`;
+
+const StatusRow = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    line-height: 15px;
+    font-weight: 700;
+    color: ${(props) => props.theme.colors.textSecondary};
+`;
+
+const Track = styled.div<{ $thickness: number }>`
+    width: 100%;
+    height: ${({ $thickness }) => $thickness}px;
+    border-radius: 200px;
+    background: ${(props) => props.theme.colors.bgSurface};
+    overflow: hidden;
+`;
+
+const Fill = styled.div<{ $pct: number; $variant: ProgressBarVariant }>`
+    height: 100%;
+    width: ${({ $pct }) => $pct}%;
+    background: ${({ theme, $variant }) => {
+        const [start, end] = gradientStops(theme, $variant);
+        return `linear-gradient(270deg, ${start} 0%, ${end} 100%)`;
+    }};
+    border-radius: 200px;
+    transition: width 0.4s ease;
+`;
+
+const Subtext = styled.div`
+    font-size: 12px;
+    line-height: 15px;
+    font-weight: 400;
+    color: ${(props) => props.theme.colors.textSecondary};
+`;
+
+export function ProgressBar({
+    value,
+    variant = 'brand',
+    leftLabel,
+    rightLabel,
+    subtext,
+    thickness = 6,
+    ariaLabel,
+}: Props) {
+    const pct = Math.max(0, Math.min(100, value));
+    const resolvedVariant = resolveVariant(variant, pct);
+    const showStatusRow = leftLabel !== undefined || rightLabel !== undefined;
+
+    return (
+        <Container>
+            {showStatusRow && (
+                <StatusRow>
+                    <span>{leftLabel}</span>
+                    <span>{rightLabel}</span>
+                </StatusRow>
+            )}
+            <Track
+                $thickness={thickness}
+                role="progressbar"
+                aria-label={ariaLabel}
+                aria-valuenow={Math.round(pct)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+            >
+                <Fill $pct={pct} $variant={resolvedVariant} />
+            </Track>
+            {subtext !== undefined && <Subtext>{subtext}</Subtext>}
+        </Container>
+    );
+}

--- a/datahub-web-react/src/app/dataviz/scatter/ScatterPlot.tsx
+++ b/datahub-web-react/src/app/dataviz/scatter/ScatterPlot.tsx
@@ -1,0 +1,336 @@
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import { GridColumns, GridRows } from '@visx/grid';
+import { Group } from '@visx/group';
+import { ParentSize } from '@visx/responsive';
+import { scaleLinear } from '@visx/scale';
+import React, { useState } from 'react';
+import styled, { useTheme } from 'styled-components';
+
+export type ScatterPoint<T = unknown> = {
+    id: string;
+    x: number;
+    y: number;
+    label?: string;
+    /** Optional fill for the circle. Defaults to brand color. */
+    color?: string;
+    meta?: T;
+};
+
+type Props<T> = {
+    points: ScatterPoint<T>[];
+    /** Domain for the X axis. Defaults to [0, 100]. */
+    xDomain?: [number, number];
+    /** Domain for the Y axis. Defaults to [0, 100]. */
+    yDomain?: [number, number];
+    xLabel?: string;
+    yLabel?: string;
+    /** Tick formatter. Defaults to `${v}%`. */
+    formatTick?: (v: number) => string;
+    /**
+     * Optional threshold for "danger zone" shading. The rectangle from
+     * [xDomain[0], threshold.x] × [yDomain[0], threshold.y] is shaded red.
+     */
+    dangerThreshold?: { x: number; y: number };
+    /** Optional label rendered inside the danger zone (e.g. "Needs attention"). */
+    dangerLabel?: string;
+    /**
+     * Optional threshold for "healthy zone" shading. The rectangle from
+     * [threshold.x, xDomain[1]] × [threshold.y, yDomain[1]] is shaded green.
+     */
+    healthyThreshold?: { x: number; y: number };
+    /** Optional label rendered inside the healthy zone (e.g. "Healthy"). */
+    healthyLabel?: string;
+    /** Called when a point is clicked. */
+    onPointClick?: (point: ScatterPoint<T>) => void;
+    /** Optional renderer for tooltip body — receives the hovered point. */
+    renderTooltip?: (point: ScatterPoint<T>) => React.ReactNode;
+    /** Chart height in pixels. Defaults to 360. */
+    height?: number;
+};
+
+const DEFAULT_HEIGHT = 360;
+const DEFAULT_DOMAIN: [number, number] = [0, 100];
+const POINT_RADIUS = 7;
+const POINT_HOVER_RADIUS = 9;
+const POINT_HALO_RADIUS = 13;
+const POINT_HALO_HOVER_RADIUS = 16;
+const POINT_HALO_OPACITY = 0.22;
+const POINT_HALO_HOVER_OPACITY = 0.35;
+const Y_AXIS_LABEL_TRANSFORM = 'rotate(-90)';
+
+const ChartWrapper = styled.div<{ $height: number }>`
+    position: relative;
+    width: 100%;
+    height: ${({ $height }) => $height}px;
+`;
+
+const TooltipBox = styled.div`
+    position: absolute;
+    pointer-events: none;
+    background: ${(props) => props.theme.colors.bg};
+    color: ${(props) => props.theme.colors.textSecondary};
+    border: 1px solid ${(props) => props.theme.colors.border};
+    border-radius: 6px;
+    box-shadow: ${(props) => props.theme.colors.shadowMd};
+    padding: 6px 8px;
+    font-size: 12px;
+    line-height: 1.4;
+    transform: translate(-50%, calc(-100% - 12px));
+    white-space: nowrap;
+    z-index: 10;
+`;
+
+const PointLabel = styled.text`
+    font-size: 11px;
+    font-weight: 500;
+    pointer-events: none;
+    user-select: none;
+`;
+
+const AxisLabel = styled.text`
+    font-size: 11px;
+    font-weight: 500;
+    text-anchor: middle;
+    pointer-events: none;
+`;
+
+const ZoneLabel = styled.text`
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    pointer-events: none;
+    user-select: none;
+`;
+
+export function ScatterPlot<T = unknown>({
+    points,
+    xDomain = DEFAULT_DOMAIN,
+    yDomain = DEFAULT_DOMAIN,
+    xLabel,
+    yLabel,
+    formatTick = (v) => `${v}%`,
+    dangerThreshold,
+    dangerLabel,
+    healthyThreshold,
+    healthyLabel,
+    onPointClick,
+    renderTooltip,
+    height = DEFAULT_HEIGHT,
+}: Props<T>) {
+    const theme = useTheme();
+    const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+    const margin = { top: 16, right: 24, bottom: xLabel ? 56 : 36, left: yLabel ? 64 : 44 };
+
+    return (
+        <ChartWrapper $height={height}>
+            <ParentSize>
+                {({ width }) => {
+                    if (!width) return null;
+                    const innerWidth = Math.max(0, width - margin.left - margin.right);
+                    const innerHeight = Math.max(0, height - margin.top - margin.bottom);
+
+                    const xScale = scaleLinear<number>({
+                        domain: xDomain,
+                        range: [0, innerWidth],
+                        clamp: true,
+                    });
+                    const yScale = scaleLinear<number>({
+                        domain: yDomain,
+                        range: [innerHeight, 0],
+                        clamp: true,
+                    });
+
+                    const dangerWidth = dangerThreshold ? xScale(dangerThreshold.x) - xScale(xDomain[0]) : 0;
+                    const dangerHeight = dangerThreshold ? yScale(yDomain[0]) - yScale(dangerThreshold.y) : 0;
+
+                    const healthyWidth = healthyThreshold ? xScale(xDomain[1]) - xScale(healthyThreshold.x) : 0;
+                    const healthyHeight = healthyThreshold ? yScale(healthyThreshold.y) - yScale(yDomain[1]) : 0;
+
+                    const hoveredPoint = points.find((p) => p.id === hoveredId);
+
+                    return (
+                        <>
+                            <svg width={width} height={height}>
+                                <Group left={margin.left} top={margin.top}>
+                                    {dangerThreshold && dangerWidth > 0 && dangerHeight > 0 && (
+                                        <>
+                                            <rect
+                                                x={xScale(xDomain[0])}
+                                                y={yScale(dangerThreshold.y)}
+                                                width={dangerWidth}
+                                                height={dangerHeight}
+                                                fill={theme.colors.bgSurfaceError}
+                                                opacity={0.4}
+                                                rx={4}
+                                            />
+                                            {dangerLabel && (
+                                                <ZoneLabel
+                                                    x={xScale(xDomain[0]) + 8}
+                                                    y={yScale(yDomain[0]) - 8}
+                                                    fill={theme.colors.textError}
+                                                >
+                                                    {dangerLabel}
+                                                </ZoneLabel>
+                                            )}
+                                        </>
+                                    )}
+
+                                    {healthyThreshold && healthyWidth > 0 && healthyHeight > 0 && (
+                                        <>
+                                            <rect
+                                                x={xScale(healthyThreshold.x)}
+                                                y={yScale(yDomain[1])}
+                                                width={healthyWidth}
+                                                height={healthyHeight}
+                                                fill={theme.colors.bgSurfaceSuccess}
+                                                opacity={0.35}
+                                                rx={4}
+                                            />
+                                            {healthyLabel && (
+                                                <ZoneLabel
+                                                    x={xScale(xDomain[1]) - 8}
+                                                    y={yScale(yDomain[1]) + 16}
+                                                    textAnchor="end"
+                                                    fill={theme.colors.textSuccess}
+                                                >
+                                                    {healthyLabel}
+                                                </ZoneLabel>
+                                            )}
+                                        </>
+                                    )}
+
+                                    <GridRows
+                                        scale={yScale}
+                                        width={innerWidth}
+                                        numTicks={5}
+                                        stroke={theme.colors.border}
+                                        strokeOpacity={0.6}
+                                    />
+                                    <GridColumns
+                                        scale={xScale}
+                                        height={innerHeight}
+                                        numTicks={5}
+                                        stroke={theme.colors.border}
+                                        strokeOpacity={0.6}
+                                    />
+
+                                    <AxisLeft
+                                        scale={yScale}
+                                        numTicks={5}
+                                        tickFormat={(v) => formatTick(v as number)}
+                                        stroke={theme.colors.border}
+                                        tickStroke={theme.colors.border}
+                                        tickLabelProps={() => ({
+                                            fill: theme.colors.textSecondary,
+                                            fontSize: 11,
+                                            textAnchor: 'end',
+                                            dx: '-0.25em',
+                                            dy: '0.33em',
+                                        })}
+                                    />
+                                    <AxisBottom
+                                        scale={xScale}
+                                        top={innerHeight}
+                                        numTicks={5}
+                                        tickFormat={(v) => formatTick(v as number)}
+                                        stroke={theme.colors.border}
+                                        tickStroke={theme.colors.border}
+                                        tickLabelProps={() => ({
+                                            fill: theme.colors.textSecondary,
+                                            fontSize: 11,
+                                            textAnchor: 'middle',
+                                        })}
+                                    />
+
+                                    {yLabel && (
+                                        <AxisLabel
+                                            x={-innerHeight / 2}
+                                            y={-margin.left + 16}
+                                            transform={Y_AXIS_LABEL_TRANSFORM}
+                                            fill={theme.colors.textSecondary}
+                                        >
+                                            {yLabel}
+                                        </AxisLabel>
+                                    )}
+                                    {xLabel && (
+                                        <AxisLabel
+                                            x={innerWidth / 2}
+                                            y={innerHeight + margin.bottom - 8}
+                                            fill={theme.colors.textSecondary}
+                                        >
+                                            {xLabel}
+                                        </AxisLabel>
+                                    )}
+
+                                    {points.map((point) => {
+                                        const cx = xScale(point.x);
+                                        const cy = yScale(point.y);
+                                        const isHovered = point.id === hoveredId;
+                                        const fill = point.color ?? theme.colors.iconBrand;
+                                        // Estimate label width (~7px per char @ fontSize 11) so we can flip
+                                        // labels to the left when a dot is too close to the right edge.
+                                        const estLabelWidth = (point.label?.length ?? 0) * 7 + 8;
+                                        const flipLabelLeft = cx + POINT_HALO_RADIUS + 4 + estLabelWidth > innerWidth;
+                                        const labelX = flipLabelLeft
+                                            ? cx - POINT_HALO_RADIUS - 4
+                                            : cx + POINT_HALO_RADIUS + 4;
+                                        return (
+                                            <g
+                                                key={point.id}
+                                                onMouseEnter={() => setHoveredId(point.id)}
+                                                onMouseLeave={() => setHoveredId(null)}
+                                                onClick={() => onPointClick?.(point)}
+                                                style={{ cursor: onPointClick ? 'pointer' : 'default' }}
+                                            >
+                                                <circle
+                                                    cx={cx}
+                                                    cy={cy}
+                                                    r={isHovered ? POINT_HALO_HOVER_RADIUS : POINT_HALO_RADIUS}
+                                                    fill={fill}
+                                                    fillOpacity={
+                                                        isHovered ? POINT_HALO_HOVER_OPACITY : POINT_HALO_OPACITY
+                                                    }
+                                                />
+                                                <circle
+                                                    cx={cx}
+                                                    cy={cy}
+                                                    r={isHovered ? POINT_HOVER_RADIUS : POINT_RADIUS}
+                                                    fill={fill}
+                                                    stroke={theme.colors.bg}
+                                                    strokeWidth={2}
+                                                />
+                                                {point.label && (
+                                                    <PointLabel
+                                                        x={labelX}
+                                                        y={cy + 4}
+                                                        textAnchor={flipLabelLeft ? 'end' : 'start'}
+                                                        fill={theme.colors.text}
+                                                    >
+                                                        {point.label}
+                                                    </PointLabel>
+                                                )}
+                                            </g>
+                                        );
+                                    })}
+                                </Group>
+                            </svg>
+
+                            {hoveredPoint && renderTooltip && (
+                                <TooltipBox
+                                    style={{
+                                        left: margin.left + xScale(hoveredPoint.x),
+                                        top: margin.top + yScale(hoveredPoint.y),
+                                    }}
+                                >
+                                    {renderTooltip(hoveredPoint)}
+                                </TooltipBox>
+                            )}
+                        </>
+                    );
+                }}
+            </ParentSize>
+        </ChartWrapper>
+    );
+}

--- a/datahub-web-react/src/app/dataviz/utils.ts
+++ b/datahub-web-react/src/app/dataviz/utils.ts
@@ -1,3 +1,22 @@
+// private utils to help with rounding y axis numbers
+const NUMERICAL_ABBREVIATIONS = ['k', 'm', 'b', 't'];
+function roundToPrecision(n: number, precision: number) {
+    const prec = 10 ** precision;
+    return Math.round(n * prec) / prec;
+}
+
+/**
+ * ie. 24044 -> 24k
+ * @param n
+ */
+export const truncateNumberForDisplay = (n: number, skipRounding?: boolean): string => {
+    let base = Math.floor(Math.log(Math.abs(n)) / Math.log(1000));
+    const suffix = NUMERICAL_ABBREVIATIONS[Math.min(NUMERICAL_ABBREVIATIONS.length - 1, base - 1)];
+    base = NUMERICAL_ABBREVIATIONS.indexOf(suffix) + 1;
+    const roundedNumber = skipRounding ? n : Math.round(n);
+    return suffix ? roundToPrecision(n / 1000 ** base, 0) + suffix : `${roundedNumber}`;
+};
+
 // IEEE-754 doubles carry ~16 significant decimal digits, and arithmetic like
 // `2713.2 / 1000` lands 1 ULP off its intended value (= 2.7131999999999996), so
 // String() prints the full noisy tail. Rounding to this many significant figures
@@ -17,3 +36,71 @@ export const abbreviateNumber = (str) => {
     const shortNumber = number / 10 ** (index * 3);
     return `${Number(shortNumber.toPrecision(ABBREVIATION_SIGNIFICANT_DIGITS))}${suffix}`;
 };
+
+type CalculateYScaleExtentForChartOptions = {
+    defaultYValue: number;
+    // Between 0-1, represents what % of the chart's height should be empty above and below.
+    // ie. if this is .1, then 10% of the chart's height will be empty.
+    yScaleBufferFactor?: number;
+};
+
+/**
+ * Creates a yscale range for charts, with optional buffers
+ * @param yValues
+ * @param options
+ */
+export const calculateYScaleExtentForChart = (
+    yValues: number[],
+    options: CalculateYScaleExtentForChartOptions = { defaultYValue: 0 },
+): { min: number; max: number } => {
+    let min = yValues.length ? Math.min(...yValues) : options.defaultYValue;
+    let max = yValues.length ? Math.max(...yValues) : options.defaultYValue;
+
+    // Add some extra range above and below so things aren't pushed to the edge
+    const { yScaleBufferFactor } = options;
+    if (yScaleBufferFactor) {
+        let yScaleBuffer = 0;
+        // Edge case: if max and min are the same, add some buffer above and below so the points are nicely centered
+        if (max === min) {
+            // Ie. Let's say max/min=1.5B. In this case we want to add ~100M buffer and and below
+            // This will make the y-axis display 1.4B at the bottom and 1.6B at the top,
+            // While nicely centering the data points.
+            const decimalPlaceValue = max.toString().length;
+            yScaleBuffer = 10 ** (decimalPlaceValue - 1);
+        } else {
+            // By default, the chart will put the min at the bottom edge and the max at the top edge.
+            // So if yScaleBufferFactor=0.1, then we want 10% of the chart at the top and bottom to be empty
+            const distance = max - min;
+            const newDistance = distance / (1 - yScaleBufferFactor);
+            yScaleBuffer = newDistance * yScaleBufferFactor;
+        }
+
+        min -= yScaleBuffer;
+        max += yScaleBuffer;
+    }
+
+    return { min, max };
+};
+
+/**
+ * Gets the px overlap between two markers
+ * @param marker1
+ * @param marker2
+ * @returns {number | undefined} undefined if no overlap
+ */
+export function calculateOverlapBetweenTwoMarkers(
+    marker1: { xOffset: number; width: number },
+    marker2: { xOffset: number; width: number },
+): undefined | number {
+    let markerOverlapPx: number | undefined;
+
+    // Take width of the left and right half of the two markers (where they will collide)
+    const netWidth = marker1.width / 2 + marker2.width / 2;
+
+    // Calculate distance and potential overlap
+    const distance = Math.abs(marker1.xOffset - marker2.xOffset);
+    if (distance < netWidth) {
+        markerOverlapPx = netWidth - distance;
+    }
+    return markerOverlapPx;
+}

--- a/datahub-web-react/src/app/sharedV2/icons/InfoTooltip.tsx
+++ b/datahub-web-react/src/app/sharedV2/icons/InfoTooltip.tsx
@@ -1,0 +1,32 @@
+import { InfoCircleFilled, InfoCircleOutlined } from '@ant-design/icons';
+import { Tooltip } from '@components';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+const InfoWrapper = styled.div`
+    color: ${(props) => props.theme.colors.textBrand};
+`;
+
+interface Props {
+    content: React.ReactNode;
+    className?: string;
+}
+
+export default function InfoTooltip({ content, className }: Props) {
+    const [showTooltip, setShowTooltip] = useState(false);
+
+    return (
+        <InfoWrapper className={className}>
+            <Tooltip
+                placement="top"
+                title={content}
+                trigger="hover"
+                open={showTooltip}
+                onOpenChange={setShowTooltip}
+                showArrow={false}
+            >
+                {showTooltip ? <InfoCircleFilled /> : <InfoCircleOutlined />}
+            </Tooltip>
+        </InfoWrapper>
+    );
+}

--- a/datahub-web-react/yarn.lock
+++ b/datahub-web-react/yarn.lock
@@ -5611,6 +5611,20 @@
     classnames "^2.3.1"
     prop-types "^15.6.2"
 
+"@visx/grid@^3.5.0":
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/@visx/grid/-/grid-3.12.0.tgz#fca39fa246f273ea31c80e4a66762a037bacca99"
+  integrity sha512-L4ex2ooSYhwNIxJ3XFIKRhoSvEGjPc2Y3YCrtNB4TV5Ofdj4q0UMOsxfrH23Pr8HSHuQhb6VGMgYoK0LuWqDmQ==
+  dependencies:
+    "@types/react" "*"
+    "@visx/curve" "3.12.0"
+    "@visx/group" "3.12.0"
+    "@visx/point" "3.12.0"
+    "@visx/scale" "3.12.0"
+    "@visx/shape" "3.12.0"
+    classnames "^2.3.1"
+    prop-types "^15.6.2"
+
 "@visx/group@3.12.0":
   version "3.12.0"
   resolved "https://registry.npmjs.org/@visx/group/-/group-3.12.0.tgz"
@@ -5658,6 +5672,11 @@
   version "3.0.1"
   resolved "https://registry.npmjs.org/@visx/point/-/point-3.0.1.tgz"
   integrity sha512-S5WOBMgEP2xHcgs3A2BFB2vwzrk0tMmn3PGZAbQJ+lu4HlnalDP72klUnxLTH8xclNNvpUHtHM5eLIJXyHx6Pw==
+
+"@visx/point@3.12.0":
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/@visx/point/-/point-3.12.0.tgz#d3eedcbb37acef5ec86550cbacb013a61e7e7eee"
+  integrity sha512-I6UrHoJAEVbx3RORQNupgTiX5EzjuZpiwLPxn8L2mI5nfERotPKi1Yus12Cq2WtXqEBR/WgqTnoImlqOXBykcA==
 
 "@visx/react-spring@3.2.0":
   version "3.2.0"


### PR DESCRIPTION
Brings datahub-web-react/src/app/dataviz in line with the DataHub Cloud fork, where the directory had grown a full chart library that OSS never received. Two commits, reviewable independently:

1. utils.ts helpers (+87/−0) — truncateNumberForDisplay for K/M/B/T axis labels, calculateYScaleExtentForChart for y-axis extents with an optional buffer, and calculateOverlapBetweenTwoMarkers for marker collision in px. The file is now identical to the fork; existing abbreviateNumber is untouched.
2. Chart primitives (+1318) — ChartCard, Legend, the shared ChartWrapper and colour constants, plus bar/ (BarChart, HorizontalBarChart, HorizontalFullBarChart), candle/ (CandleStick), donut/ (Donut), line/ (SimpleLineChart), progress/ (ProgressBar) and scatter/ (ScatterPlot), together with the InfoTooltip icon that ChartCard depends on.

@visx/grid becomes a direct dependency because ScatterPlot imports it directly; it was previously only reachable transitively through @visx/xychart, and the lockfile pinned a version that would not have satisfied the import. The lockfile gains the matching @visx/grid and @visx/point entries and stays consistent under --frozen-lockfile.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings the Cloud fork's dataviz chart library and number/scale helpers into OSS so the recurring auto-merge stops conflicting on `app/dataviz`. Nothing in OSS imports these yet, so there's no behavior change — this is a convergence port, not a new feature.

**Refactors**
- Adds `truncateNumberForDisplay`, `calculateYScaleExtentForChart`, and `calculateOverlapBetweenTwoMarkers`; existing `abbreviateNumber` is untouched.
- Adds bar, candle, donut, line, progress, and scatter charts plus `ChartCard`, `Legend`, `ChartWrapper`, color constants, and `InfoTooltip`.
- These are visx/styled-components presentation components with no feature-flag, entity-type, route, or GraphQL coupling.
- `@visx/grid` is now a direct dependency because `ScatterPlot` imports it; the lockfile gains matching `@visx/grid` and `@visx/point` entries.
- `ChartCard` keeps its antd import behind an eslint-disable so the file stays identical to the fork; the antd-to-alchemy migration should happen in both repos together.

<sup>Written for commit 6d8654ac1058c3a52e8cf4100627f0d7f1f3b7dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

