### PR TITLE
fix(executor): route runner log echo through stdlib logging

### DIFF
--- a/metadata-ingestion/src/datahub/executor/execution/runner.py
+++ b/metadata-ingestion/src/datahub/executor/execution/runner.py
@@ -4,6 +4,7 @@ import dataclasses
 import functools
 import hashlib
 import json
+import logging
 import os
 import pathlib
 import shlex
@@ -25,7 +26,6 @@ from expandvars import (
     UnboundVariable,
     expand as _expandvars_expand,
 )
-from loguru import logger
 
 # TODO: promote to a public config_loader helper.
 from datahub.configuration.config_loader import _extract_env_var_names
@@ -35,6 +35,8 @@ from datahub.executor.common.env_config import (
 )
 from datahub.masking.masking_filter import SecretMaskingFilter
 from datahub.masking.secret_registry import SecretRegistry
+
+logger = logging.getLogger(__name__)
 
 
 def _expand_pip_req(req: str) -> str:
@@ -185,7 +187,9 @@ class LogHolder:
         # If partial_line ends with a '\n', then the line is complete.
         if partial_line.endswith("\n"):
             if self._echo_logs_prefix is not None:
-                logger.opt(raw=True).debug(f"{self._echo_logs_prefix}{self._lines[-1]}")
+                logger.debug(
+                    "%s%s", self._echo_logs_prefix, self._lines[-1].rstrip("\n")
+                )
 
             # On the next append, we'll create a new line.
             self._create_new_line = True

--- a/metadata-ingestion/tests/unit/executor/test_runner.py
+++ b/metadata-ingestion/tests/unit/executor/test_runner.py
@@ -1,10 +1,10 @@
+import logging
 import pathlib
 import subprocess
 import sys
 import tempfile
 import threading
 import time
-from io import StringIO
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -485,18 +485,14 @@ class TestLogHolder:
         # Should be truncated to approximately the max size
         assert len(logs) <= 200  # Some tolerance for truncation messages
 
-    def test_echo_to_stdout_functionality(self):
-        """Test echo to stdout with prefix."""
-        # Capture stdout
-        captured_output = StringIO()
-
-        with patch("sys.stdout", captured_output):
+    def test_echo_goes_through_stdlib_logging(self, caplog):
+        """Echoed lines are stdlib log records, so masking filters on logging
+        handlers apply to them."""
+        with caplog.at_level(logging.DEBUG, logger="datahub.executor.execution.runner"):
             log_holder = LogHolder(echo_to_stdout_prefix="[TEST] ")
             log_holder.append("Test message\n")
 
-        # Check if message was echoed (depends on loguru implementation)
-        # This test verifies the LogHolder can be created with echo prefix
-        assert log_holder._echo_logs_prefix == "[TEST] "
+        assert "[TEST] Test message" in caplog.text
 
     def test_concurrent_log_access(self):
         """Test thread-safe access to logs."""


### PR DESCRIPTION
Port of **[acryldata/acryl-executor#108](https://github.com/acryldata/acryl-executor/pull/108)** — 2 of 5 in a stack. **Stacked on #19641**; review that first, or read this diff alone (it is 4 lines of source).

### What

Replaces loguru with stdlib logging in `runner.py` — the only loguru user anywhere in the repo.

### Why

`LogHolder.append` echoes every completed shared-log line to the console channel. Loguru is not stdlib logging, which has two consequences:

- Handler-level masking filters, which we install on `logging` handlers, can never apply to it.
- It captures the real `stderr` at import time, bypassing the stream wrappers.

That made the echo an unmaskable channel with the widest blast radius of any — pod logs and whatever aggregates them. As stdlib records, the echo joins the same masking installation as everything else.

`logger.opt(raw=True).debug(f"...")` becomes `logger.debug("%s%s", prefix, line.rstrip("\n"))`: `%s`-style so the record keeps its args for the filter to mask, and an explicit `rstrip` because stdlib adds the newline that `raw=True` did not.

## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] Tests updated (`test_echo_goes_through_stdlib_logging`)
- [ ] Docs — n/a
- [ ] Breaking changes — none



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the runner log echo through stdlib logging so handler-level masking filters apply to it. Previously the echo was unmaskable because loguru bypasses stdlib handlers and captures stderr directly.

- `loguru` is now unused in the repo but stays in base dependencies; removing it requires regenerating lockfiles and is left for a follow-up.

<sup>Written for commit d1a6eec5097a2b615d9940f440015b382b46b057. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



