### PR TITLE
fix(i18n): show custom ownership type names verbatim instead of appending an English "s"

### DIFF
--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/Ownership/__tests__/ownershipUtils.test.ts
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/Ownership/__tests__/ownershipUtils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getOwnershipTypeName } from '@app/entityV2/shared/containers/profile/sidebar/Ownership/ownershipUtils';
+
+import { EntityType, OwnershipTypeEntity } from '@types';
+
+// Echo interpolation so we can assert the pluralized vs. verbatim branch deterministically.
+vi.mock('i18next', () => ({
+    default: {
+        t: (key: string, opts?: { name?: string }) => {
+            if (key.endsWith('pluralName')) return `${opts?.name}s`;
+            if (key.endsWith('otherName')) return 'Other';
+            return key;
+        },
+    },
+}));
+
+const makeOwnershipType = (urn: string, name?: string | null): OwnershipTypeEntity =>
+    ({
+        urn,
+        type: EntityType.CustomOwnershipType,
+        info: name === undefined ? undefined : { name },
+    }) as OwnershipTypeEntity;
+
+describe('getOwnershipTypeName', () => {
+    it('shows custom ownership type names verbatim, without pluralization', () => {
+        // A French custom type must not gain an English "s" (the bug this fixes).
+        expect(getOwnershipTypeName(makeOwnershipType('urn:li:ownershipType:custom', 'Responsable métier'))).toEqual(
+            'Responsable métier',
+        );
+    });
+
+    it('pluralizes the built-in system ownership types', () => {
+        expect(
+            getOwnershipTypeName(
+                makeOwnershipType('urn:li:ownershipType:__system__technical_owner', 'Technical Owner'),
+            ),
+        ).toEqual('Technical Owners');
+    });
+
+    it('falls back to "Other" when there is no name', () => {
+        expect(getOwnershipTypeName(makeOwnershipType('urn:li:ownershipType:custom', null))).toEqual('Other');
+        expect(getOwnershipTypeName(null)).toEqual('Other');
+    });
+});

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/Ownership/ownershipUtils.ts
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/Ownership/ownershipUtils.ts
@@ -2,6 +2,11 @@ import i18next from 'i18next';
 
 import { OwnershipType, OwnershipTypeEntity } from '@types';
 
+// Built-in ownership types carry URNs under this prefix (e.g. __system__technical_owner).
+// Their English display names pluralize with a naive "s"; custom types do not — especially
+// in non-English languages where plural rules differ — so custom type names are shown verbatim.
+const SYSTEM_OWNERSHIP_TYPE_URN_PREFIX = 'urn:li:ownershipType:__system__';
+
 /**
  * A mapping from OwnershipType to it's display name & description. In the future,
  * we intend to make this configurable.
@@ -55,11 +60,13 @@ export const getNameFromType = (type: OwnershipType) => {
 };
 
 export function getOwnershipTypeName(ownershipType?: OwnershipTypeEntity | null) {
-    return (
-        (ownershipType?.info?.name &&
-            i18next.t('entity.shared.containers:sidebar.ownership.type.pluralName', {
-                name: ownershipType?.info?.name,
-            })) ||
-        i18next.t('entity.shared.containers:sidebar.ownership.type.otherName')
-    );
+    const name = ownershipType?.info?.name;
+    if (!name) {
+        return i18next.t('entity.shared.containers:sidebar.ownership.type.otherName');
+    }
+    // Only the built-in system types get a pluralized label; custom types are shown as-is.
+    if (ownershipType?.urn?.startsWith(SYSTEM_OWNERSHIP_TYPE_URN_PREFIX)) {
+        return i18next.t('entity.shared.containers:sidebar.ownership.type.pluralName', { name });
+    }
+    return name;
 }


### PR DESCRIPTION
## Summary

`getOwnershipTypeName` pluralized **every** ownership type name by interpolating it into the i18next key `sidebar.ownership.type.pluralName` = `"{{name}}s"` — i.e. it blindly appended an English `"s"`, in every locale.

For **custom** ownership types, the display name is free-text entered by a user (via the Manage Ownership UI) and is frequently non-English, so appending `"s"` produced incorrect plurals. It also affected ordering: the pluralized name is used as both the map key and the alphabetical sort key for the owner sidebar sections, so the appended letter shifted the grouping order.

## What changed

Only the built-in **system** ownership types (URNs under `urn:li:ownershipType:__system__…`: Technical Owner, Business Owner, Data Steward, None) are pluralized now. **Custom** ownership types are rendered exactly as entered. This mirrors the change-history popover, which already shows custom values verbatim.

Single behavioral change in `getOwnershipTypeName` (`ownershipUtils.ts`), plus a focused unit test.

### Before → After (custom ownership type named `Responsable métier`, French UI)

| | Before | After |
|---|---|---|
| Sidebar group header | `Responsable métiers` ❌ | `Responsable métier` ✅ |
| Built-in Technical Owner | `Technical Owners` | `Technical Owners` (unchanged) |

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added (`ownershipUtils.test.ts`: custom → verbatim, system → pluralized, empty → "Other")
- [ ] Docs — n/a
- [ ] Breaking change — n/a (display-only)

## Testing

`yarn test ownershipUtils.test.ts` (3/3), sibling `SidebarOwnerSection.test.tsx` (3/3), eslint clean, `format-check` clean, repo-wide `type-check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops appending an English "s" to custom ownership type names, which produced wrong plurals for non-English names and shifted the sidebar section ordering. Only built-in system ownership types are pluralized now; custom names display exactly as entered.

- Changes `getOwnershipTypeName` to pluralize only URNs under `urn:li:ownershipType:__system__`.
- Adds unit tests covering custom, system, and empty-name cases.

<sup>Written for commit feeffd3f30cb77acf8fdc364e4e0082f7462f135. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

