### PR TITLE
ci(release): Slack-notify docker-unified start on GitHub release publish

### DIFF
--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -82,6 +82,44 @@ permissions:
   id-token: write
 
 jobs:
+  # Announce build start in the release Slack channel when a GitHub release is
+  # published, linking to this run. Non-blocking: never gates the actual build.
+  # Only fires on release events — not on ordinary pushes to releases/**
+  # branches, which would notify on every merge.
+  notify_release_build_start:
+    name: Notify Release Channel of Build Start
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: true
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Notify release channel of build start
+        continue-on-error: true
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.CI_NOTIFIER_SLACK_BOT_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          PYTHONPATH: ${{ github.workspace }}/.github/scripts:${{ github.workspace }}/.github/scripts/release
+        run: |
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MESSAGE="*Docker build started* for \`${RELEASE_TAG}\` — <${RUN_URL}|view run>"
+          python3 .github/scripts/release/notify_release_channel.py \
+            --version "${RELEASE_TAG}" \
+            --emoji ":hammer_and_wrench:" \
+            --message "${MESSAGE}"
+
   setup:
     runs-on: depot-ubuntu-24.04-small
     outputs:


### PR DESCRIPTION
## Summary
- Add Cloud's `notify_release_build_start` job to OSS `docker-unified.yml` so RC and final GitHub releases post a "Docker build started" message (with a link to the run) in `oss_release_v*`.
- Job is gated on `github.event_name == 'release'` so ordinary pushes to `releases/**` do not notify, and the Slack step is `continue-on-error` so a missing token or API error cannot fail image builds.

## Test plan
- [ ] Confirm `CI_NOTIFIER_SLACK_BOT_TOKEN` is set on `datahub-project/datahub` and the bot is in the target `oss_release_v*` channel
- [ ] On the next RC or final GitHub `release` publish, check that `Notify Release Channel of Build Start` runs and posts the hammer-and-wrench message
- [ ] Confirm a normal push/PR to `releases/**` does **not** run this job
- [ ] Confirm a Slack failure still lets the rest of `docker-unified` proceed


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Slack notification job to `docker-unified.yml` so GitHub release publishes post a "Docker build started" message with a link to the run in the `oss_release_v*` channel.

- Mirrors Cloud's existing `notify_release_build_start` job using the release notification script.
- Gated on `release` events, so pushes to `releases/**` don't notify.
- Slack step is `continue-on-error`, so a missing token or API error can't fail the image build.
- Requires `CI_NOTIFIER_SLACK_BOT_TOKEN` and bot access to `oss_release_v*`.

<sup>Written for commit 0c59a6d004be52e4a111d39ca2cc94761d58c070. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

