### PR TITLE
refactor(ui): consolidate app/analyticsDashboardV2 with SaaS

### DIFF
--- a/datahub-web-react/src/app/analyticsDashboardV2/components/TableChart.tsx
+++ b/datahub-web-react/src/app/analyticsDashboardV2/components/TableChart.tsx
@@ -1,5 +1,6 @@
 import { Button, Table } from 'antd';
-import React from 'react';
+import type { ColumnsType } from 'antd/lib/table';
+import React, { useMemo } from 'react';
 import { useHistory } from 'react-router';
 import styled from 'styled-components';
 
@@ -74,15 +75,56 @@ const TableCell = ({ cell }: TableCellProps) => {
     return <span>{cell.value}</span>;
 };
 
+const NUMERIC_VALUE_RE = /^-?\d+(\.\d+)?$/;
+
+function parseSortValue(cell: Cell): number {
+    // Strip a trailing % so percentages sort numerically. Safe to assume the
+    // result is finite because isNumericColumn gates sortability.
+    return parseFloat((cell.value ?? '').replace(/%$/, ''));
+}
+
+// A column is numeric if every non-empty cell in it parses as a number
+// (optionally followed by %). Detecting via content rather than column name
+// avoids coupling sort behavior to specific header strings.
+function isNumericColumn(rows: TableChartType['rows'], colIndex: number): boolean {
+    const nonEmptyValues = rows
+        .map((row) => row.cells?.[colIndex]?.value)
+        .filter((v): v is string => v != null && v !== '');
+    if (nonEmptyValues.length === 0) return false;
+    return nonEmptyValues.every((v) => NUMERIC_VALUE_RE.test(v.replace(/%$/, '').trim()));
+}
+
+type TableRow = Record<string, Cell>;
+
 export const TableChart = ({ chartData }: Props) => {
-    const columns = chartData.columns.map((column) => ({
-        title: column,
-        key: column,
-        dataIndex: column,
-        render: (cell) => <TableCell cell={cell} />,
-    }));
-    const tableData = chartData.rows.map(
-        (row) => row.cells?.reduce((acc, cell, i) => ({ ...acc, [chartData.columns[i]]: cell }), {}) || {},
+    const tableData: TableRow[] = chartData.rows.map(
+        (row) =>
+            row.cells?.reduce<TableRow>((acc, cell, i) => ({ ...acc, [chartData.columns[i]]: cell }), {}) ||
+            ({} as TableRow),
     );
-    return <StyledTable columns={columns} dataSource={tableData} pagination={false} size="small" />;
+
+    const { numericByIndex, defaultSortColumn } = useMemo(() => {
+        const numeric = chartData.columns.map((_, i) => isNumericColumn(chartData.rows, i));
+        // Default-sort by the first numeric column whose header is "Count" (case-insensitive).
+        const defaultSort = chartData.columns.find((c, i) => numeric[i] && /^count$/i.test(c));
+        return { numericByIndex: numeric, defaultSortColumn: defaultSort };
+    }, [chartData.rows, chartData.columns]);
+
+    const columns: ColumnsType<TableRow> = chartData.columns.map((column, i) => {
+        const isSortable = numericByIndex[i];
+        return {
+            title: column,
+            key: column,
+            dataIndex: column,
+            render: (cell: Cell) => <TableCell cell={cell} />,
+            ...(isSortable && {
+                sorter: (a: TableRow, b: TableRow) => parseSortValue(a[column]) - parseSortValue(b[column]),
+                defaultSortOrder: column === defaultSortColumn ? ('descend' as const) : undefined,
+            }),
+        };
+    });
+
+    return (
+        <StyledTable columns={columns as ColumnsType<object>} dataSource={tableData} pagination={false} size="small" />
+    );
 };

--- a/datahub-web-react/src/app/analyticsDashboardV2/utils/analyticsChartColors.ts
+++ b/datahub-web-react/src/app/analyticsDashboardV2/utils/analyticsChartColors.ts
@@ -15,7 +15,7 @@ import { findDataHubEntityColor } from '@app/analyticsDashboardV2/utils/chartCol
 /**
  * Describes the strategy used to assign a color
  */
-export interface ColorStrategy {
+interface ColorStrategy {
     type: 'semantic' | 'qualitative' | 'generated';
     source: string;
 }


### PR DESCRIPTION
Port the non-SaaS-specific analyticsDashboardV2 changes from the SaaS fork so the two repos stop diverging in this directory.

- TableChart: sort numeric columns. A column is treated as numeric when every non-empty cell parses as a number (optionally followed by %), which avoids coupling sort behaviour to specific header strings, and a "Count" column now defaults to descending
- TableChart: type the row map as `Record<string, Cell>` and the columns as `ColumnsType`, removing the implicit `any` on the cell renderer
- analyticsChartColors: drop the unused `export` on `ColorStrategy`, which is only referenced inside its own module

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the non-SaaS-specific `analyticsDashboardV2` changes from the SaaS fork so the two repos stop diverging in this directory. `TableChart` now sorts numeric columns and tightens its typing, removing implicit `any`s.

- A column is numeric when every non-empty cell parses as a number (optionally followed by `%`), so sort behavior no longer depends on specific header strings.
- A "Count" column (case-insensitive) now defaults to descending sort.
- Row maps are typed as `Record<string, Cell>` and columns as `ColumnsType`, removing the implicit `any` on the cell renderer.
- Drops the unused `export` on `ColorStrategy` in `analyticsChartColors`, which is only referenced inside its own module.

<sup>Written for commit e7b2fccd880d432fe03585c090ad2cb2cf87acb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

