### PR TITLE
fix(ingest/kafka): resolve a topic to its own registry subject

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/confluent_schema_registry.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/confluent_schema_registry.py
@@ -111,16 +111,26 @@ class ConfluentSchemaRegistry(KafkaSchemaRegistryBase):
         #  (c) TopicNameStrategy differing by environment name suffixes.
         #       e.g "a.b.c.d-value" and "a.b.c.d.qa-value"
         #       For such instances, the wrong schema registry entries could picked by the previous logic.
+
+        # (a) is unambiguous, so honour it before considering any longer subject. A scan
+        # that only tests the topic as a prefix cannot distinguish this topic's own
+        # subject from one belonging to a topic whose name merely begins the same way,
+        # which is case (c): given "a.b.c.d-value" and "a.b.c.d.qa-value", topic
+        # "a.b.c.d" is served either subject depending on registry ordering.
+        if subject_key in self.known_schema_registry_subjects:
+            return subject_key
+
+        if self.source_config.disable_topic_record_naming_strategy:
+            return None
+
+        # (b) appends "-<record name>" to the topic, so require that delimiter. It is
+        # what separates this topic's subjects from those of a "<topic>.<suffix>" topic,
+        # whose name continues with "." and which is a different topic altogether -
+        # ".RETRY" and ".DLT" companion topics being the common shape.
+        record_name_prefix: str = topic + "-"
         for subject in self.known_schema_registry_subjects:
-            if (
-                self.source_config.disable_topic_record_naming_strategy
-                and subject == subject_key
-            ):
-                return subject
-            if (
-                (not self.source_config.disable_topic_record_naming_strategy)
-                and subject.startswith(topic)
-                and subject.endswith(subject_key_suffix)
+            if subject.startswith(record_name_prefix) and subject.endswith(
+                subject_key_suffix
             ):
                 return subject
         return None

--- a/metadata-ingestion/tests/unit/kafka/test_confluent_schema_registry.py
+++ b/metadata-ingestion/tests/unit/kafka/test_confluent_schema_registry.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from typing import List
 from unittest.mock import patch
 
 from confluent_kafka.schema_registry.schema_registry_client import (
@@ -213,6 +214,102 @@ class ConfluentSchemaRegistryTest(unittest.TestCase):
         assert report.schema_registry_connectivity_failures == 1
         assert result["topic-a"].schema is None
         assert result["topic-a"].fields == []
+
+
+class SubjectForTopicTest(unittest.TestCase):
+    """Which registry subject a topic resolves to.
+
+    Companion topics (`.RETRY`, `.DLT`, environment suffixes) produce subjects that
+    all begin with the parent topic's name, so resolving on prefix alone is
+    order-dependent and can hand a topic another topic's schema.
+    """
+
+    @staticmethod
+    def _registry(subjects: List[str], **config: object) -> ConfluentSchemaRegistry:
+        kafka_source_config = KafkaSourceConfig.model_validate(
+            {
+                "connection": {
+                    "bootstrap": "localhost:9092",
+                    "schema_registry_url": "http://localhost:8081",
+                },
+                **config,
+            }
+        )
+        with patch(
+            "datahub.ingestion.source.confluent_schema_registry.SchemaRegistryClient"
+        ) as mock_client_cls:
+            mock_client_cls.return_value.get_subjects.return_value = subjects
+            return ConfluentSchemaRegistry.create(
+                kafka_source_config, KafkaSourceReport()
+            )
+
+    def test_exact_subject_wins_over_companion_topic_listed_first(self):
+        # The registry lists the .RETRY companion before the topic's own subject.
+        registry = self._registry(
+            [
+                "orders.RETRY-value",
+                "orders.DLT-value",
+                "orders-value",
+            ]
+        )
+        assert registry._get_subject_for_topic("orders", False) == "orders-value"
+
+    def test_companion_topics_keep_their_own_subjects(self):
+        registry = self._registry(
+            ["orders-value", "orders.RETRY-value", "orders.DLT-value"]
+        )
+        assert (
+            registry._get_subject_for_topic("orders.RETRY", False)
+            == "orders.RETRY-value"
+        )
+        assert (
+            registry._get_subject_for_topic("orders.DLT", False) == "orders.DLT-value"
+        )
+
+    def test_companion_subject_is_not_served_to_a_schemaless_topic(self):
+        # "orders" has no subject of its own. Handing it the .RETRY schema would be
+        # worse than reporting it schemaless, which is what the caller warns about.
+        registry = self._registry(["orders.RETRY-value"])
+        assert registry._get_subject_for_topic("orders", False) is None
+
+    def test_environment_suffixed_topics_do_not_collide(self):
+        # Case (c) from the naming-strategy comment.
+        registry = self._registry(["a.b.c.d.qa-value", "a.b.c.d-value"])
+        assert registry._get_subject_for_topic("a.b.c.d", False) == "a.b.c.d-value"
+        assert (
+            registry._get_subject_for_topic("a.b.c.d.qa", False) == "a.b.c.d.qa-value"
+        )
+
+    def test_topic_record_name_strategy_still_resolves(self):
+        # TopicRecordNameStrategy joins the record name with "-", so it is still
+        # reachable when the topic has no TopicNameStrategy subject.
+        registry = self._registry(["orders-io.acryl.Order-value"])
+        assert (
+            registry._get_subject_for_topic("orders", False)
+            == "orders-io.acryl.Order-value"
+        )
+
+    def test_key_schemas_resolve_independently(self):
+        registry = self._registry(["orders.RETRY-key", "orders-key", "orders-value"])
+        assert registry._get_subject_for_topic("orders", True) == "orders-key"
+        assert registry._get_subject_for_topic("orders", False) == "orders-value"
+
+    def test_topic_subject_map_still_overrides(self):
+        registry = self._registry(
+            ["orders-value"],
+            topic_subject_map={"orders-value": "explicitly.mapped-value"},
+        )
+        assert (
+            registry._get_subject_for_topic("orders", False)
+            == "explicitly.mapped-value"
+        )
+
+    def test_disable_topic_record_naming_strategy_is_exact_only(self):
+        registry = self._registry(
+            ["orders-io.acryl.Order-value"],
+            disable_topic_record_naming_strategy=True,
+        )
+        assert registry._get_subject_for_topic("orders", False) is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

A topic could be given another topic's schema. `_get_subject_for_topic` returned the first registry subject that began with the topic name and ended with the `-key`/`-value` suffix, so any companion topic sharing that prefix was a candidate: topic `orders` resolved to `orders.RETRY-value` whenever the registry happened to list the retry subject first.

Nothing fails when this happens, which is what makes it worth fixing. The topic gets the companion's `schemaMetadata`, its `Schema Name` custom property names a subject belonging to a different topic, and its description is read from that schema's Avro `doc`. The mismatch survives until somebody compares a field list against the producer.

Measured on one Confluent Cloud estate of 966 topics: of the 538 that resolved a schema, **95 were bound to a `.RETRY` or `.DLT` subject while their own subject sat in the registry**. Registry listing order is the only reason it went that way rather than the other.

## What changes

Two steps, in order:

1. **Prefer the exact `<topic>-<key/value>` subject.** TopicNameStrategy makes that name unambiguous, so honour it before considering any longer subject.
2. **Require the `-` delimiter for the prefix fallback.** TopicRecordNameStrategy forms subjects as `<topic>-<record name>-<key/value>`, so the character after the topic name must be `-`. A `<topic>.<suffix>` topic continues its name with `.` and is a separate topic that owns its own subjects.

Together these implement case (c) that the existing comment already describes but the code did not handle - `a.b.c.d` and `a.b.c.d.qa` now each resolve to their own subject instead of racing for whichever the registry lists first.

A topic with no subject of its own now reports as schemaless rather than silently adopting a companion's schema. The caller already warns about that case, so the gap becomes visible instead of wrong.

## Behaviour preserved

Covered by tests rather than asserted:

- TopicRecordNameStrategy subjects still resolve (`orders-io.acryl.Order-value` for topic `orders`)
- `topic_subject_map` still overrides everything
- `disable_topic_record_naming_strategy` remains exact-match only
- key and value schemas resolve independently

## Testing

Eight new cases in `tests/unit/kafka/test_confluent_schema_registry.py`. Four of them fail against the unpatched resolver; the other four are the regression guards above and pass either way.

- `pytest tests/unit/kafka/` - 221 passed
- `ruff check .`, `ruff format --check .`, `mypy .` - clean
- `:metadata-ingestion:connectorRegistry` + `:metadata-ingestion:lineageGen` - no generated-file drift
- Kafka integration goldens unaffected: every golden subject is an exact match with no prefix overlap between fixture topics

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing#commit-message-format))
- [x] Links to related issues (if applicable)
- [x] Tests for the changes have been added/updated (if applicable)
- [x] Docs related to the changes have been added/updated (if applicable)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kafka topic schema resolution so a topic can no longer be served a companion topic's schema (for example, `orders` resolving to `orders.RETRY-value`) based on registry listing order. The resolver now prefers the exact `<topic>-<key>/<value>` subject and, failing that, requires the `-` delimiter before considering a record-name subject.

**Bug Fixes**
- Topics without their own subject now report as schemaless instead of silently adopting a companion's schema.
- Preserves TopicRecordNameStrategy subjects, `topic_subject_map` overrides, and `disable_topic_record_naming_strategy` exact-match-only behavior.

<sup>Written for commit 6edc0e8f633b6d68938599d1198f447e81b5d0b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

