### PR TITLE
refactor(ui): consolidate app/lineage with the SaaS fork

### DIFF
--- a/datahub-web-react/src/app/lineage/types.ts
+++ b/datahub-web-react/src/app/lineage/types.ts
@@ -176,7 +176,7 @@ export interface UpdatedLineages {
     [urn: string]: UpdatedLineage;
 }
 
-export interface UpdatedLineage {
+interface UpdatedLineage {
     lineageDirection: Direction;
     entitiesToAdd: Entity[];
     urnsToRemove: string[];

--- a/datahub-web-react/src/app/lineage/utils/__tests__/columnLineageUtils.test.tsx
+++ b/datahub-web-react/src/app/lineage/utils/__tests__/columnLineageUtils.test.tsx
@@ -1,0 +1,139 @@
+import { FetchedEntity } from '@app/lineage/types';
+import {
+    decodeSchemaField,
+    encodeSchemaField,
+    getFieldPathFromSchemaFieldUrn,
+    getPopulatedColumnsByUrn,
+    getSourceUrnFromSchemaFieldUrn,
+} from '@app/lineage/utils/columnLineageUtils';
+import { dataJob1, dataset1, dataset2 } from '@src/Mocks';
+
+import { FineGrainedLineage, SchemaFieldDataType } from '@types';
+
+describe('getSourceUrnFromSchemaFieldUrn', () => {
+    it('should get the source urn for a chart schemaField', () => {
+        const schemaFieldUrn = 'urn:li:schemaField:(urn:li:chart:(looker,dashboard_elements.1),goal)';
+        const sourceUrn = getSourceUrnFromSchemaFieldUrn(schemaFieldUrn);
+        expect(sourceUrn).toBe('urn:li:chart:(looker,dashboard_elements.1)');
+    });
+
+    it('should get the source urn for a dataset schemaField', () => {
+        const schemaFieldUrn =
+            'urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_created,PROD),user_name)';
+        const sourceUrn = getSourceUrnFromSchemaFieldUrn(schemaFieldUrn);
+        expect(sourceUrn).toBe('urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_created,PROD)');
+    });
+
+    it('should get the source urn for a nested schemaField', () => {
+        const schemaFieldUrn =
+            'urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_created,PROD),user.name.test)';
+        const sourceUrn = getSourceUrnFromSchemaFieldUrn(schemaFieldUrn);
+        expect(sourceUrn).toBe('urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_created,PROD)');
+    });
+});
+
+describe('getFieldPathFromSchemaFieldUrn', () => {
+    it('should get the fieldPath from a chart schemaField urn', () => {
+        const schemaFieldUrn = 'urn:li:schemaField:(urn:li:chart:(looker,dashboard_elements.1),goal)';
+        const sourceUrn = getFieldPathFromSchemaFieldUrn(schemaFieldUrn);
+        expect(sourceUrn).toBe('goal');
+    });
+
+    it('should get the fieldPath for a dataset schemaField', () => {
+        const schemaFieldUrn =
+            'urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_created,PROD),user_name)';
+        const sourceUrn = getFieldPathFromSchemaFieldUrn(schemaFieldUrn);
+        expect(sourceUrn).toBe('user_name');
+    });
+
+    it('should get the fieldPath for a nested schemaField', () => {
+        const schemaFieldUrn =
+            'urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:hive,fct_cypress_users_created,PROD),user.name.test)';
+        const sourceUrn = getFieldPathFromSchemaFieldUrn(schemaFieldUrn);
+        expect(sourceUrn).toBe('user.name.test');
+    });
+});
+
+describe('decodeSchemaField', () => {
+    it('should decode a schemaField path when it has encoded reserved characters', () => {
+        const decodedSchemaField = decodeSchemaField('Test%2C test%2C test %28and test%29');
+        expect(decodedSchemaField).toBe('Test, test, test (and test)');
+    });
+
+    it('should return a regular schemaField path when it was not encoded', () => {
+        const schemaField = 'user.name';
+        const decodedSchemaField = decodeSchemaField(schemaField);
+        expect(decodedSchemaField).toBe(schemaField);
+    });
+});
+
+describe('encodeSchemaField', () => {
+    it('should encode a schemaField path when it has encoded reserved characters', () => {
+        const encodedSchemaField = encodeSchemaField('Test, test, test (and test)');
+        expect(encodedSchemaField).toBe('Test%2C test%2C test %28and test%29');
+    });
+
+    it('should return a regular schemaField path when it does not have reserved characters', () => {
+        const schemaField = 'user.name';
+        const encodedSchemaField = encodeSchemaField(schemaField);
+        expect(encodedSchemaField).toBe(schemaField);
+    });
+
+    it('should encode a decoded schemaField that we generate', () => {
+        const schemaField = 'Adults, men (% of pop)';
+        const encodedSchemaField = encodeSchemaField(schemaField);
+        const decodedSchemaField = decodeSchemaField(encodedSchemaField);
+        expect(encodedSchemaField).toBe('Adults%2C men %28% of pop%29');
+        expect(decodedSchemaField).toBe(schemaField);
+    });
+});
+
+describe('getPopulatedColumnsByUrn', () => {
+    it('should update columns by urn with data job fine grained data so that the data job appears to have the upstream and downstream columns', () => {
+        const dataJobWithCLL = {
+            ...dataJob1,
+            name: '',
+            fineGrainedLineages: [
+                {
+                    upstreams: [{ urn: dataset1.urn, path: 'test1' }],
+                    downstreams: [{ urn: dataset2.urn, path: 'test2' }],
+                },
+                {
+                    upstreams: [{ urn: dataset1.urn, path: 'test3' }],
+                    downstreams: [{ urn: dataset2.urn, path: 'test4' }],
+                },
+            ] as FineGrainedLineage[],
+        };
+        const fetchedEntities = new Map([[dataJobWithCLL.urn, dataJobWithCLL as FetchedEntity]]);
+        const columnsByUrn = getPopulatedColumnsByUrn({}, fetchedEntities);
+
+        expect(columnsByUrn).toMatchObject({
+            [dataJobWithCLL.urn]: [
+                {
+                    fieldPath: 'test1',
+                    nullable: false,
+                    recursive: false,
+                    type: SchemaFieldDataType.String,
+                },
+                {
+                    fieldPath: 'test2',
+                    nullable: false,
+                    recursive: false,
+                    type: SchemaFieldDataType.String,
+                },
+                {
+                    fieldPath: 'test3',
+                    nullable: false,
+                    recursive: false,
+                    type: SchemaFieldDataType.String,
+                },
+                {
+                    fieldPath: 'test4',
+                    nullable: false,
+                    recursive: false,
+                    type: SchemaFieldDataType.String,
+                },
+            ],
+        });
+    });
+});

--- a/datahub-web-react/src/app/lineage/utils/columnLineageUtils.ts
+++ b/datahub-web-react/src/app/lineage/utils/columnLineageUtils.ts
@@ -70,7 +70,7 @@ export function convertInputFieldsToSchemaFields(inputFields?: InputFields) {
  * pointing to and to know where to draw column arrows in and out of the entity. DataJobs won't show columns
  * underneath them, but we need this populated for validating that this column "exists" on the entity.
  */
-function getPopulatedColumnsByUrn(
+export function getPopulatedColumnsByUrn(
     columnsByUrn: Record<string, SchemaField[]>,
     fetchedEntities: Map<string, FetchedEntity>,
 ) {

--- a/datahub-web-react/src/app/lineage/utils/navigateToLineageUrl.ts
+++ b/datahub-web-react/src/app/lineage/utils/navigateToLineageUrl.ts
@@ -12,6 +12,7 @@ export const navigateToLineageUrl = ({
     showColumns,
     startTimeMillis,
     endTimeMillis,
+    showAllTimeLineage,
 }: {
     location: {
         search: string;
@@ -23,6 +24,7 @@ export const navigateToLineageUrl = ({
     showColumns?: boolean;
     startTimeMillis?: number;
     endTimeMillis?: number;
+    showAllTimeLineage?: boolean;
 }) => {
     const parsedSearch = QueryString.parse(location.search, { arrayFormat: 'comma' });
     let newSearch: any = {
@@ -30,6 +32,7 @@ export const navigateToLineageUrl = ({
         is_lineage_mode: isLineageMode,
         start_time_millis: startTimeMillis || null,
         end_time_millis: endTimeMillis || null,
+        show_all_time_lineage: showAllTimeLineage || null,
     };
     if (isHideSiblingMode !== undefined) {
         newSearch = {


### PR DESCRIPTION
Upstream the non-SaaS-specific edits that had accumulated in app/lineage, so the regular auto-merge has less to conflict over.

- navigateToLineageUrl: forward showAllTimeLineage as the show_all_time_lineage query param. The param was already read by useGetLineageTimeParams and written by LineageTabTimeSelector and LineageEmptyGraphNudge, but navigateToLineageUrl dropped it.
- types: stop exporting UpdatedLineage, which has no consumer outside types.ts.
- columnLineageUtils: export getPopulatedColumnsByUrn for the tests below.
- add unit tests for columnLineageUtils.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upstreams the non-SaaS-specific `app/lineage` changes into the OSS codebase so the auto-merge with the SaaS fork has less to conflict over.

- `navigateToLineageUrl` now forwards `showAllTimeLineage` as `show_all_time_lineage`; it previously dropped the param.
- Stops exporting `UpdatedLineage` from `types.ts` since nothing outside the file uses it.
- Exports `getPopulatedColumnsByUrn` and adds unit tests for `columnLineageUtils`.
- `useGetDefaultLineageStartTimeMillis` is left unchanged because its SaaS version reads a field the OSS GraphQL schema doesn't declare.

<sup>Written for commit 24dd929303815c3eccd4592e686b71f9ba16b55b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

