### PR TITLE
fix(executor): mask requirements logging in-process instead of cat

### DIFF
--- a/metadata-ingestion/src/datahub/executor/execution/runner.py
+++ b/metadata-ingestion/src/datahub/executor/execution/runner.py
@@ -27,10 +27,14 @@ from expandvars import (
 )
 from loguru import logger
 
+# TODO: promote to a public config_loader helper.
+from datahub.configuration.config_loader import _extract_env_var_names
 from datahub.executor.common.env_config import (
     get_bundled_venv_path,
     get_dependency_resolution_enabled,
 )
+from datahub.masking.masking_filter import SecretMaskingFilter
+from datahub.masking.secret_registry import SecretRegistry
 
 
 def _expand_pip_req(req: str) -> str:
@@ -56,6 +60,17 @@ def _expand_pip_req(req: str) -> str:
         raise RuntimeError(
             f"pip requirement {req!r} has invalid environment variable syntax: {e}"
         ) from e
+
+
+def _referenced_env_values(reqs: list[str]) -> dict[str, str]:
+    """Values of only the env vars the user references in pip requirements."""
+    values: dict[str, str] = {}
+    for req in reqs:
+        for name in _extract_env_var_names(req):
+            value = os.environ.get(name)
+            if value is not None:
+                values[name] = value
+    return values
 
 
 _DEFAULT_MAX_LOG_LINES = 2000
@@ -138,6 +153,12 @@ class LogHolder:
         self._lines.clear()
         self._create_new_line = True
         self.most_recent_log_ts = None
+
+    def append_masked(self, content: str) -> None:
+        """Masks the whole buffer before splitting, so multi-line secrets cannot straddle lines."""
+        masked = SecretMaskingFilter(SecretRegistry.get_instance()).mask_text(content)
+        for line in masked.splitlines():
+            self.append(f"{line}\n")
 
     def append(self, partial_line: str) -> None:
         self.most_recent_log_ts = datetime.now(tz=timezone.utc)
@@ -502,6 +523,10 @@ async def setup_venv(
         )
 
     # Handle dynamic venvs
+    SecretRegistry.get_instance().register_secrets_batch(
+        _referenced_env_values(venv_config.extra_pip_requirements)
+    )
+
     # Expand env-var templates once so that the venv cache key and the
     # requirements file see the same os.environ snapshot.
     expanded_pip_reqs = venv_config.resolve_pip_requirements()
@@ -550,7 +575,7 @@ async def setup_venv(
         runner._logs.append(
             f"Installing requirements from: {venv_config.requirements_file}\n"
         )
-        await runner.execute(["cat", str(venv_config.requirements_file)])
+        runner._logs.append_masked(venv_config.requirements_file.read_text())
         install_cmd = [
             _find_uv(),
             "pip",
@@ -614,7 +639,7 @@ async def setup_venv(
         extra_req_file = venv_loc / "extra-requirements.txt"
         extra_req_file.write_text("\n".join(expanded_pip_reqs))
         runner._logs.append(f"Installing extra requirements from: {extra_req_file}\n")
-        await runner.execute(["cat", str(extra_req_file)])
+        runner._logs.append_masked("\n".join(expanded_pip_reqs))
         await runner.execute(
             [_find_uv(), "pip", "install", "-r", str(extra_req_file)],
             env=venv_env,

--- a/metadata-ingestion/tests/unit/executor/test_requirements_logging.py
+++ b/metadata-ingestion/tests/unit/executor/test_requirements_logging.py
@@ -1,0 +1,64 @@
+import pytest
+
+from datahub.executor.execution.runner import (
+    LogHolder,
+    _referenced_env_values,
+)
+from datahub.masking.secret_registry import SecretRegistry
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry():
+    SecretRegistry.reset_instance()
+    yield
+    SecretRegistry.reset_instance()
+
+
+class TestReferencedEnvValues:
+    def test_only_referenced_vars_are_collected(self, monkeypatch):
+        monkeypatch.setenv("PIP_INDEX_TOKEN", "tok-super-secret-1")
+        monkeypatch.setenv("UNRELATED_VAR", "unrelated-value")
+        reqs = [
+            "pkg @ https://user:${PIP_INDEX_TOKEN}@example.com/simple",
+            "plainpkg==1.0",
+        ]
+        assert _referenced_env_values(reqs) == {"PIP_INDEX_TOKEN": "tok-super-secret-1"}
+
+    def test_default_syntax_bare_refs_and_unset_vars(self, monkeypatch):
+        monkeypatch.setenv("SET_VAR", "set-value-123")
+        monkeypatch.setenv("BARE_VAR", "bare-value-456")
+        monkeypatch.delenv("UNSET_VAR", raising=False)
+        reqs = ["a==${SET_VAR:-1.0}", "b==${UNSET_VAR}", "c @ https://x/$BARE_VAR"]
+        assert _referenced_env_values(reqs) == {
+            "SET_VAR": "set-value-123",
+            "BARE_VAR": "bare-value-456",
+        }
+
+
+class TestAppendMasked:
+    def test_registered_secret_is_masked(self):
+        SecretRegistry.get_instance().register_secret("TOKEN", "tok-super-secret-1")
+        logs = LogHolder()
+        logs.append_masked(
+            "pkg @ https://user:tok-super-secret-1@example.com/simple\nplain==1.0"
+        )
+        joined = "".join(logs.get_lines())
+        assert "tok-super-secret-1" not in joined
+        assert "***REDACTED:TOKEN***" in joined
+        assert "plain==1.0" in joined
+
+    def test_multi_line_secret_is_masked_whole_buffer(self):
+        key = "first-key-line-material\nsecond-key-line-material"
+        SecretRegistry.get_instance().register_secret("MULTI_KEY", key)
+        logs = LogHolder()
+        logs.append_masked(f"before\n{key}\nafter")
+        joined = "".join(logs.get_lines())
+        assert "first-key-line-material" not in joined
+        assert "second-key-line-material" not in joined
+        assert "before" in joined
+        assert "after" in joined
+
+    def test_unregistered_content_passes_through(self):
+        logs = LogHolder()
+        logs.append_masked("acryl-datahub[snowflake]==1.2.3")
+        assert "acryl-datahub[snowflake]==1.2.3\n" in logs.get_lines()


### PR DESCRIPTION
Port of **[acryldata/acryl-executor#107](https://github.com/acryldata/acryl-executor/pull/107)** — 1 of 5 in a stack picking up the changes that landed on `acryl-executor` after the engine moved into OSS (`datahub.executor`).

### What

- The two `cat <requirements-file>` subprocess calls in `setup_venv` are replaced by in-process logging that masks the **whole buffer** before line-splitting, so a multi-line secret cannot straddle per-line masking.
- Env values the user references via `${VAR}` in `extra_pip_requirements` are registered into the process `SecretRegistry` before any expanded content can reach a log line.

### Why

Expanded requirement lines can embed credentials resolved from environment variables — a token inside an index URL, most commonly. They were `cat`'ed verbatim into the shared logs, and those logs reach the execution report, which is readable with `Manage Ingestion` alone. Nothing could mask them, because the values were never registered anywhere. This keeps full install-content logging, just redacted.

### Notes for review

- Upstream also bumped `acryl-datahub>=1.7.0.8` and dropped two `initialize_secret_masking(force=True)` call sites. Neither applies here: `datahub.masking` is in-repo and already at that level (idempotent `initialize_secret_masking()`, fail-closed `mask_text`, no-op `shutdown_secret_masking`), and master's call sites already pass no `force`.
- `_extract_env_var_names` is imported from `datahub.configuration.config_loader` under a `TODO` — it's private there, and the upstream note about promoting it to a public helper still stands now that the caller is in the same package.


## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] Tests added (`tests/unit/executor/test_requirements_logging.py`)
- [ ] Docs — n/a
- [ ] Breaking changes — none


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Masks credentials in pip requirements install logs instead of cat'ing the files verbatim into the execution report.

- Replaces both `cat <requirements-file>` subprocess calls with in-process logging that masks the whole buffer before line splitting, so a multi-line secret can't straddle lines.
- Registers env values referenced via `${VAR}` in `extra_pip_requirements` into the process `SecretRegistry` before any expanded content can reach a log line.

**Notes**
- Overlaps with #19458, which stops logging requirement contents entirely; if this PR is taken, #19458 should be closed.

<sup>Written for commit c91da1c8955cd223f8bad2d6d8889d9f53b8fe16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

