### PR TITLE
fix(executor): fail-closed masking at every publish choke point

### DIFF
--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_ingestion_task.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_ingestion_task.py
@@ -48,9 +48,7 @@ from datahub.executor.execution.sub_process_task_common import (
     resolve_wrapper_script,
 )
 from datahub.executor.execution.task import Task, TaskError
-from datahub.masking.bootstrap import shutdown_secret_masking
 from datahub.masking.masking_filter import SecretMaskingFilter
-from datahub.masking.secret_registry import SecretRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -448,6 +446,7 @@ class SubProcessIngestionTask(Task):
     ) -> None:
         """Monitor subprocess execution with async tasks for output reading and progress reporting."""
         most_recent_log_ts: Optional[datetime] = None
+        masking_filter = SecretMaskingFilter()
 
         async def _read_output_lines() -> None:
             nonlocal most_recent_log_ts
@@ -522,7 +521,7 @@ class SubProcessIngestionTask(Task):
 
                     # TODO maybe use the normal report field here?
                     logger.debug(f"Reporting in-progress for exec_id={exec_id}")
-                    ctx.request.progress_callback(report)
+                    ctx.request.progress_callback(masking_filter.mask_text(report))
 
                 full_log_file.flush()
                 await asyncio.sleep(0)
@@ -594,21 +593,15 @@ class SubProcessIngestionTask(Task):
         code from a non-cancelled run — so callers can invoke this from a
         `finally` block without fear of masking an in-flight exception.
         """
+        masking_filter = SecretMaskingFilter()
 
         if os.path.exists(report_out_file):
             try:
                 with open(report_out_file) as structured_report_fp:
                     report_content = structured_report_fp.read()
-                try:
-                    registry = SecretRegistry.get_instance()
-                    if registry and registry.get_count() > 0:
-                        report_content = SecretMaskingFilter(registry).mask_text(
-                            report_content
-                        )
-                except Exception:
-                    # Better to have the report than to fail completely.
-                    logger.warning("Failed to mask structured report, using original")
-                ctx.get_report().set_structured_report(report_content)
+                ctx.get_report().set_structured_report(
+                    masking_filter.mask_text(report_content)
+                )
             except Exception:
                 logger.exception(
                     "Failed to process structured report from %s", report_out_file
@@ -616,17 +609,14 @@ class SubProcessIngestionTask(Task):
 
         try:
             ctx.get_report().set_logs(
-                SubProcessTaskUtil._format_log_lines(shared_logs.get_lines())
+                masking_filter.mask_text(
+                    SubProcessTaskUtil._format_log_lines(shared_logs.get_lines())
+                )
             )
         except Exception:
             logger.exception("Failed to set logs on execution report")
 
         SubProcessTaskUtil._remove_directory(exec_out_dir)
-
-        try:
-            shutdown_secret_masking()
-        except Exception as e:
-            logger.warning(f"Failed to shutdown secret masking: {e}")
 
         if cancelled:
             ctx.get_report().report_info("Ingestion task was cancelled")

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_task_common.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_task_common.py
@@ -88,14 +88,16 @@ class SubProcessTaskUtil:
         return text
 
     @staticmethod
-    def _resolve_secrets(secret_names: list[str], ctx: ExecutorContext) -> dict:
+    def _resolve_secrets(
+        secret_names: list[str], ctx: ExecutorContext
+    ) -> dict[str, str]:
         # Attempt to resolve secret using by checking each configured secret store.
         secret_stores = ctx.get_secret_stores()
         store_ids = [s.get_id() for s in secret_stores]
         logger.info(
             f"Resolving {len(secret_names)} secret(s) across {len(secret_stores)} store(s): {store_ids}"
         )
-        final_secret_values = dict({})
+        final_secret_values: dict[str, str] = {}
 
         for secret_store in secret_stores:
             try:
@@ -185,23 +187,15 @@ class SubProcessTaskUtil:
                     )
                     secret_values_dict[secret_name] = ""
 
-        # Set up secret masking in the executor process (for masking logs/reports)
         if secrets_to_resolve:
-            try:
-                initialize_secret_masking()
-                registry = SecretRegistry.get_instance()
-                for secret_name in secrets_to_resolve:
-                    secret_value = secret_values_dict.get(secret_name)
-                    if secret_value:
-                        registry.register_secret(secret_name, secret_value)
-
-                logger.info(
-                    f"Secret masking enabled for {registry.get_count()} secret(s)"
-                )
-            except Exception as e:
-                logger.warning(
-                    f"Failed to set up secret masking: {e}. Continuing without masking."
-                )
+            initialize_secret_masking()
+            SecretRegistry.get_instance().register_secrets_batch(
+                {
+                    name: secret_values_dict[name]
+                    for name in secrets_to_resolve
+                    if secret_values_dict.get(name)
+                }
+            )
 
         # Validate secret values and warn on potential issues
         if secret_matches:

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
@@ -38,9 +38,7 @@ from datahub.executor.execution.sub_process_task_common import (
     resolve_wrapper_script,
 )
 from datahub.executor.execution.task import Task, TaskError
-from datahub.masking.bootstrap import shutdown_secret_masking
 from datahub.masking.masking_filter import SecretMaskingFilter
-from datahub.masking.secret_registry import SecretRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -151,28 +149,14 @@ class SubProcessTestConnectionTask(Task):
         ingest_process.stdin.write(stdin_envelope)
         ingest_process.stdin.close()
 
-        try:
-            # Create masking filter for subprocess stdout
-            # Masking was already set up in _resolve_recipe for the executor process
-            masking_filter = None
-            try:
-                registry = SecretRegistry.get_instance()
-                if registry and registry.get_count() > 0:
-                    masking_filter = SecretMaskingFilter(registry)
-                    logger.info(
-                        f"[TEST_CONNECTION] Created masking filter with {registry.get_count()} secret(s)"
-                    )
-            except Exception as e:
-                logger.warning(
-                    f"[TEST_CONNECTION] Failed to create masking filter: {e}"
-                )
+        masking_filter = SecretMaskingFilter()
 
+        try:
             while ingest_process.poll() is None:
                 assert ingest_process.stdout
                 line = ingest_process.stdout.readline()
 
-                # Mask secrets before writing to stdout
-                masked_line = masking_filter.mask_text(line) if masking_filter else line
+                masked_line = masking_filter.mask_text(line)
                 sys.stdout.write(masked_line)
                 stdout_lines.append(masked_line)
                 await asyncio.sleep(0)
@@ -188,32 +172,19 @@ class SubProcessTestConnectionTask(Task):
             if os.path.exists(report_out_file):
                 with open(report_out_file) as structured_report_fp:
                     report_content = structured_report_fp.read()
+                    ctx.get_report().set_structured_report(
+                        masking_filter.mask_text(report_content)
+                    )
 
-                    # Mask secrets in structured report
-                    try:
-                        registry = SecretRegistry.get_instance()
-                        if registry and registry.get_count() > 0:
-                            temp_filter = SecretMaskingFilter(registry)
-                            report_content = temp_filter.mask_text(report_content)
-                    except Exception:
-                        logger.warning(
-                            "Failed to mask structured report, using original"
-                        )
-
-                    ctx.get_report().set_structured_report(report_content)
-
+            # Whole-buffer mask: covers multi-line secrets that the per-line masking cannot.
             ctx.get_report().set_logs(
-                SubProcessTaskUtil._format_log_lines(stdout_lines)
+                masking_filter.mask_text(
+                    SubProcessTaskUtil._format_log_lines(stdout_lines)
+                )
             )
 
             # Cleanup execution directory
             SubProcessTaskUtil._remove_directory(exec_out_dir)
-
-            # Shutdown DataHub masking framework
-            try:
-                shutdown_secret_masking()
-            except Exception as e:
-                logger.warning(f"Failed to shutdown secret masking: {e}")
 
         if return_code != 0:
             # Failed

--- a/metadata-ingestion/tests/unit/executor/test_subprocess_ingestion_task.py
+++ b/metadata-ingestion/tests/unit/executor/test_subprocess_ingestion_task.py
@@ -30,6 +30,7 @@ from datahub.executor.execution.sub_process_task_common import SubProcessTaskUti
 from datahub.executor.execution.task import TaskError
 from datahub.executor.report.execution_report import ExecutionReport
 from datahub.executor.request.execution_request import ExecutionRequest
+from datahub.masking.constants import MASKING_ERROR_MESSAGE
 from datahub.masking.secret_registry import SecretRegistry
 
 _RESOLVE_RECIPE = (
@@ -53,9 +54,8 @@ _SETUP_VENV = "datahub.executor.execution.sub_process_ingestion_task.setup_venv"
 
 @pytest.fixture(autouse=True)
 def reset_secret_registry() -> Iterator[None]:
-    # SecretRegistry is a process-wide singleton and _handle_subprocess_completion
-    # both reads it (to mask the structured report) and clears it via
-    # shutdown_secret_masking(). Reset around every test so these tests neither
+    # SecretRegistry is a process-wide singleton that the publish choke points read
+    # to mask what they publish. Reset around every test so these tests neither
     # inherit nor leak registered secrets under --random-order.
     SecretRegistry.reset_instance()
     yield
@@ -874,11 +874,6 @@ class TestSubProcessIngestionTaskCompletion:
             patch("builtins.open", side_effect=OSError(errno.EIO, "I/O error")),
             # set_logs fails.
             patch(_FORMAT_LOG_LINES, side_effect=RuntimeError("format boom")),
-            # Secret-masking shutdown fails.
-            patch(
-                "datahub.executor.execution.sub_process_ingestion_task.shutdown_secret_masking",
-                side_effect=Exception("masking boom"),
-            ),
             # _remove_directory is internally guarded; stub it out.
             patch(_REMOVE_DIRECTORY),
         ):
@@ -1603,3 +1598,77 @@ class TestMonitorSubprocessCancellation:
         ]
         proc.terminate.assert_not_called()
         proc.kill.assert_not_called()
+
+
+class TestPublishChokePoints:
+    """Everything published from the task passes through fail-closed masking."""
+
+    @staticmethod
+    def _run_completion(
+        ingestion_task: SubProcessIngestionTask,
+        mock_execution_context: Mock,
+        shared_logs: LogHolder,
+    ) -> None:
+        with (
+            patch("os.path.exists", return_value=True),
+            patch(
+                "builtins.open",
+                mock_open(read_data='{"sink": "user:db-secret-value-1@host"}'),
+            ),
+            patch(_REMOVE_DIRECTORY),
+        ):
+            process = Mock()
+            process.returncode = 0
+            ingestion_task._handle_subprocess_completion(
+                process,
+                mock_execution_context,
+                "/tmp/report.json",
+                "/tmp/artifacts",
+                {},
+                "/tmp/exec",
+                shared_logs,
+            )
+
+    def test_structured_report_is_masked(
+        self, ingestion_task: SubProcessIngestionTask, mock_execution_context: Mock
+    ) -> None:
+        SecretRegistry.get_instance().register_secret("DB_PASS", "db-secret-value-1")
+        self._run_completion(ingestion_task, mock_execution_context, LogHolder())
+        report = mock_execution_context.get_report()
+        published = report.set_structured_report.call_args.args[0]
+        assert "db-secret-value-1" not in published
+        assert "***REDACTED:DB_PASS***" in published
+
+    def test_final_logs_are_masked_whole_buffer(
+        self, ingestion_task: SubProcessIngestionTask, mock_execution_context: Mock
+    ) -> None:
+        key = "first-line-of-multiline-key\nsecond-line-of-multiline-key"
+        SecretRegistry.get_instance().register_secret("MULTI_KEY", key)
+        shared_logs = LogHolder()
+        shared_logs.append(f"connecting with {key} now\n")
+        self._run_completion(ingestion_task, mock_execution_context, shared_logs)
+        report = mock_execution_context.get_report()
+        published = report.set_logs.call_args.args[0]
+        assert "first-line-of-multiline-key" not in published
+        assert "second-line-of-multiline-key" not in published
+
+    def test_report_masking_failure_withholds_report(
+        self, ingestion_task: SubProcessIngestionTask, mock_execution_context: Mock
+    ) -> None:
+        registry = SecretRegistry.get_instance()
+        registry.register_secret("DB_PASS", "db-secret-value-1")
+        with patch.object(
+            registry, "get_pattern_and_replacements", side_effect=KeyError("boom")
+        ):
+            self._run_completion(ingestion_task, mock_execution_context, LogHolder())
+        report = mock_execution_context.get_report()
+        published = report.set_structured_report.call_args.args[0]
+        assert published == MASKING_ERROR_MESSAGE
+
+    def test_completion_does_not_unregister_other_runs_secrets(
+        self, ingestion_task: SubProcessIngestionTask, mock_execution_context: Mock
+    ) -> None:
+        registry = SecretRegistry.get_instance()
+        registry.register_secret("SIBLING_SECRET", "sibling-secret-value")
+        self._run_completion(ingestion_task, mock_execution_context, LogHolder())
+        assert registry.has_secret("SIBLING_SECRET")

--- a/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
+++ b/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
@@ -137,9 +137,6 @@ async def test_execute_success(
         patch(
             "datahub.executor.execution.sub_process_task_common.SubProcessTaskUtil._remove_directory"
         ) as _mock_remove_dir,
-        patch(
-            "datahub.executor.execution.sub_process_test_connection_task.shutdown_secret_masking"
-        ),
     ):
         # Setup mocks: _resolve_recipe now returns (recipe, secret_values)
         mock_resolve.return_value = (
@@ -257,9 +254,6 @@ async def test_execute_failure_raises(
         patch(
             "datahub.executor.execution.sub_process_task_common.SubProcessTaskUtil._remove_directory"
         ) as _mock_remove_dir,
-        patch(
-            "datahub.executor.execution.sub_process_test_connection_task.shutdown_secret_masking"
-        ),
     ):
         # Setup mocks: _resolve_recipe now returns (recipe, secret_values)
         mock_resolve.return_value = ({"source": {"type": "demo-data"}}, {})
@@ -342,9 +336,6 @@ async def test_cancellation_terminates_the_subprocess(
         patch("os.path.exists", return_value=False),
         patch(
             "datahub.executor.execution.sub_process_task_common.SubProcessTaskUtil._remove_directory"
-        ),
-        patch(
-            "datahub.executor.execution.sub_process_test_connection_task.shutdown_secret_masking"
         ),
     ):
         mock_resolve.return_value = ({"source": {"type": "demo-data"}}, {})


### PR DESCRIPTION
Port of **[acryldata/acryl-executor#109](https://github.com/acryldata/acryl-executor/pull/109)** — 3 of 5 in a stack. **Stacked on #19642.**

### What

- Recipe secrets batch-register into the process registry, and `initialize_secret_masking()` is left installed for the life of the process. The `shutdown_secret_masking()` calls are removed.
- Every string published from the tasks now passes through fail-closed `mask_text`:
  - progress / heartbeat reports,
  - final logs — **whole-buffer**, so a multi-line secret cannot straddle per-line masking,
  - the structured report,
  - both of the same paths in the test-connection twin.
- The warn-and-publish-original fallbacks and the `registry.get_count() > 0` guards are gone. A masking failure now withholds the output behind a fixed marker instead of leaking it.

### Why

Three separate defects, one fix:

1. **The per-run lifecycle unmasked live runs.** The executor runs several ingestions in one process. `shutdown_secret_masking()` cleared the *shared* registry when the first of them finished, silently unmasking every still-running sibling. Observed as a raw secret in a published structured report.
2. **Progress reports and final logs were published with no masking at all** — only the structured report was ever masked.
3. **Every mask site failed open.** `except Exception: publish the original` is the wrong default for a redaction path.

`SecretMaskingFilter` instances are stateless views over the process registry, so the tasks construct one at the point of use. There is no lifecycle to race and nothing to tear down; `shutdown_secret_masking()` is already a documented no-op in `datahub.masking`.


### Notes for review

- The upstream test added its own registry-isolation fixture; this repo's ingestion test file already has an autouse `reset_secret_registry`, so I reused it and corrected its comment, which described the teardown behaviour being removed here.
- Upstream's `_run_completion` helper patches `get_default_graph` and `ExecutorCredentials`; neither exists in the OSS task (they are fork/cloud-only), so those patches are dropped.
- One leg of `test_..._does_not_raise_when_cleanup_steps_fail` patched `shutdown_secret_masking` to raise. With the call gone, the leg is gone; the rest of that contract test is unchanged.

## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] Tests added (`TestPublishChokePoints` — masked report, whole-buffer logs, withheld-on-failure, and no sibling unregistration)
- [ ] Docs — n/a
- [ ] Breaking changes — none


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes secret masking fail-closed at every executor publish point, so secrets never leak from masking gaps or masking failures. Previously, the first finished run cleared the shared registry and silently unmasked its still-running siblings, progress reports and final logs were published unmasked, and every mask site published the original on error.

**Masking behavior**

- Recipe secrets batch-register into the process registry, and `initialize_secret_masking()` stays installed for the process lifetime.
- `mask_text` now covers progress reports, final logs as a whole buffer (multi-line secrets can't straddle per-line masking), the structured report, and both test-connection paths.
- Masking failures withhold the output behind a fixed marker instead of publishing the original; the empty-registry guards and `shutdown_secret_masking()` calls are gone.


