### PR TITLE
feat(ui): adding toggle and feature flags and fixing domains and glossary icons

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/resolvers/config/AppConfigResolver.java
@@ -263,6 +263,7 @@ public class AppConfigResolver implements DataFetcher<CompletableFuture<AppConfi
             .setThemeV2Enabled(_featureFlags.isThemeV2Enabled())
             .setThemeV2Default(_featureFlags.isThemeV2Default())
             .setThemeV2Toggleable(_featureFlags.isThemeV2Toggleable())
+            .setThemeDarkModeEnabled(_featureFlags.isThemeDarkModeEnabled())
             .setShowSeparateSiblings(_featureFlags.isShowSeparateSiblings())
             .setShowManageStructuredProperties(_featureFlags.isShowManageStructuredProperties())
             .setSchemaFieldCLLEnabled(_featureFlags.isSchemaFieldCLLEnabled())

--- a/datahub-graphql-core/src/main/resources/app.graphql
+++ b/datahub-graphql-core/src/main/resources/app.graphql
@@ -737,6 +737,12 @@ type FeatureFlagsConfig {
   themeV2Toggleable: Boolean!
 
   """
+  If turned on, show the light/dark mode toggle in Appearance settings and apply the dark color theme.
+  Controlled by THEME_DARK_MODE_ENABLED.
+  """
+  themeDarkModeEnabled: Boolean!
+
+  """
   Enables links to schema field-level lineage on lineage explorer.
   """
   schemaFieldCLLEnabled: Boolean!

--- a/datahub-web-react/src/app/entityV2/shared/links/DomainColoredIcon.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/links/DomainColoredIcon.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { hexToRgb, hexToRgba, useGenerateDomainColorFromPalette } from '@app/sharedV2/colors/colorUtils';
-import { getLighterRGBColor } from '@app/sharedV2/icons/colorUtils';
+import { useGenerateDomainColorFromPalette } from '@app/sharedV2/colors/colorUtils';
 import { useMuiIcons } from '@app/sharedV2/icons/useMuiIcons';
 
 import { Domain } from '@types';
 
-const DomainIconContainer = styled.div<{ color: string; size: number }>`
+const DomainIconContainer = styled.div<{ $color: string; size: number }>`
     display: flex;
     align-items: center;
     justify-content: center;
@@ -15,13 +14,13 @@ const DomainIconContainer = styled.div<{ color: string; size: number }>`
     height: ${(props) => props.size}px;
     width: ${(props) => props.size}px;
     min-width: ${(props) => props.size}px;
-    background-color: ${({ color }) => color};
+    color: ${(props) => `color-mix(in srgb, ${props.$color} 75%, ${props.theme.colors.text})`};
+    background-color: ${(props) => `color-mix(in srgb, ${props.$color} 12%, ${props.theme.colors.bg})`};
 `;
 
-const DomainCharacterIcon = styled.div<{ color: string; $fontSize: number }>`
+const DomainCharacterIcon = styled.div<{ $fontSize: number }>`
     font-size: ${(props) => (props.$fontSize ? props.$fontSize : '20')}px;
-    font-weight: 500;
-    color: ${({ color }) => color};
+    font-weight: 600;
 `;
 
 type Props = {
@@ -50,18 +49,13 @@ export const DomainColoredIcon = ({ iconColor, domain, size = 40, fontSize = 20,
     const domainColor = domain?.displayProperties?.colorHex || generateColor(domain?.urn || '');
 
     const domainHexColor = iconColor || domainColor;
-    const [r, g, b] = hexToRgb(domainHexColor);
-    const domainBackgroundColor = `rgb(${getLighterRGBColor(r, g, b).join(', ')})`;
-    const domainIconColor = hexToRgba(domainHexColor, 1.0);
 
     return (
-        <DomainIconContainer color={domainBackgroundColor} size={size} onClick={onClick}>
+        <DomainIconContainer $color={domainHexColor} size={size} onClick={onClick}>
             {MaterialIcon ? (
-                <MaterialIcon style={{ color: domainIconColor, fontSize }} />
+                <MaterialIcon style={{ color: 'currentColor', fontSize }} />
             ) : (
-                <DomainCharacterIcon color={domainIconColor} $fontSize={fontSize}>
-                    {domain?.properties?.name.charAt(0)}
-                </DomainCharacterIcon>
+                <DomainCharacterIcon $fontSize={fontSize}>{domain?.properties?.name.charAt(0)}</DomainCharacterIcon>
             )}
         </DomainIconContainer>
     );

--- a/datahub-web-react/src/app/glossaryV2/GlossaryColoredIcon.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryColoredIcon.tsx
@@ -2,10 +2,7 @@ import type { Icon } from '@phosphor-icons/react';
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { hexToRgb } from '@app/sharedV2/colors/colorUtils';
-import { getLighterRGBColor } from '@app/sharedV2/icons/colorUtils';
-
-const Container = styled.div<{ $bg: string; $size: number; $radius: number }>`
+const Container = styled.div<{ $color: string; $size: number; $radius: number }>`
     display: flex;
     align-items: center;
     justify-content: center;
@@ -13,7 +10,8 @@ const Container = styled.div<{ $bg: string; $size: number; $radius: number }>`
     height: ${(props) => props.$size}px;
     width: ${(props) => props.$size}px;
     min-width: ${(props) => props.$size}px;
-    background-color: ${(props) => props.$bg};
+    color: ${(props) => `color-mix(in srgb, ${props.$color} 75%, ${props.theme.colors.text})`};
+    background-color: ${(props) => `color-mix(in srgb, ${props.$color} 12%, ${props.theme.colors.bg})`};
     flex-shrink: 0;
 `;
 
@@ -35,14 +33,12 @@ export default function GlossaryColoredIcon({
     radius,
     className,
 }: Props) {
-    const [r, g, b] = hexToRgb(color);
-    const bg = `rgb(${getLighterRGBColor(r, g, b).join(', ')})`;
     const resolvedIconSize = iconSize ?? Math.round(size * 0.6);
     const resolvedRadius = radius ?? size / 4;
 
     return (
-        <Container $bg={bg} $size={size} $radius={resolvedRadius} className={className}>
-            <IconComponent size={resolvedIconSize} color={color} weight="regular" />
+        <Container $color={color} $size={size} $radius={resolvedRadius} className={className}>
+            <IconComponent size={resolvedIconSize} color="currentColor" weight="bold" />
         </Container>
     );
 }

--- a/datahub-web-react/src/app/settingsV2/Preferences.tsx
+++ b/datahub-web-react/src/app/settingsV2/Preferences.tsx
@@ -7,6 +7,8 @@ import styled, { useTheme } from 'styled-components';
 import { useUserContext } from '@app/context/useUserContext';
 import { LanguageSelect } from '@app/i18n/components/LanguageSelect';
 import { useIsI18nEnabled } from '@app/i18n/hooks/useIsI18nEnabled';
+import { useFeatureFlag } from '@app/sharedV2/hooks/useFeatureFlag';
+import { THEME_DARK_MODE_FLAG, useIsDarkMode } from '@app/theme/useIsDarkMode';
 import { useAppConfig } from '@app/useAppConfig';
 
 import { useUpdateApplicationsSettingsMutation } from '@graphql/app.generated';
@@ -74,6 +76,8 @@ export const Preferences = () => {
     const userContext = useUserContext();
     const appConfig = useAppConfig();
     const i18nEnabled = useIsI18nEnabled();
+    const darkModeEnabled = useFeatureFlag(THEME_DARK_MODE_FLAG);
+    const [isDarkMode, toggleDarkMode] = useIsDarkMode();
 
     const applicationsEnabled = appConfig.config?.visualConfig?.application?.showApplicationInNavigation ?? false;
 
@@ -89,6 +93,28 @@ export const Preferences = () => {
                         <PageTitle title={t('appearance.title')} subTitle={t('appearance.subTitle')} />
                     </HeaderContainer>
                 </TokensContainer>
+                {darkModeEnabled && (
+                    <StyledCard>
+                        <UserSettingRow>
+                            <TextContainer>
+                                <SettingText>{t('darkMode.title')}</SettingText>
+                                <DescriptionText>{t('darkMode.description')}</DescriptionText>
+                            </TextContainer>
+                            <Switch
+                                label={t('darkMode.title')}
+                                labelStyle={{
+                                    position: 'absolute',
+                                    width: 1,
+                                    height: 1,
+                                    overflow: 'hidden',
+                                    clip: 'rect(0 0 0 0)',
+                                }}
+                                checked={isDarkMode}
+                                onChange={toggleDarkMode}
+                            />
+                        </UserSettingRow>
+                    </StyledCard>
+                )}
                 {canManageApplicationAppearance && (
                     <StyledCard>
                         <UserSettingRow>
@@ -128,7 +154,7 @@ export const Preferences = () => {
                         </UserSettingRow>
                     </StyledCard>
                 )}
-                {!canManageApplicationAppearance && !i18nEnabled && (
+                {!canManageApplicationAppearance && !i18nEnabled && !darkModeEnabled && (
                     <div style={{ color: theme.colors.textSecondary }}>{t('noSettings')}</div>
                 )}
             </SourceContainer>

--- a/datahub-web-react/src/app/settingsV2/__tests__/Preferences.test.tsx
+++ b/datahub-web-react/src/app/settingsV2/__tests__/Preferences.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { ThemeProvider } from 'styled-components';
+
+import { Preferences } from '@app/settingsV2/Preferences';
+import { useFeatureFlag } from '@app/sharedV2/hooks/useFeatureFlag';
+import { THEME_DARK_MODE_FLAG } from '@app/theme/useIsDarkMode';
+import themes from '@conf/theme/themes';
+
+vi.mock('@app/context/useUserContext', () => ({
+    useUserContext: () => ({ platformPrivileges: { manageFeatures: false } }),
+}));
+
+vi.mock('@app/i18n/hooks/useIsI18nEnabled', () => ({
+    useIsI18nEnabled: () => false,
+}));
+
+vi.mock('@app/useAppConfig', () => ({
+    useAppConfig: () => ({ config: { visualConfig: {} }, refreshContext: vi.fn() }),
+}));
+
+vi.mock('@app/sharedV2/hooks/useFeatureFlag', () => ({
+    useFeatureFlag: vi.fn(() => true),
+    loadFromLocalStorage: () => false,
+}));
+
+vi.mock('@graphql/app.generated', () => ({
+    useUpdateApplicationsSettingsMutation: () => [vi.fn()],
+}));
+
+describe('Preferences', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        vi.mocked(useFeatureFlag).mockImplementation((key: string) => key === THEME_DARK_MODE_FLAG);
+    });
+
+    it('lets the user switch between light and dark mode when the flag is on', () => {
+        render(
+            <ThemeProvider theme={themes.themeV2}>
+                <Preferences />
+            </ThemeProvider>,
+        );
+
+        const darkModeToggle = screen.getByRole('checkbox', { name: 'Dark mode' });
+        expect(darkModeToggle).not.toBeChecked();
+
+        fireEvent.click(darkModeToggle);
+
+        expect(darkModeToggle).toBeChecked();
+        expect(localStorage.getItem('isDarkModeEnabled')).toBe('true');
+    });
+
+    it('hides the dark mode toggle when the flag is off', () => {
+        vi.mocked(useFeatureFlag).mockReturnValue(false);
+
+        render(
+            <ThemeProvider theme={themes.themeV2}>
+                <Preferences />
+            </ThemeProvider>,
+        );
+
+        expect(screen.queryByRole('checkbox', { name: 'Dark mode' })).not.toBeInTheDocument();
+        expect(screen.getByText('No appearance settings found.')).toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/app/theme/__tests__/useIsDarkMode.test.ts
+++ b/datahub-web-react/src/app/theme/__tests__/useIsDarkMode.test.ts
@@ -2,7 +2,18 @@ import { act } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { loadIsDarkMode, useIsDarkMode } from '@app/theme/useIsDarkMode';
+import { useFeatureFlag } from '@app/sharedV2/hooks/useFeatureFlag';
+import { THEME_DARK_MODE_FLAG, loadIsDarkMode, useIsDarkMode } from '@app/theme/useIsDarkMode';
+
+vi.mock('@app/sharedV2/hooks/useFeatureFlag', async () => {
+    const actual = await vi.importActual<typeof import('@app/sharedV2/hooks/useFeatureFlag')>(
+        '@app/sharedV2/hooks/useFeatureFlag',
+    );
+    return {
+        ...actual,
+        useFeatureFlag: vi.fn(() => true),
+    };
+});
 
 // Helpers
 
@@ -13,10 +24,10 @@ const DARK_MODE_CHANGE_EVENT = 'datahub-darkmode-change';
 
 beforeEach(() => {
     localStorage.clear();
+    vi.mocked(useFeatureFlag).mockReturnValue(true);
 });
 
 afterEach(() => {
-    vi.restoreAllMocks();
     localStorage.clear();
 });
 
@@ -27,12 +38,19 @@ describe('loadIsDarkMode', () => {
         expect(loadIsDarkMode()).toBe(false);
     });
 
-    it('returns true when localStorage value is "true"', () => {
+    it('returns false when dark mode is preferred but the feature flag is off', () => {
+        localStorage.setItem(DARK_MODE_KEY, 'true');
+        expect(loadIsDarkMode()).toBe(false);
+    });
+
+    it('returns true when localStorage value is "true" and the feature flag is on', () => {
+        localStorage.setItem(THEME_DARK_MODE_FLAG, 'true');
         localStorage.setItem(DARK_MODE_KEY, 'true');
         expect(loadIsDarkMode()).toBe(true);
     });
 
     it('returns false when localStorage value is "false"', () => {
+        localStorage.setItem(THEME_DARK_MODE_FLAG, 'true');
         localStorage.setItem(DARK_MODE_KEY, 'false');
         expect(loadIsDarkMode()).toBe(false);
     });
@@ -157,5 +175,26 @@ describe('useIsDarkMode – cross-instance sync', () => {
         const { unmount } = renderHook(() => useIsDarkMode());
         unmount();
         expect(removeEventListenerSpy).toHaveBeenCalledWith(DARK_MODE_CHANGE_EVENT, expect.any(Function));
+    });
+});
+
+describe('useIsDarkMode – feature flag', () => {
+    it('stays in light mode when the feature flag is off even if preference is dark', () => {
+        vi.mocked(useFeatureFlag).mockReturnValue(false);
+        localStorage.setItem(DARK_MODE_KEY, 'true');
+
+        const { result } = renderHook(() => useIsDarkMode());
+
+        expect(result.current[0]).toBe(false);
+    });
+
+    it('does not persist a toggle when the feature flag is off', () => {
+        vi.mocked(useFeatureFlag).mockReturnValue(false);
+        const { result } = renderHook(() => useIsDarkMode());
+
+        act(() => result.current[1]());
+
+        expect(result.current[0]).toBe(false);
+        expect(localStorage.getItem(DARK_MODE_KEY)).toBeNull();
     });
 });

--- a/datahub-web-react/src/app/theme/useIsDarkMode.ts
+++ b/datahub-web-react/src/app/theme/useIsDarkMode.ts
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { loadFromLocalStorage, useFeatureFlag } from '@app/sharedV2/hooks/useFeatureFlag';
+
 const DARK_MODE_KEY = 'isDarkModeEnabled';
 const DARK_MODE_CHANGE_EVENT = 'datahub-darkmode-change';
+
+export const THEME_DARK_MODE_FLAG = 'themeDarkModeEnabled';
 
 function loadDarkModeFromLocalStorage(): boolean {
     const item = localStorage.getItem(DARK_MODE_KEY);
@@ -16,16 +20,21 @@ function saveDarkModeToLocalStorage(isDark: boolean) {
 /**
  * Hook that provides the current dark mode state and a toggle function.
  * Persisted in localStorage; defaults to light mode.
+ * Dark mode only applies when the themeDarkModeEnabled feature flag is on.
  *
  * All hook instances in the same tab stay in sync via a custom window event.
  */
 export function useIsDarkMode(): [boolean, () => void] {
+    const darkModeEnabled = useFeatureFlag(THEME_DARK_MODE_FLAG);
     const [isDarkMode, setIsDarkMode] = useState(loadDarkModeFromLocalStorage);
     const isFirstRender = useRef(true);
 
     const toggleDarkMode = useCallback(() => {
+        if (!darkModeEnabled) {
+            return;
+        }
         setIsDarkMode((prev) => !prev);
-    }, []);
+    }, [darkModeEnabled]);
 
     // Persist to localStorage and notify other instances when state changes (skip first render)
     useEffect(() => {
@@ -46,13 +55,15 @@ export function useIsDarkMode(): [boolean, () => void] {
         return () => window.removeEventListener(DARK_MODE_CHANGE_EVENT, syncHandler);
     }, []);
 
-    return [isDarkMode, toggleDarkMode];
+    return [Boolean(darkModeEnabled) && isDarkMode, toggleDarkMode];
 }
 
 /**
  * Reads the dark mode preference from localStorage without React state.
  * Used for initial theme selection before hooks are available.
+ * Requires the cached feature flag to be on so a previous preference cannot
+ * enable dark mode after the flag is turned off.
  */
 export function loadIsDarkMode(): boolean {
-    return loadDarkModeFromLocalStorage();
+    return loadFromLocalStorage(THEME_DARK_MODE_FLAG) && loadDarkModeFromLocalStorage();
 }

--- a/datahub-web-react/src/appConfigContext.tsx
+++ b/datahub-web-react/src/appConfigContext.tsx
@@ -75,6 +75,7 @@ export const DEFAULT_APP_CONFIG = {
         themeV2Enabled: false,
         themeV2Default: false,
         themeV2Toggleable: false,
+        themeDarkModeEnabled: false,
         showSeparateSiblings: false,
         schemaFieldCLLEnabled: false,
         schemaFieldLineageIgnoreStatus: false,

--- a/datahub-web-react/src/graphql/app.graphql
+++ b/datahub-web-react/src/graphql/app.graphql
@@ -96,6 +96,7 @@ query appConfig {
             themeV2Enabled
             themeV2Default
             themeV2Toggleable
+            themeDarkModeEnabled
             showSeparateSiblings
             showManageStructuredProperties
             schemaFieldCLLEnabled

--- a/datahub-web-react/src/i18n/locales/en/settings.preferences.json
+++ b/datahub-web-react/src/i18n/locales/en/settings.preferences.json
@@ -1,6 +1,8 @@
 {
     "appearance.subTitle": "Manage your appearance settings.",
     "appearance.title": "Appearance",
+    "darkMode.description": "Use a dark color theme throughout DataHub.",
+    "darkMode.title": "Dark mode",
     "language.description": "Choose your preferred display language",
     "language.title": "User interface language",
     "noSettings": "No appearance settings found.",

--- a/docs/deploy/environment-vars.md
+++ b/docs/deploy/environment-vars.md
@@ -838,6 +838,7 @@ Reference Links:
 | `THEME_V2_ENABLED`                      | `true`  | Allow theme v2 to be turned on                                                                                  | GMS        |
 | `THEME_V2_DEFAULT`                      | `true`  | Set default theme for users                                                                                     | GMS        |
 | `THEME_V2_TOGGLEABLE`                   | `false` | Allow theme v2 to be toggled (DataHub Cloud only)                                                               | GMS        |
+| `THEME_DARK_MODE_ENABLED`               | `false` | Show the light/dark mode toggle and apply the dark color theme                                                  | GMS        |
 | `SCHEMA_FIELD_CLL_ENABLED`              | `false` | Enable schema field-level lineage links                                                                         | GMS        |
 | `SCHEMA_FIELD_LINEAGE_IGNORE_STATUS`    | `true`  | Ignore schema field status in lineage                                                                           | GMS        |
 | `SHOW_SEPARATE_SIBLINGS`                | `false` | Separate siblings with no combined view                                                                         | GMS        |

--- a/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/system_info/collectors/PropertiesCollectorConfigurationTest.java
@@ -607,6 +607,7 @@ public class PropertiesCollectorConfigurationTest extends AbstractTestNGSpringCo
           "featureFlags.timeseriesAspectAggBatchLoadEnabled",
           "featureFlags.entityHealthBatchLoadEnabled",
           "featureFlags.datasetStatsSummaryBatchLoadEnabled",
+          "featureFlags.themeDarkModeEnabled",
           "featureFlags.themeV2Default",
           "featureFlags.themeV2Enabled",
           "featureFlags.themeV2Toggleable",

--- a/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
+++ b/metadata-service/configuration/src/main/java/com/linkedin/datahub/graphql/featureflags/FeatureFlags.java
@@ -39,6 +39,9 @@ public class FeatureFlags {
   private boolean themeV2Enabled = false;
   private boolean themeV2Default = false;
   private boolean themeV2Toggleable = false;
+  // Gates the user-facing light/dark mode toggle and applying the dark color theme.
+  // Default OFF until dark mode is ready to ship. Preference is still stored locally when enabled.
+  private boolean themeDarkModeEnabled = false;
   private boolean showSeparateSiblings = false;
   private boolean alternateMCPValidation = false;
   private boolean showManageStructuredProperties = false;

--- a/metadata-service/configuration/src/main/resources/application.yaml
+++ b/metadata-service/configuration/src/main/resources/application.yaml
@@ -1676,6 +1676,7 @@ featureFlags:
   themeV2Enabled: ${THEME_V2_ENABLED:true} # Allows theme v2 to be turned on. One of themeV2Default and themeV2Toggleable must be false for this to have any effect.
   themeV2Default: ${THEME_V2_DEFAULT:true} # Sets the default theme for users. The default is the only available theme if theme is not toggleable.
   themeV2Toggleable: ${THEME_V2_TOGGLEABLE:false} # Acryl only! Allows theme v2 to be toggled on / off by users.
+  themeDarkModeEnabled: ${THEME_DARK_MODE_ENABLED:false} # If turned on, show the light/dark mode toggle in Appearance settings and apply the dark color theme.
   schemaFieldCLLEnabled: ${SCHEMA_FIELD_CLL_ENABLED:false} # Enables links to schema field-level lineage on lineage explorer and columns tab
   schemaFieldLineageIgnoreStatus: ${SCHEMA_FIELD_LINEAGE_IGNORE_STATUS:true} # If turned on, schema field lineage will always fetch ghost entities
   showSeparateSiblings: ${SHOW_SEPARATE_SIBLINGS:false} # If turned on, all siblings will be separated with no way to get to a "combined" sibling view


### PR DESCRIPTION
<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional dark mode toggle to Appearance settings behind a new feature flag, and fixes domain and glossary colored icons so they render correctly in dark mode.

**New Features**
- Set `THEME_DARK_MODE_ENABLED` to show the toggle and apply the dark theme; default is off.
- While the flag is off, any saved dark mode preference is ignored.

**Bug Fixes**
- Domain and glossary icons now use theme-aware colors instead of fixed lighter backgrounds.

<sup>Written for commit 3b1d2769563593cb05c002e0bcc62085f28b0046. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

