### PR TITLE
feat(ml): resolve health for mlModel, mlFeature and mlFeatureTable

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/GmsGraphQLEngine.java
@@ -3130,7 +3130,15 @@ public class GmsGraphQLEngine {
                               return entity.getDataPlatformInstance() != null
                                   ? entity.getDataPlatformInstance().getUrn()
                                   : null;
-                            })))
+                            }))
+                    .dataFetcher(
+                        "health",
+                        new EntityHealthResolver(
+                            entityClient,
+                            graphClient,
+                            timeseriesAspectService,
+                            new EntityHealthResolver.Config(false, true, false),
+                            featureFlags)))
         .type(
             "MLFeatureTableProperties",
             typeWiring ->
@@ -3224,7 +3232,15 @@ public class GmsGraphQLEngine {
                               return mlModel.getDataPlatformInstance() != null
                                   ? mlModel.getDataPlatformInstance().getUrn()
                                   : null;
-                            })))
+                            }))
+                    .dataFetcher(
+                        "health",
+                        new EntityHealthResolver(
+                            entityClient,
+                            graphClient,
+                            timeseriesAspectService,
+                            new EntityHealthResolver.Config(false, true, false),
+                            featureFlags)))
         .type(
             "MLModelProperties",
             typeWiring ->
@@ -3305,7 +3321,15 @@ public class GmsGraphQLEngine {
                               return entity.getDataPlatformInstance() != null
                                   ? entity.getDataPlatformInstance().getUrn()
                                   : null;
-                            })))
+                            }))
+                    .dataFetcher(
+                        "health",
+                        new EntityHealthResolver(
+                            entityClient,
+                            graphClient,
+                            timeseriesAspectService,
+                            new EntityHealthResolver.Config(false, true, false),
+                            featureFlags)))
         .type(
             "MLPrimaryKey",
             typeWiring ->

--- a/datahub-graphql-core/src/main/resources/entity.graphql
+++ b/datahub-graphql-core/src/main/resources/entity.graphql
@@ -10892,6 +10892,11 @@ type MLModel implements EntityWithRelationships & Entity & BrowsableEntity {
     @aspectMapping(aspects: ["structuredProperties"])
 
   """
+  Experimental! The resolved health statuses of the asset
+  """
+  health: [Health!] @noAspects
+
+  """
   The forms associated with the Dataset
   """
   forms: Forms @aspectMapping(aspects: ["forms"])
@@ -11263,6 +11268,11 @@ type MLFeature implements EntityWithRelationships & Entity {
   """
   structuredProperties: StructuredProperties
     @aspectMapping(aspects: ["structuredProperties"])
+
+  """
+  Experimental! The resolved health statuses of the asset
+  """
+  health: [Health!] @noAspects
 
   """
   The forms associated with the Dataset
@@ -11723,6 +11733,11 @@ type MLFeatureTable implements EntityWithRelationships & Entity & BrowsableEntit
   """
   structuredProperties: StructuredProperties
     @aspectMapping(aspects: ["structuredProperties"])
+
+  """
+  Experimental! The resolved health statuses of the asset
+  """
+  health: [Health!] @noAspects
 
   """
   The forms associated with the Dataset

--- a/datahub-web-react/src/app/entityV2/mlFeature/MLFeatureEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeature/MLFeatureEntity.tsx
@@ -195,6 +195,7 @@ export class MLFeatureEntity implements Entity<MlFeature> {
                 owners={data.ownership?.owners}
                 platform={platform}
                 dataProduct={getDataProduct(genericProperties?.dataProduct)}
+                health={data.health}
                 headerDropdownItems={headerDropdownItems}
                 previewType={previewType}
                 browsePaths={data.browsePathV2 || undefined}
@@ -218,6 +219,7 @@ export class MLFeatureEntity implements Entity<MlFeature> {
                 dataProduct={getDataProduct(genericProperties?.dataProduct)}
                 platform={platform}
                 platformInstanceId={data.dataPlatformInstance?.instanceId}
+                health={data.health}
                 degree={(result as any).degree}
                 paths={(result as any).paths}
                 isOutputPort={isOutputPort(result)}
@@ -262,6 +264,7 @@ export class MLFeatureEntity implements Entity<MlFeature> {
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
             EntityCapabilityType.LINEAGE,
+            EntityCapabilityType.HEALTH,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
             EntityCapabilityType.FORMS,

--- a/datahub-web-react/src/app/entityV2/mlFeature/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeature/preview/Preview.tsx
@@ -7,7 +7,7 @@ import DefaultPreviewCard from '@app/previewV2/DefaultPreviewCard';
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
-import { BrowsePathV2, DataPlatform, DataProduct, EntityPath, EntityType, Owner } from '@types';
+import { BrowsePathV2, DataPlatform, DataProduct, EntityPath, EntityType, Health, Owner } from '@types';
 
 export const Preview = ({
     urn,
@@ -19,6 +19,7 @@ export const Preview = ({
     dataProduct,
     owners,
     platform,
+    health,
     degree,
     paths,
     isOutputPort,
@@ -35,6 +36,7 @@ export const Preview = ({
     dataProduct?: DataProduct | null;
     owners?: Array<Owner> | null;
     platform?: DataPlatform | null | undefined;
+    health?: Health[] | null;
     degree?: number;
     paths?: EntityPath[];
     isOutputPort?: boolean;
@@ -63,6 +65,7 @@ export const Preview = ({
             typeIcon={entityRegistry.getIcon(EntityType.Mlfeature, 14, IconStyleType.ACCENT)}
             owners={owners}
             dataProduct={dataProduct}
+            health={health || undefined}
             degree={degree}
             paths={paths}
             isOutputPort={isOutputPort}

--- a/datahub-web-react/src/app/entityV2/mlFeature/preview/__tests__/Preview.test.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeature/preview/__tests__/Preview.test.tsx
@@ -1,0 +1,61 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { PreviewType } from '@app/entityV2/Entity';
+import { Preview } from '@app/entityV2/mlFeature/preview/Preview';
+import { mocks } from '@src/Mocks';
+import TestPageContainer from '@utils/test-utils/TestPageContainer';
+
+import { DataPlatform, EntityType, Health, HealthStatus, HealthStatusType } from '@types';
+
+const FEATURE_URN = 'urn:li:mlFeature:(fraud_features,txn_amount_30d)';
+const FEATURE_NAME = 'txn_amount_30d';
+const FEATURE_NAMESPACE = 'fraud_features';
+const HEALTH_ICON_TEST_ID = `${FEATURE_URN}-health-icon`;
+
+const platform = {
+    urn: 'urn:li:dataPlatform:feast',
+    type: EntityType.DataPlatform,
+    name: 'feast',
+} as DataPlatform;
+
+const failingIncidentHealth: Health[] = [
+    {
+        type: HealthStatusType.Incidents,
+        status: HealthStatus.Fail,
+        message: '1 active incident',
+        causes: [],
+    },
+];
+
+const renderPreview = (health?: Health[] | null) =>
+    render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+            <TestPageContainer>
+                <Preview
+                    urn={FEATURE_URN}
+                    data={{ name: FEATURE_NAME }}
+                    name={FEATURE_NAME}
+                    featureNamespace={FEATURE_NAMESPACE}
+                    platform={platform}
+                    health={health}
+                    previewType={PreviewType.PREVIEW}
+                />
+            </TestPageContainer>
+        </MockedProvider>,
+    );
+
+describe('Preview', () => {
+    it('renders the health icon when the feature has an active incident', () => {
+        const { getByText, getByTestId } = renderPreview(failingIncidentHealth);
+        expect(getByText(FEATURE_NAME)).toBeInTheDocument();
+        expect(getByTestId(HEALTH_ICON_TEST_ID)).toBeInTheDocument();
+    });
+
+    it('renders no health icon when health is undefined', () => {
+        const { getByText, queryByTestId } = renderPreview(undefined);
+        expect(getByText(FEATURE_NAME)).toBeInTheDocument();
+        expect(queryByTestId(HEALTH_ICON_TEST_ID)).not.toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/app/entityV2/mlFeatureTable/MLFeatureTableEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeatureTable/MLFeatureTableEntity.tsx
@@ -181,6 +181,7 @@ export class MLFeatureTableEntity implements Entity<MlFeatureTable> {
                 logoUrl={data.platform?.properties?.logoUrl}
                 platformName={data.platform?.properties?.displayName || capitalizeFirstLetterOnly(data.platform?.name)}
                 dataProduct={getDataProduct(genericProperties?.dataProduct)}
+                health={data.health}
                 headerDropdownItems={headerDropdownItems}
                 previewType={previewType}
             />
@@ -201,6 +202,7 @@ export class MLFeatureTableEntity implements Entity<MlFeatureTable> {
                 platformName={data.platform?.properties?.displayName || capitalizeFirstLetterOnly(data.platform?.name)}
                 platformInstanceId={data.dataPlatformInstance?.instanceId}
                 dataProduct={getDataProduct(genericProperties?.dataProduct)}
+                health={data.health}
                 degree={(result as any).degree}
                 paths={(result as any).paths}
                 isOutputPort={isOutputPort(result)}
@@ -243,6 +245,7 @@ export class MLFeatureTableEntity implements Entity<MlFeatureTable> {
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
             EntityCapabilityType.LINEAGE,
+            EntityCapabilityType.HEALTH,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
             EntityCapabilityType.FORMS,

--- a/datahub-web-react/src/app/entityV2/mlFeatureTable/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeatureTable/preview/Preview.tsx
@@ -6,7 +6,7 @@ import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuA
 import DefaultPreviewCard from '@app/previewV2/DefaultPreviewCard';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
-import { DataProduct, EntityPath, EntityType, Owner } from '@types';
+import { DataProduct, EntityPath, EntityType, Health, Owner } from '@types';
 
 export const Preview = ({
     urn,
@@ -18,6 +18,7 @@ export const Preview = ({
     platformName,
     dataProduct,
     platformInstanceId,
+    health,
     degree,
     paths,
     isOutputPort,
@@ -33,6 +34,7 @@ export const Preview = ({
     platformName?: string | null;
     dataProduct?: DataProduct | null;
     platformInstanceId?: string;
+    health?: Health[] | null;
     degree?: number;
     paths?: EntityPath[];
     isOutputPort?: boolean;
@@ -55,6 +57,7 @@ export const Preview = ({
             platformInstanceId={platformInstanceId}
             dataProduct={dataProduct}
             logoComponent={entityRegistry.getIcon(EntityType.MlfeatureTable, 20, IconStyleType.HIGHLIGHT)}
+            health={health || undefined}
             degree={degree}
             paths={paths}
             isOutputPort={isOutputPort}

--- a/datahub-web-react/src/app/entityV2/mlFeatureTable/preview/__tests__/Preview.test.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeatureTable/preview/__tests__/Preview.test.tsx
@@ -1,0 +1,54 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { PreviewType } from '@app/entityV2/Entity';
+import { Preview } from '@app/entityV2/mlFeatureTable/preview/Preview';
+import { mocks } from '@src/Mocks';
+import TestPageContainer from '@utils/test-utils/TestPageContainer';
+
+import { Health, HealthStatus, HealthStatusType } from '@types';
+
+const FEATURE_TABLE_URN = 'urn:li:mlFeatureTable:(urn:li:dataPlatform:feast,fraud_features)';
+const FEATURE_TABLE_NAME = 'fraud_features';
+const PLATFORM_NAME = 'Feast';
+const HEALTH_ICON_TEST_ID = `${FEATURE_TABLE_URN}-health-icon`;
+
+const failingIncidentHealth: Health[] = [
+    {
+        type: HealthStatusType.Incidents,
+        status: HealthStatus.Fail,
+        message: '1 active incident',
+        causes: [],
+    },
+];
+
+const renderPreview = (health?: Health[] | null) =>
+    render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+            <TestPageContainer>
+                <Preview
+                    urn={FEATURE_TABLE_URN}
+                    data={{ name: FEATURE_TABLE_NAME }}
+                    name={FEATURE_TABLE_NAME}
+                    platformName={PLATFORM_NAME}
+                    health={health}
+                    previewType={PreviewType.PREVIEW}
+                />
+            </TestPageContainer>
+        </MockedProvider>,
+    );
+
+describe('Preview', () => {
+    it('renders the health icon when the feature table has an active incident', () => {
+        const { getByText, getByTestId } = renderPreview(failingIncidentHealth);
+        expect(getByText(FEATURE_TABLE_NAME)).toBeInTheDocument();
+        expect(getByTestId(HEALTH_ICON_TEST_ID)).toBeInTheDocument();
+    });
+
+    it('renders no health icon when health is undefined', () => {
+        const { getByText, queryByTestId } = renderPreview(undefined);
+        expect(getByText(FEATURE_TABLE_NAME)).toBeInTheDocument();
+        expect(queryByTestId(HEALTH_ICON_TEST_ID)).not.toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/app/entityV2/mlModel/MLModelEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModel/MLModelEntity.tsx
@@ -195,6 +195,7 @@ export class MLModelEntity implements Entity<MlModel> {
             <Preview
                 data={genericProperties}
                 model={data}
+                health={data.health}
                 headerDropdownItems={headerDropdownItems}
                 previewType={previewType}
             />
@@ -208,6 +209,7 @@ export class MLModelEntity implements Entity<MlModel> {
             <Preview
                 data={genericProperties}
                 model={data}
+                health={data.health}
                 degree={(result as any).degree}
                 paths={(result as any).paths}
                 isOutputPort={isOutputPort(result)}
@@ -251,6 +253,7 @@ export class MLModelEntity implements Entity<MlModel> {
             EntityCapabilityType.SOFT_DELETE,
             EntityCapabilityType.DATA_PRODUCTS,
             EntityCapabilityType.LINEAGE,
+            EntityCapabilityType.HEALTH,
             EntityCapabilityType.APPLICATIONS,
             EntityCapabilityType.RELATED_DOCUMENTS,
             EntityCapabilityType.FORMS,

--- a/datahub-web-react/src/app/entityV2/mlModel/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModel/preview/Preview.tsx
@@ -8,11 +8,12 @@ import DefaultPreviewCard from '@app/previewV2/DefaultPreviewCard';
 import { capitalizeFirstLetterOnly } from '@app/shared/textUtil';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
-import { EntityPath, EntityType, MlModel } from '@types';
+import { EntityPath, EntityType, Health, MlModel } from '@types';
 
 export const Preview = ({
     data,
     model,
+    health,
     degree,
     paths,
     isOutputPort,
@@ -21,6 +22,7 @@ export const Preview = ({
 }: {
     data: GenericEntityProperties | null;
     model: MlModel;
+    health?: Health[] | null;
     degree?: number;
     paths?: EntityPath[];
     isOutputPort?: boolean;
@@ -45,6 +47,7 @@ export const Preview = ({
             tags={model.globalTags || undefined}
             owners={model?.ownership?.owners}
             dataProduct={getDataProduct(genericProperties?.dataProduct)}
+            health={health || undefined}
             degree={degree}
             paths={paths}
             isOutputPort={isOutputPort}

--- a/datahub-web-react/src/app/entityV2/mlModel/preview/__tests__/Preview.test.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModel/preview/__tests__/Preview.test.tsx
@@ -1,0 +1,57 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { PreviewType } from '@app/entityV2/Entity';
+import { Preview } from '@app/entityV2/mlModel/preview/Preview';
+import { mocks } from '@src/Mocks';
+import TestPageContainer from '@utils/test-utils/TestPageContainer';
+
+import { EntityType, Health, HealthStatus, HealthStatusType, MlModel } from '@types';
+
+const MODEL_URN = 'urn:li:mlModel:(urn:li:dataPlatform:sagemaker,trustmodel,PROD)';
+const MODEL_NAME = 'trust model';
+const HEALTH_ICON_TEST_ID = `${MODEL_URN}-health-icon`;
+
+const model = {
+    urn: MODEL_URN,
+    type: EntityType.Mlmodel,
+    name: MODEL_NAME,
+    platform: {
+        urn: 'urn:li:dataPlatform:sagemaker',
+        type: EntityType.DataPlatform,
+        name: 'sagemaker',
+    },
+} as MlModel;
+
+const failingIncidentHealth: Health[] = [
+    {
+        type: HealthStatusType.Incidents,
+        status: HealthStatus.Fail,
+        message: '1 active incident',
+        causes: [],
+    },
+];
+
+const renderPreview = (health?: Health[] | null) =>
+    render(
+        <MockedProvider mocks={mocks} addTypename={false}>
+            <TestPageContainer>
+                <Preview data={{ name: MODEL_NAME }} model={model} health={health} previewType={PreviewType.PREVIEW} />
+            </TestPageContainer>
+        </MockedProvider>,
+    );
+
+describe('Preview', () => {
+    it('renders the health icon when the model has an active incident', () => {
+        const { getByText, getByTestId } = renderPreview(failingIncidentHealth);
+        expect(getByText(MODEL_NAME)).toBeInTheDocument();
+        expect(getByTestId(HEALTH_ICON_TEST_ID)).toBeInTheDocument();
+    });
+
+    it('renders no health icon when health is undefined', () => {
+        const { getByText, queryByTestId } = renderPreview(undefined);
+        expect(getByText(MODEL_NAME)).toBeInTheDocument();
+        expect(queryByTestId(HEALTH_ICON_TEST_ID)).not.toBeInTheDocument();
+    });
+});

--- a/datahub-web-react/src/graphql/lineage.graphql
+++ b/datahub-web-react/src/graphql/lineage.graphql
@@ -398,6 +398,9 @@ fragment lineageNodeProperties on EntityWithRelationships {
         editableProperties {
             description
         }
+        health {
+            ...entityHealth
+        }
         structuredProperties {
             properties {
                 ...structuredPropertiesFields
@@ -409,9 +412,15 @@ fragment lineageNodeProperties on EntityWithRelationships {
     }
     ... on MLFeatureTable {
         ...nonRecursiveMLFeatureTable
+        health {
+            ...entityHealth
+        }
     }
     ... on MLFeature {
         ...nonRecursiveMLFeature
+        health {
+            ...entityHealth
+        }
     }
     ... on MLPrimaryKey {
         ...nonRecursiveMLPrimaryKey

--- a/datahub-web-react/src/graphql/mlFeature.graphql
+++ b/datahub-web-react/src/graphql/mlFeature.graphql
@@ -17,6 +17,9 @@ query getMLFeature($urn: String!, $skipSiblingsSearch: Boolean = false) {
                 ...structuredPropertiesFields
             }
         }
+        health {
+            ...entityHealth
+        }
         activeIncidents: incidents(start: 0, count: 1, state: ACTIVE) {
             total
         }

--- a/datahub-web-react/src/graphql/mlFeatureTable.graphql
+++ b/datahub-web-react/src/graphql/mlFeatureTable.graphql
@@ -14,6 +14,9 @@ query getMLFeatureTable($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
+        health {
+            ...entityHealth
+        }
         activeIncidents: incidents(start: 0, count: 1, state: ACTIVE) {
             total
         }

--- a/datahub-web-react/src/graphql/mlModel.graphql
+++ b/datahub-web-react/src/graphql/mlModel.graphql
@@ -48,6 +48,9 @@ query getMLModel($urn: String!) {
                 ...structuredPropertiesFields
             }
         }
+        health {
+            ...entityHealth
+        }
         activeIncidents: incidents(start: 0, count: 1, state: ACTIVE) {
             total
         }

--- a/datahub-web-react/src/graphql/preview.graphql
+++ b/datahub-web-react/src/graphql/preview.graphql
@@ -284,6 +284,9 @@ fragment entityPreview on Entity {
         deprecation {
             ...deprecationFields
         }
+        health {
+            ...entityHealth
+        }
     }
     ... on MLModel {
         name
@@ -298,6 +301,9 @@ fragment entityPreview on Entity {
         deprecation {
             ...deprecationFields
         }
+        health {
+            ...entityHealth
+        }
     }
     ... on MLFeature {
         name
@@ -307,6 +313,9 @@ fragment entityPreview on Entity {
         }
         deprecation {
             ...deprecationFields
+        }
+        health {
+            ...entityHealth
         }
     }
     ... on MLModelGroup {

--- a/datahub-web-react/src/graphql/recommendationPreview.graphql
+++ b/datahub-web-react/src/graphql/recommendationPreview.graphql
@@ -195,6 +195,9 @@ fragment recommendationEntityPreview on Entity {
         deprecation {
             ...deprecationFields
         }
+        health {
+            ...entityHealth
+        }
     }
     ... on MLModel {
         name
@@ -204,11 +207,17 @@ fragment recommendationEntityPreview on Entity {
         deprecation {
             ...deprecationFields
         }
+        health {
+            ...entityHealth
+        }
     }
     ... on MLFeature {
         name
         deprecation {
             ...deprecationFields
+        }
+        health {
+            ...entityHealth
         }
     }
     ... on MLModelGroup {

--- a/datahub-web-react/src/graphql/search.graphql
+++ b/datahub-web-react/src/graphql/search.graphql
@@ -1243,6 +1243,9 @@ fragment searchResultsWithoutSchemaField on Entity {
         dataPlatformInstance {
             ...dataPlatformInstanceFields
         }
+        health {
+            ...entityHealth
+        }
         structuredProperties {
             properties {
                 ...structuredPropertiesFields
@@ -1254,6 +1257,9 @@ fragment searchResultsWithoutSchemaField on Entity {
     }
     ... on MLFeature {
         ...nonRecursiveMLFeature
+        health {
+            ...entityHealth
+        }
         structuredProperties {
             properties {
                 ...structuredPropertiesFields
@@ -1289,6 +1295,9 @@ fragment searchResultsWithoutSchemaField on Entity {
         }
         dataPlatformInstance {
             ...dataPlatformInstanceFields
+        }
+        health {
+            ...entityHealth
         }
         structuredProperties {
             properties {

--- a/metadata-models/docs/entities/mlFeature.md
+++ b/metadata-models/docs/entities/mlFeature.md
@@ -339,6 +339,8 @@ Features are accessible through DataHub's GraphQL API via the `MLFeatureType` cl
 
 ML Features participate in the shared incidents subsystem. Incidents can be raised on a feature via the `raiseIncident` GraphQL mutation (or the Python SDK), listed back through the `incidents` field on the `MLFeature` GraphQL type, and the feature carries a rolled-up `incidentsSummary` aspect that is maintained automatically as incidents are raised and resolved.
 
+Active incidents also roll up into the feature's health badge, which shows on the feature's profile page, on its node in the lineage graph, and on search result cards. Health for ML Features is derived from incidents only, so assertions and tests do not contribute to the badge.
+
 ## Notable Exceptions
 
 ### Feature Namespace vs Feature Table

--- a/metadata-models/docs/entities/mlFeatureTable.md
+++ b/metadata-models/docs/entities/mlFeatureTable.md
@@ -218,6 +218,8 @@ Feature tables are associated with a specific data platform (e.g., Feast, Tecton
 
 ML Feature Tables participate in the shared incidents subsystem. Incidents can be raised on a feature table via the `raiseIncident` GraphQL mutation (or the Python SDK), listed back through the `incidents` field on the `MLFeatureTable` GraphQL type, and the feature table carries a rolled-up `incidentsSummary` aspect that is maintained automatically as incidents are raised and resolved.
 
+Active incidents also roll up into the feature table's health badge, which shows on the feature table's profile page, on its node in the lineage graph, and on search result cards. Health for ML Feature Tables is derived from incidents only, so assertions and tests do not contribute to the badge.
+
 ## Notable Exceptions
 
 ### Feature Store Platform Variations

--- a/metadata-models/docs/entities/mlModel.md
+++ b/metadata-models/docs/entities/mlModel.md
@@ -335,6 +335,8 @@ The GraphQL API provides rich querying capabilities for ML Models through resolv
 
 ML Models participate in the shared incidents subsystem. Incidents can be raised on a model via the `raiseIncident` GraphQL mutation (or the Python SDK), listed back through the `incidents` field on the `MLModel` GraphQL type, and the model carries a rolled-up `incidentsSummary` aspect that is maintained automatically as incidents are raised and resolved. Since an incident can reference multiple entities, a single incident can link an upstream dataset and the affected model under one lifecycle.
 
+Active incidents also roll up into the model's health badge, which shows on the model's profile page, on its node in the lineage graph, and on search result cards. Health for ML Models is derived from incidents only, so assertions and tests do not contribute to the badge.
+
 ### Ingestion Sources
 
 Several ingestion sources automatically extract ML Model metadata:


### PR DESCRIPTION
Closes #19114. Implements it as approved there on 2026-09-05, with the interpretation stated in my reply on the issue: incidents-only health on the three ML catalog types, surfaced on the entity page, in lineage, and on search cards.

## Changes

**Server (datahub-graphql-core)**
- `entity.graphql`: `health: [Health!] @noAspects` on `MLModel`, `MLFeature` and `MLFeatureTable`, placed and documented exactly as on Chart. `@noAspects` because health is computed, so the aspect-mapping completeness check stays satisfied and entity-registry.yml is untouched.
- `GmsGraphQLEngine`: each of the three type wirings gets the `health` data fetcher with `EntityHealthResolver.Config(false, true, false)` and the feature flags, copied verbatim from the DataJob wiring (Chart, Dashboard and DataFlow construct the same resolver; DataJob sits at the same nesting depth, so its lines were copied as is). Nothing in metadata-io or metadata-service changes; `EntityHealthBatchLoader` partitions by entity type already.

**Client (datahub-web-react)**
- `lineage.graphql`: `health { ...entityHealth }` on the `MLModel`, `MLFeatureTable` and `MLFeature` blocks of `lineageNodeProperties`. `NodeContents` already renders `HealthIcon` from `entity.health`, so the node badge needs no component change. Health reaches the node through `getLineageVizConfigV2`, which copies it from the generic entity properties, so the per-entity `getLineageVizConfig` methods are untouched. The Lineage tab's Impact Analysis list reads `searchResultFields`, so ML rows there get the badge from the search.graphql change below.
- `search.graphql`, `preview.graphql`, `recommendationPreview.graphql`: the same selection on the three ML blocks. `searchResultCardFields` is left alone, its header deliberately omits health.
- `mlModel.graphql`, `mlFeature.graphql`, `mlFeatureTable.graphql`: top-level `health` next to the existing `activeIncidents` block, which lights the header badge through the generic `DefaultEntityHeader` and the `SidebarEntityHeader`, both of which read `entityData.health`.
- The three ML `Preview.tsx` accept a `health` prop and pass it to `DefaultPreviewCard`, following the Dataset preview; the three entity classes forward it from `renderPreview` and `renderSearch` and add `EntityCapabilityType.HEALTH`.

**Docs**: one short paragraph under the Incidents section of `mlModel.md`, `mlFeature.md`, `mlFeatureTable.md`.

**Tests**: `Preview.test.tsx` under each of the three ML preview directories, using the same harness as the existing glossary term and business attribute preview tests. Each renders the card with an active FAIL incident health entry and asserts the `HealthIcon` test id is present, then renders it without health and asserts it is absent; the card title is checked in both cases so the negative case cannot pass on an empty render. No other entity's preview has a health test today.

## Decisions worth a look

- **Incidents only.** Assertions cannot be enabled: no `Asserts` relationship admits an ML entity, so `assertionsEnabled` would only add a graph call per node that always comes back empty. Tests stay off: the TESTS badge deep-links to `/Governance`, which no ML page mounts, so it would be a dead link. All three types register `testResults`, so that is a one-boolean flip once a Governance tab exists.
- **Placement, not fragments.** Health goes on the inline blocks rather than inside `nonRecursiveMLFeature` / `nonRecursiveMLFeatureTable` / `nonRecursiveMLModel`. Those fragments are nested under feature table and model pages and would resolve health for every contained feature.
- **Reach of the lineage change.** `lineageNodeProperties` is also spread by `relationshipFields` through `fullRelationshipResults`, so relationship results on `getMLFeature`, `getMLModelGroup`, `getMLPrimaryKey`, `getChart` and `getDashboard` now carry health for any ML entity they list. That is inherent to using the shared fragment the lineage badge reads from; the batched loader coalesces each request into one `getActiveIncidentStats` and one `batchGetV2`, so the cost is bounded.
- **One PR, not two.** The generated TypeScript types come from the SDL at build time, so the client selections only compile once the server field exists. Splitting server and client would break the client build in between.
- **Upstream-health rollup.** The sidebar Lineage section on dataset, chart, dashboard and data job pages counts upstream entities whose search result carries an unhealthy `health`. It reads `searchResultFields`, so with this change an ML entity with an active incident upstream of one of those assets now shows up in that rollup. Mounting the Lineage sidebar section on the ML pages themselves is a separate feature and stays out.
- **Smoke test.** My design comment on the issue proposed extending `smoke-test/tests/incidents/health_batch_test.py` to an ML entity. Its fixtures and assertions are dataset-shaped, and the resolver path this PR wires is the same entity-type-agnostic loader that test already exercises, so I kept this PR to the surfaces above rather than grow the smoke suite blind. Happy to add an mlModel case in a follow-up if you want it covered end to end.
- **Out of scope**, deliberately: the `docs/incidents/incidents.md` supported-types list (owned by #18685); the MCP `entity_details.gql` fragment in datahub-agent-context, which carries its own `entityHealth` selection and `#[NEWER_GMS]` markers, so adding ML health there sets a GMS version floor and belongs in its own change; mlModelGroup and mlPrimaryKey, which are not in the IncidentOn allowlist, so health would always resolve empty.

## Not verified locally

No JDK or node toolchain on this machine, so compilation and codegen are CI's job. Every Java line was checked against the 100-column limit and the SDL and GraphQL documents were parsed; the TSX hunks mirror the Dataset preview pattern line for line.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly Commit Message Format)
- [x] Links to related issues
- [x] Tests for the changes have been added/updated: server side is covered by the GraphQL engine schema validation and AspectMappingCompletenessTest in CI (no per-entity health test pattern exists for the other types); client side adds a preview test for each of the three ML cards, rendering with and without health and asserting on the HealthIcon test id
- [x] Docs related to the changes have been added/updated
