### PR TITLE
fix(ingest/documents): keep pages retryable when inline embedding fails

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/datahub_documents/datahub_documents_source.py
@@ -518,12 +518,21 @@ class DataHubDocumentsSource(StatefulIngestionSourceBase):
             # semanticText aspect, so fetch it.
             raw_contents = aspect_dict.get("contents")
             if raw_contents is None:
-                # Partial aspect with no contents: skip silently (mirroring batch mode)
-                # rather than stamping a skip marker from content we could not read.
-                logger.debug(
-                    f"documentInfo event for {entity_urn} has null contents, skipping"
-                )
-                return
+                # Partial event payload with no contents: fall back to fetching the full
+                # aspect (mirroring the semanticText branch) so a document whose only
+                # event was partial is not silently dropped until some later event.
+                info_dict = self._fetch_document_info_dict(entity_urn)
+                raw_contents = info_dict.get("contents") if info_dict else None
+                if info_dict is None or raw_contents is None:
+                    # Genuinely unreadable body: skip without stamping a skip marker from
+                    # content we could not read.
+                    logger.debug(
+                        f"documentInfo event for {entity_urn} has null contents and no "
+                        f"readable fallback, skipping"
+                    )
+                    return
+                # Downstream source-type filtering reads from the documentInfo shape.
+                aspect_dict = info_dict
             contents = dict(raw_contents)
             contents["semanticText"] = self._fetch_semantic_text(entity_urn)
 

--- a/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/notion/notion_source.py
@@ -2195,10 +2195,14 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
             if self.chunking_source.report.num_documents_limit_reached:
                 self.report.num_documents_limit_reached = True
                 raise
+            # No semanticContent was written: return before the report accounting and the
+            # (stateful) _update_document_state below. Recording state would checkpoint the
+            # page as done and permanently skip it next run; leaving it unrecorded retries it.
             short_error = str(e).split("\n")[0][:150]
             logger.warning(
-                f"Failed to generate embeddings for {page_id}: {short_error}"
+                f"Embeddings deferred for {page_id}, will retry next run: {short_error}"
             )
+            return
         except Exception as e:
             short_error = str(e).split("\n")[0][:150]
             is_credential_error = any(
@@ -2215,12 +2219,16 @@ class NotionSource(StatefulIngestionSourceBase, TestableSource):
             if is_credential_error:
                 logger.error(
                     f"EMBEDDING CREDENTIAL ERROR for {page_id}: {short_error}\n"
-                    f"Document ingested without embeddings. Fix AWS/Cohere credentials."
+                    f"Document left without embeddings; will retry next run after "
+                    f"credentials are fixed."
                 )
             else:
                 logger.warning(
-                    f"Failed to generate embeddings for {page_id}: {short_error}"
+                    f"Embeddings deferred for {page_id}, will retry next run: {short_error}"
                 )
+            # Same rationale as the RuntimeError branch: return before state is recorded so
+            # the page is retried next run instead of being checkpointed as done.
+            return
 
         # Update report
         file_type = metadata.get("filetype", "unknown")

--- a/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_source.py
+++ b/metadata-ingestion/tests/unit/ingestion/source/notion/test_notion_source.py
@@ -11,6 +11,9 @@ from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.notion.notion_config import NotionSourceConfig
 from datahub.ingestion.source.notion.notion_report import NotionSourceReport
 from datahub.ingestion.source.notion.notion_source import NotionSource
+from datahub.ingestion.source.unstructured.chunking_source import (
+    SkipMarkerReadError,
+)
 from datahub.ingestion.workunit_processors.auto_stale_entity_removal import (
     AutoStaleEntityRemovalProcessor,
 )
@@ -1077,14 +1080,11 @@ def test_icon_dispatcher_unknown_types_preserves_known_types():
     assert emoji_result.emoji == "📝"
 
 
-def test_skip_marker_read_error_leaves_document_retryable(notion_source):
-    """A SkipMarkerReadError from the chunking sub-source must not record document
-    state (or count the document processed): state would permanently drop the skip
-    marker; returning early leaves the document retryable next run."""
-    from datahub.ingestion.source.unstructured.chunking_source import (
-        SkipMarkerReadError,
-    )
-
+def _document_entity_test_setup(notion_source, side_effect):
+    """Wire a mocked document builder + chunking source whose inline processing raises
+    side_effect, with the stateful gate enabled so _update_document_state WOULD be
+    reached on the swallow-and-continue path (without this, assert_not_called on it is
+    vacuous)."""
     data = {
         "elements": [{"type": "NarrativeText", "text": "hello", "metadata": {}}],
         "metadata": {
@@ -1101,13 +1101,19 @@ def test_skip_marker_read_error_leaves_document_retryable(notion_source):
         "hello"
     )
     notion_source.chunking_source = MagicMock()
-    notion_source.chunking_source.process_elements_inline.side_effect = (
-        SkipMarkerReadError("read failed")
-    )
+    notion_source.chunking_source.process_elements_inline.side_effect = side_effect
     notion_source.chunking_source.report.num_documents_limit_reached = False
-    # Enable the stateful gate so _update_document_state WOULD be reached on the
-    # swallow-and-continue path — without this the assertion below is vacuous.
     notion_source.config.stateful_ingestion = MagicMock(enabled=True)
+    return data
+
+
+def test_skip_marker_read_error_leaves_document_retryable(notion_source):
+    """A SkipMarkerReadError from the chunking sub-source must not record document
+    state (or count the document processed): state would permanently drop the skip
+    marker; returning early leaves the document retryable next run."""
+    data = _document_entity_test_setup(
+        notion_source, SkipMarkerReadError("read failed")
+    )
 
     with patch.object(notion_source, "_update_document_state") as update_state:
         list(notion_source._create_document_entity(data))
@@ -1115,5 +1121,23 @@ def test_skip_marker_read_error_leaves_document_retryable(notion_source):
     # Discriminates the dedicated SkipMarkerReadError handler: if it were removed,
     # the generic RuntimeError handler swallows the error and execution falls
     # through to report accounting and the (enabled) state update.
+    update_state.assert_not_called()
+    assert notion_source.report.num_files_processed == 0
+
+
+def test_embedding_failure_leaves_document_retryable(notion_source):
+    """An inline embedding failure (provider error or zero-vector response surfaces as a
+    RuntimeError) must not record document state or count the page as processed: no
+    semanticContent was written, and checkpointing would permanently skip the unchanged
+    page instead of retrying it."""
+    data = _document_entity_test_setup(
+        notion_source, RuntimeError("provider returned no vectors")
+    )
+
+    with patch.object(notion_source, "_update_document_state") as update_state:
+        list(notion_source._create_document_entity(data))
+
+    # The non-limit RuntimeError handler must return: without the return, execution falls
+    # through to report accounting and the (enabled) state update, checkpointing the page.
     update_state.assert_not_called()
     assert notion_source.report.num_files_processed == 0

--- a/metadata-ingestion/tests/unit/test_datahub_documents_source.py
+++ b/metadata-ingestion/tests/unit/test_datahub_documents_source.py
@@ -2459,6 +2459,61 @@ class TestPartialEntityHandling:
             workunits = list(source._process_single_event(event))
             assert len(workunits) == 0
 
+    def test_document_info_event_null_contents_falls_back_to_fetch(
+        self, ctx, config, mock_graph
+    ):
+        """A partial documentInfo event (null contents) falls back to fetching the full
+        aspect instead of dropping the event, so a document whose only event carried a
+        partial payload is still embedded."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            event: dict[str, Any] = {
+                "entityUrn": "urn:li:document:partial-event",
+                "aspectName": "documentInfo",
+                "aspect": json.dumps({"contents": None}),
+            }
+
+            with (
+                patch.object(
+                    source,
+                    "_fetch_document_info_dict",
+                    return_value={
+                        "source": {"sourceType": "NATIVE"},
+                        "contents": {"text": "full body from fetch"},
+                    },
+                ) as mock_fetch,
+                patch.object(source, "_fetch_semantic_text", return_value=None),
+                patch.object(
+                    source, "_process_document_with_throttle", return_value=iter([])
+                ) as mock_process,
+            ):
+                list(source._process_single_event(event))
+
+            mock_fetch.assert_called_once()
+            mock_process.assert_called_once()
+            doc = mock_process.call_args[0][0]
+            assert doc["text"] == "full body from fetch"
+
+    def test_document_info_event_null_contents_and_unreadable_fallback_skips(
+        self, ctx, config, mock_graph
+    ):
+        """When the fetch fallback is also unreadable, the event is skipped without
+        stamping a skip marker from content that was never readable."""
+        with mock_graph:
+            source = DataHubDocumentsSource(ctx, config)
+
+            event: dict[str, Any] = {
+                "entityUrn": "urn:li:document:unreadable",
+                "aspectName": "documentInfo",
+                "aspect": json.dumps({"contents": None}),
+            }
+
+            with patch.object(source, "_fetch_document_info_dict", return_value=None):
+                workunits = list(source._process_single_event(event))
+
+        assert workunits == []
+
     def test_fetch_documents_mixed_null_and_valid(self, ctx, config, mock_graph):
         """Test batch mode with a mix of null-info, null-contents, and valid entities."""
         with mock_graph:


### PR DESCRIPTION
## Problem

Two ways a document can be permanently left without `semanticContent`:

1. **Notion inline embedding.** When embedding fails (provider error, or the provider returns no vectors), `chunking_source.process_elements_inline` raises. Notion's `_create_document_entity` caught the error, logged "ingested without embeddings", then fell through to `_update_document_state` — recording the content hash as if the page were done. Because the hash is unchanged on the next run, `_should_process_document` skips the page forever, so one transient embed error permanently excludes it from semantic search until the content changes or a force-reprocess is run. This is the same checkpoint-poisoning class that #19466 fixed for the `datahub-documents` source; that fix did not touch Notion's separate `document_state`.

2. **datahub-documents event mode.** A `documentInfo` event whose partial payload had no `contents` was skipped silently, so a document whose only event was partial stayed unembedded until some later event.

## Fix

- `notion_source`: the non-limit `RuntimeError` handler and the generic `Exception` handler now `return` before report accounting and `_update_document_state`, leaving the page retryable next run. The `max_documents` `RuntimeError` path is unchanged (still re-raises).
- `datahub_documents_source` (event mode): on a partial `documentInfo` payload, fetch the full aspect (mirroring the existing `semanticText` branch) before deciding to skip.

Tests: `test_embedding_failure_leaves_document_retryable` (Notion) and two event-mode fallback tests for `datahub-documents`.

## Scope

An earlier revision of this PR also refactored Confluence and introduced an `EmbeddingFailedError(RuntimeError)` subclass. Both were dropped after review:

- **Confluence** has no incremental content-hash gate — `_should_process_document` / `_update_document_state` don't exist there. Every run re-enumerates all pages and unconditionally rebuilds the document, so a transient embed failure was already retried next run. The refactor was unnecessary, and its early-return skipped report accounting entirely (a reporting hole).
- The **typed exception** was both more code and under-inclusive: it only wrapped the provider-generation block, so chunking / semantic-content-construction failures would still fall through and poison Notion state. Returning from Notion's existing handlers covers every no-output failure with a smaller diff.

Follow-up (out of scope): the event-mode fallback fetch, if it fails transiently, still returns silently without suppressing the offset commit — worth distinguishing "aspect absent" from "read failed" later.
