### PR TITLE
feat(executor): register user-supplied env values for masking

### DIFF
--- a/metadata-ingestion/src/datahub/executor/execution/runner.py
+++ b/metadata-ingestion/src/datahub/executor/execution/runner.py
@@ -64,7 +64,7 @@ def _expand_pip_req(req: str) -> str:
         ) from e
 
 
-def _referenced_env_values(reqs: list[str]) -> dict[str, str]:
+def referenced_env_values(reqs: list[str]) -> dict[str, str]:
     """Values of only the env vars the user references in pip requirements."""
     values: dict[str, str] = {}
     for req in reqs:
@@ -528,7 +528,7 @@ async def setup_venv(
 
     # Handle dynamic venvs
     SecretRegistry.get_instance().register_secrets_batch(
-        _referenced_env_values(venv_config.extra_pip_requirements)
+        referenced_env_values(venv_config.extra_pip_requirements)
     )
 
     # Expand env-var templates once so that the venv cache key and the

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_ingestion_task.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_ingestion_task.py
@@ -264,6 +264,8 @@ class SubProcessIngestionTask(Task):
         Secrets and recipe are passed via stdin as a JSON envelope to avoid
         writing secrets to env vars or recipe to disk.
         """
+        user_env_secrets = SubProcessTaskUtil.subprocess_env_secrets(validated_args)
+
         # First, set up the venv using Python utilities with shared logging
         venv_ref = await self._setup_venv(
             validated_args, plugin, exec_out_dir, shared_logs
@@ -295,10 +297,11 @@ class SubProcessIngestionTask(Task):
         # __recipe_yaml__ and __secrets__ are consumed by datahub's config_loader.
         # __report_out_file__ and __debug_mode__ are consumed by the wrapper script.
         # All envelope keys use dunder prefix to distinguish from recipe content.
+        # Per-run values only, never the whole registry; recipe values win on collision.
         stdin_envelope = json.dumps(
             {
                 "__recipe_yaml__": yaml.dump(recipe),
-                "__secrets__": secret_values,
+                "__secrets__": {**user_env_secrets, **secret_values},
                 "__report_out_file__": report_out_file,
                 "__debug_mode__": debug_mode,
             }

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_task_common.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_task_common.py
@@ -29,6 +29,7 @@ from datahub.executor.common.config import PermissiveConfigModel
 from datahub.executor.context.execution_context import ExecutionContext
 from datahub.executor.context.executor_context import ExecutorContext
 from datahub.executor.execution import venv_utils
+from datahub.executor.execution.runner import referenced_env_values
 from datahub.masking.bootstrap import initialize_secret_masking
 from datahub.masking.secret_registry import SecretRegistry
 
@@ -214,6 +215,20 @@ class SubProcessTaskUtil:
     def _get_plugin_from_recipe(recipe: dict) -> str:
         # The source type -- ASSUMPTION ALERT: This should always correspond to the plugin name.
         return recipe["source"]["type"]
+
+    @staticmethod
+    def subprocess_env_secrets(args: "SubProcessRecipeTaskArgs") -> dict[str, str]:
+        """Env values referenced in pip requirements, for the subprocess stdin
+        envelope. Names the user overrides via extra_env_vars are excluded so
+        recipe resolution keeps get_combined_env_vars precedence (user value
+        wins); setup_venv registers all referenced values for masking."""
+        return {
+            name: value
+            for name, value in referenced_env_values(
+                args.extra_pip_requirements
+            ).items()
+            if name not in args.extra_env_vars
+        }
 
     @staticmethod
     def _remove_directory(dir_path: str) -> None:

--- a/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
+++ b/metadata-ingestion/src/datahub/executor/execution/sub_process_test_connection_task.py
@@ -90,6 +90,8 @@ class SubProcessTestConnectionTask(Task):
             extra_pip_plugins=validated_args.extra_pip_plugins,
             extra_env_vars=validated_args.extra_env_vars,
         )
+        user_env_secrets = SubProcessTaskUtil.subprocess_env_secrets(validated_args)
+
         venv_setup_logs = LogHolder()
         venv_runner = SubprocessRunner(logs=venv_setup_logs)
         try:
@@ -123,10 +125,11 @@ class SubProcessTestConnectionTask(Task):
 
         # Build stdin envelope in datahub-compatible format.
         # All envelope keys use dunder prefix to distinguish from recipe content.
+        # Per-run values only, never the whole registry; recipe values win on collision.
         stdin_envelope = json.dumps(
             {
                 "__recipe_yaml__": yaml.dump(recipe),
-                "__secrets__": secret_values,
+                "__secrets__": {**user_env_secrets, **secret_values},
                 "__report_out_file__": report_out_file,
             }
         )

--- a/metadata-ingestion/tests/unit/executor/test_requirements_logging.py
+++ b/metadata-ingestion/tests/unit/executor/test_requirements_logging.py
@@ -2,7 +2,11 @@ import pytest
 
 from datahub.executor.execution.runner import (
     LogHolder,
-    _referenced_env_values,
+    referenced_env_values,
+)
+from datahub.executor.execution.sub_process_task_common import (
+    SubProcessRecipeTaskArgs,
+    SubProcessTaskUtil,
 )
 from datahub.masking.secret_registry import SecretRegistry
 
@@ -22,14 +26,14 @@ class TestReferencedEnvValues:
             "pkg @ https://user:${PIP_INDEX_TOKEN}@example.com/simple",
             "plainpkg==1.0",
         ]
-        assert _referenced_env_values(reqs) == {"PIP_INDEX_TOKEN": "tok-super-secret-1"}
+        assert referenced_env_values(reqs) == {"PIP_INDEX_TOKEN": "tok-super-secret-1"}
 
     def test_default_syntax_bare_refs_and_unset_vars(self, monkeypatch):
         monkeypatch.setenv("SET_VAR", "set-value-123")
         monkeypatch.setenv("BARE_VAR", "bare-value-456")
         monkeypatch.delenv("UNSET_VAR", raising=False)
         reqs = ["a==${SET_VAR:-1.0}", "b==${UNSET_VAR}", "c @ https://x/$BARE_VAR"]
-        assert _referenced_env_values(reqs) == {
+        assert referenced_env_values(reqs) == {
             "SET_VAR": "set-value-123",
             "BARE_VAR": "bare-value-456",
         }
@@ -62,3 +66,29 @@ class TestAppendMasked:
         logs = LogHolder()
         logs.append_masked("acryl-datahub[snowflake]==1.2.3")
         assert "acryl-datahub[snowflake]==1.2.3\n" in logs.get_lines()
+
+
+class TestSubprocessEnvSecrets:
+    def test_collects_pip_references_not_extra_env_vars(self, monkeypatch):
+        monkeypatch.setenv("PIP_INDEX_TOKEN", "tok-super-secret-1")
+        args = SubProcessRecipeTaskArgs(
+            recipe="{}",
+            extra_pip_requirements=[
+                "pkg @ https://user:${PIP_INDEX_TOKEN}@example.com/simple"
+            ],
+            extra_env_vars={"CONNECTOR_KEY": "connector-key-value"},
+        )
+        assert SubProcessTaskUtil.subprocess_env_secrets(args) == {
+            "PIP_INDEX_TOKEN": "tok-super-secret-1"
+        }
+
+    def test_user_override_is_excluded_so_recipe_resolution_stays_consistent(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("SHARED_NAME", "pod-value-material")
+        args = SubProcessRecipeTaskArgs(
+            recipe="{}",
+            extra_pip_requirements=["pkg @ https://x/${SHARED_NAME}/simple"],
+            extra_env_vars={"SHARED_NAME": "user-value-material"},
+        )
+        assert SubProcessTaskUtil.subprocess_env_secrets(args) == {}

--- a/metadata-ingestion/tests/unit/executor/test_runner.py
+++ b/metadata-ingestion/tests/unit/executor/test_runner.py
@@ -26,6 +26,7 @@ from datahub.executor.execution.runner import (
     setup_venv,
     validate_dependency_resolution_enabled,
 )
+from datahub.masking.secret_registry import SecretRegistry
 
 
 def test_venv_config_json_parsing() -> None:
@@ -1011,6 +1012,35 @@ class TestSetupVenvConstraints:
         pass2_cmd = extra_installs[0][0][0]
         assert "--reinstall" not in pass2_cmd
         assert "--reinstall-package" not in pass2_cmd
+
+    @patch("datahub.executor.execution.runner._find_uv", return_value="uv")
+    async def test_setup_venv_registers_referenced_env_values(
+        self, _find_uv, temp_dir, monkeypatch
+    ):
+        """Env values referenced in pip requirements must be maskable before
+        any expanded content reaches a log line."""
+        SecretRegistry.reset_instance()
+        monkeypatch.setenv("VENV_PIP_TOKEN", "venv-pip-token-value")
+        config = VenvConfig(
+            version="0.12.1",
+            main_plugin="snowflake",
+            extra_pip_requirements=[
+                "pkg @ https://user:${VENV_PIP_TOKEN}@example.com/simple"
+            ],
+        )
+        runner = SubprocessRunner()
+        mock = AsyncMock(side_effect=self._mock_execute)
+
+        try:
+            with patch.object(runner, "execute", mock):
+                await setup_venv(config, runner, temp_dir)
+
+            assert (
+                SecretRegistry.get_instance().get_secret_value("VENV_PIP_TOKEN")
+                == "venv-pip-token-value"
+            )
+        finally:
+            SecretRegistry.reset_instance()
 
     @patch("datahub.executor.execution.runner._find_uv", return_value="uv")
     async def test_custom_requirements_file_skips_pass2(self, _find_uv, temp_dir):

--- a/metadata-ingestion/tests/unit/executor/test_subprocess_ingestion_task.py
+++ b/metadata-ingestion/tests/unit/executor/test_subprocess_ingestion_task.py
@@ -20,6 +20,7 @@ from datahub.executor.execution.runner import (
     SubprocessRunner,
     VenvConfig,
     VenvReference,
+    referenced_env_values,
 )
 from datahub.executor.execution.sub_process_ingestion_task import (
     SubProcessIngestionTask,
@@ -1664,6 +1665,26 @@ class TestPublishChokePoints:
         report = mock_execution_context.get_report()
         published = report.set_structured_report.call_args.args[0]
         assert published == MASKING_ERROR_MESSAGE
+
+    def test_pip_referenced_env_secrets_are_masked_in_published_logs(
+        self,
+        ingestion_task: SubProcessIngestionTask,
+        mock_execution_context: Mock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Pins the singleton wiring: what setup_venv registers is what the
+        publish choke points redact."""
+        monkeypatch.setenv("PIP_INDEX_TOKEN", "pip-token-value-1")
+        SecretRegistry.get_instance().register_secrets_batch(
+            referenced_env_values(["pkg @ https://u:${PIP_INDEX_TOKEN}@x/simple"])
+        )
+        shared_logs = LogHolder()
+        shared_logs.append("subprocess echoed pip-token-value-1\n")
+        self._run_completion(ingestion_task, mock_execution_context, shared_logs)
+        report = mock_execution_context.get_report()
+        published = report.set_logs.call_args.args[0]
+        assert "pip-token-value-1" not in published
+        assert "***REDACTED:PIP_INDEX_TOKEN***" in published
 
     def test_completion_does_not_unregister_other_runs_secrets(
         self, ingestion_task: SubProcessIngestionTask, mock_execution_context: Mock

--- a/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
+++ b/metadata-ingestion/tests/unit/executor/test_subprocess_test_connection_task.py
@@ -191,6 +191,8 @@ async def test_execute_success(
         assert yaml.safe_load(stdin_payload["__recipe_yaml__"]) == {
             "source": {"type": "demo-data"}
         }
+        # Recipe secrets plus pip-referenced env values; extra_env_vars are
+        # deliberately NOT treated as secrets (plaintext in the source config).
         assert stdin_payload["__secrets__"] == {"SOME_SECRET": "val"}
         mock_process.stdin.close.assert_called_once()
 


### PR DESCRIPTION
Port of **[acryldata/acryl-executor#110](https://github.com/acryldata/acryl-executor/pull/110)** — 4 of 5 in a stack. **Stacked on #19643.**

### What

- New `SubProcessTaskUtil.subprocess_env_secrets()`: values the user references via `${VAR}` in `extra_pip_requirements` are collected and included in the subprocess stdin envelope, for both ingestion and test-connection. `setup_venv` (from #19641) already registers them for masking in the executor process; this carries them into the child.
- The envelope carries the **per-run union only** — never the whole process registry — so one run's subprocess never receives another run's secrets. Recipe values win on a name collision.
- Names the user overrides via `extra_env_vars` are excluded, so recipe resolution keeps `get_combined_env_vars` precedence (the user's value wins, not the pod's).
- `_referenced_env_values` in `runner.py` loses its underscore now that it has a second consumer.

### Why

These values are secrets by the user's own intent — a token in an index URL, a connector credential — but they were registered nowhere, which made them unmaskable by every layer, in the executor process *and* in the subprocess.

Ambient environment variables are deliberately **never** collected. Only what the user explicitly supplied or referenced; hoovering up `os.environ` would put unrelated pod configuration into a redaction pattern.

`extra_env_vars` values are likewise not treated as secrets — they are plaintext in the source config already — they only participate as *names* to exclude.

### Notes for review

- The rename is kept as its own step rather than folded back into #19641, so each PR in this stack maps 1:1 onto its upstream counterpart and stays diff-checkable against it.
- `sub_process_task_common` now imports `runner` at module level. No cycle: `runner` imports only `datahub.executor.common.env_config`. The pre-existing lazy import inside `get_venv_name` is left alone rather than opportunistically cleaned up.
- Also adds the assertion upstream noted was missing: that `setup_venv` genuinely registers referenced env values, rather than merely executing that line.

## Checklist

- [x] PR conforms to the Contributing Guideline
- [x] Tests added (`TestSubprocessEnvSecrets`, `test_setup_venv_registers_referenced_env_values`, and an end-to-end check that what `setup_venv` registers is what the publish choke points redact)
- [ ] Docs — n/a
- [ ] Breaking changes — none

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes unmasked secrets in subprocess logs by including env values the user references via `${VAR}` in `extra_pip_requirements` into the subprocess stdin envelope for both ingestion and test-connection. Previously these values were registered nowhere, so secrets like index URL tokens leaked unmasked into logs.

- The envelope carries only the per-run union of values, never the whole process registry, so one run's subprocess can't see another run's secrets; recipe values win on name collisions.
- Only what the user explicitly referenced is collected; ambient `os.environ` is deliberately never read.
- Names the user overrides via `extra_env_vars` are excluded so recipe resolution keeps the user's value winning over the pod's.
- `_referenced_env_values` is renamed to `referenced_env_values` now that it has a second consumer.
- Adds a test asserting `setup_venv` actually registers referenced env values rather than just executing that line.

<sup>Written for commit 44b25a0eb6304dd050d21d30df8e7d43cd1c6eea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

