### PR TITLE
refactor(ui): consolidate app/analyticsDashboard with SaaS

### DIFF
--- a/datahub-web-react/src/app/analyticsDashboard/components/Highlight.tsx
+++ b/datahub-web-react/src/app/analyticsDashboard/components/Highlight.tsx
@@ -12,23 +12,22 @@ type Props = {
 };
 
 const HighlightCard = styled(Card)`
-    width: 160px;
-    height: 160px;
     display: flex;
     align-items: center;
     justify-content: center;
     text-align: center;
     line-height: 0;
-    margin: 10px;
     box-shadow: ${(props) => props.theme.colors.shadowMd};
 `;
 
 const TitleText = styled(Typography.Text)`
     line-height: 1.4em;
     margin-top: -6px;
+    font-weight: 800;
+    font-size: 14px;
 `;
 const BodyText = styled(Typography.Text)`
-    font-size: 8px;
+    font-size: 10px;
     line-height: 1.4em;
 `;
 
@@ -47,7 +46,7 @@ export const Highlight = ({ highlight, shortenValue }: Props) => {
                 {(shortenValue && formatNumber(highlight.value)) || highlight.value}
             </Typography.Title>
             <TitleContainer>
-                <TitleText strong>{highlight.title}</TitleText>
+                <TitleText>{highlight.title}</TitleText>
             </TitleContainer>
             <BodyContainer>
                 <BodyText>{highlight.body}</BodyText>


### PR DESCRIPTION
Port the Highlight card styling from the SaaS fork so the shared analytics Highlight component no longer diverges between the two repos.

- drop the fixed 160x160 sizing and the 10px margin from HighlightCard, letting the card size to its content
- move the title's bold styling out of the antd `strong` prop into the styled component (font-weight: 800) and set an explicit 14px title / 10px body font size

The only remaining consumer in this repo is the dataset snapshot stats view, which is already identical on both sides, so this brings the rendered result in line with SaaS as well.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the Highlight card styling from the SaaS fork so the shared analytics Highlight component no longer diverges between the two repos. Drops the fixed 160x160 sizing and 10px margin so the card sizes to its content, and moves the title's bold styling into the styled component with explicit 14px title / 10px body font sizes. The only remaining consumer in this repo is the dataset snapshot stats view, which is already identical on both sides, so the rendered result now matches SaaS.

<sup>Written for commit 58c27067207d5939356446e11005ed4a54821e59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

