### PR TITLE
ci(release): surface docker-unified URL in the cut-tag summary

### DIFF
--- a/.github/actions/notify-release-channel/action.yml
+++ b/.github/actions/notify-release-channel/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: ""
   slack-bot-token:
-    description: Slack bot token (pass secrets.CI_NOTIFIER_SLACK_BOT_TOKEN)
+    description: Slack bot token used to post the message
     required: true
 
 runs:

--- a/.github/actions/notify-release-channel/action.yml
+++ b/.github/actions/notify-release-channel/action.yml
@@ -1,0 +1,46 @@
+name: Notify release Slack channel
+description: >
+  Post a message to the version-derived release Slack channel. Callers must
+  check out .github/scripts and this action first (required for a local
+  composite). Slack failures belong on the caller via continue-on-error.
+
+inputs:
+  version:
+    description: Release version or tag used to derive the channel
+    required: true
+  message:
+    description: Slack mrkdwn body
+    required: true
+  emoji:
+    description: "Optional leading emoji, e.g. :rocket:"
+    required: false
+    default: ""
+  slack-bot-token:
+    description: Slack bot token (pass secrets.CI_NOTIFIER_SLACK_BOT_TOKEN)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version: "3.12"
+
+    - name: Install dependencies
+      shell: bash
+      run: pip install requests
+
+    - name: Notify release channel
+      shell: bash
+      env:
+        SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
+        PYTHONPATH: ${{ github.workspace }}/.github/scripts:${{ github.workspace }}/.github/scripts/release
+        VERSION: ${{ inputs.version }}
+        EMOJI: ${{ inputs.emoji }}
+        MESSAGE: ${{ inputs.message }}
+      run: |
+        python3 .github/scripts/release/notify_release_channel.py \
+          --version "${VERSION}" \
+          --emoji "${EMOJI}" \
+          --message "${MESSAGE}"

--- a/.github/workflows/docker-unified.yml
+++ b/.github/workflows/docker-unified.yml
@@ -94,31 +94,20 @@ jobs:
       - name: Check out release scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          sparse-checkout: .github/scripts
+          sparse-checkout: |
+            .github/scripts
+            .github/actions/notify-release-channel
           sparse-checkout-cone-mode: true
           fetch-depth: 1
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: pip install requests
-
       - name: Notify release channel of build start
         continue-on-error: true
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.CI_NOTIFIER_SLACK_BOT_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          PYTHONPATH: ${{ github.workspace }}/.github/scripts:${{ github.workspace }}/.github/scripts/release
-        run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="*Docker build started* for \`${RELEASE_TAG}\` — <${RUN_URL}|view run>"
-          python3 .github/scripts/release/notify_release_channel.py \
-            --version "${RELEASE_TAG}" \
-            --emoji ":hammer_and_wrench:" \
-            --message "${MESSAGE}"
+        uses: ./.github/actions/notify-release-channel
+        with:
+          version: ${{ github.event.release.tag_name }}
+          emoji: ":hammer_and_wrench:"
+          message: "*Docker build started* for `${{ github.event.release.tag_name }}` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|view run>"
+          slack-bot-token: ${{ secrets.CI_NOTIFIER_SLACK_BOT_TOKEN }}
 
   setup:
     runs-on: depot-ubuntu-24.04-small

--- a/.github/workflows/release-process-cut-branch.yml
+++ b/.github/workflows/release-process-cut-branch.yml
@@ -122,32 +122,33 @@ jobs:
       - name: Check out release scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          sparse-checkout: .github/scripts
+          sparse-checkout: |
+            .github/scripts
+            .github/actions/notify-release-channel
           sparse-checkout-cone-mode: true
           fetch-depth: 1
 
-      - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.12"
-
-      - name: Install dependencies
-        run: pip install requests
-
-      - name: Notify release channel of branch cut
-        continue-on-error: true
+      - name: Build Slack message
+        id: slack_message
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.CI_NOTIFIER_SLACK_BOT_TOKEN }}
           TARGET: ${{ needs.cut_branch.outputs.target }}
           COMMIT_SHA: ${{ needs.cut_branch.outputs.commit_sha }}
           BRANCH_TYPE: ${{ inputs.branch_type }}
           VERSION: ${{ inputs.version }}
-          PYTHONPATH: ${{ github.workspace }}/.github/scripts:${{ github.workspace }}/.github/scripts/release
         run: |
           SHORT_SHA="${COMMIT_SHA:0:7}"
           BRANCH_URL="${{ github.server_url }}/${{ github.repository }}/tree/${TARGET}"
-          MESSAGE="*${BRANCH_TYPE} branch cut* for \`v${VERSION}\` — <${BRANCH_URL}|${TARGET}> (commit \`${SHORT_SHA}\`)"
-          python3 .github/scripts/release/notify_release_channel.py \
-            --version "${VERSION}" \
-            --emoji ":scissors:" \
-            --message "${MESSAGE}"
+          {
+            echo "message<<EOF"
+            echo "*${BRANCH_TYPE} branch cut* for \`v${VERSION}\` — <${BRANCH_URL}|${TARGET}> (commit \`${SHORT_SHA}\`)"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Notify release channel of branch cut
+        continue-on-error: true
+        uses: ./.github/actions/notify-release-channel
+        with:
+          version: ${{ inputs.version }}
+          emoji: ":scissors:"
+          message: ${{ steps.slack_message.outputs.message }}
+          slack-bot-token: ${{ secrets.CI_NOTIFIER_SLACK_BOT_TOKEN }}

--- a/.github/workflows/release-process-cut-tag.yml
+++ b/.github/workflows/release-process-cut-tag.yml
@@ -307,3 +307,12 @@ jobs:
           echo "  ${URL}"
           echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo ""
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## Docker Unified CI
+
+          | Field      | Value        |
+          |------------|--------------|
+          | Tag        | \`${TAG}\`   |
+          | Commit SHA | \`${SHA}\`   |
+          | Run        | ${URL}       |
+          EOF


### PR DESCRIPTION
## Summary
- Cut-tag's Print Docker Unified CI URL job now writes a job summary (tag, SHA, run link) so operators do not have to open logs, matching cut-branch.
- Extract duplicated Slack notify plumbing from cut-branch and docker-unified into `.github/actions/notify-release-channel` (addresses cubic P3 on #19640) and unify `setup-python` to v6.

## Test plan
- [ ] On the next cut-tag run, confirm the Actions summary shows a clickable docker-unified URL without opening job logs
- [ ] Confirm the boxed URL is still present in the Print Docker Unified CI URL logs
- [ ] On the next cut-branch, confirm Slack still posts the scissors branch-cut message
- [ ] On the next GitHub `release` publish, confirm docker-unified still posts the hammer-and-wrench build-start message


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces the docker-unified CI run URL in the cut-tag job summary so operators no longer need to open logs. Extracts duplicated Slack notification steps into a shared composite action and upgrades `setup-python` to v6.

**Bug Fixes**
- The cut-tag summary now includes the tag, commit SHA, and clickable run link.

<sup>Written for commit 3374235ea6f93e0a0de5133e0e3bdc27c8863f4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

