### PR TITLE
fix(embed): drop wrapper padding around the full-height embed profile

### DIFF
--- a/datahub-web-react/src/app/embed/EmbeddedPage.tsx
+++ b/datahub-web-react/src/app/embed/EmbeddedPage.tsx
@@ -17,7 +17,6 @@ import { EntityType } from '@types';
 const EmbeddedPageWrapper = styled.div`
     max-height: 100%;
     overflow: auto;
-    padding: 16px;
 `;
 
 interface RouteParams {


### PR DESCRIPTION
The embedded profile renders EntityProfileSidebar inside a SidebarWrapper fixed at height: 100vh, so the 16px padding on EmbeddedPageWrapper pushed 32px past the max-height: 100% scroll container, producing a stray scrollbar and a gutter around the sidebar.

Upstreamed from the Cloud fork, where the same padding was removed when the full V2 sidebar was enabled for the Chrome extension.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the 16px padding on `EmbeddedPageWrapper` so the embedded full-height profile no longer shows a stray scrollbar and gutter around the sidebar. The padding pushed the sidebar past the `max-height: 100%` scroll container, causing the overflow.

<sup>Written for commit b791858e5c770c65cf30c48f500c0ddd0284a259. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

