### PR TITLE
fix(ingestion/looker): default transport_options.headers to empty dict

### DIFF
--- a/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/looker/looker_lib_wrapper.py
@@ -44,7 +44,10 @@ class LookerQueryResponseFormat(Enum):
 
 class TransportOptionsConfig(ConfigModel):
     timeout: int
-    headers: MutableMapping[str, str]
+    # Previously required-without-default, so a recipe setting only
+    # transport_options.timeout failed validation ("transport_options.headers
+    # Field required") and aborted the ingestion run before any dashboard was fetched.
+    headers: MutableMapping[str, str] = Field(default_factory=dict)
 
     def get_transport_options(self) -> TransportOptions:
         return TransportOptions(timeout=self.timeout, headers=self.headers)

--- a/metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py
+++ b/metadata-ingestion/tests/unit/looker/test_looker_lib_wrapper.py
@@ -8,6 +8,7 @@ from requests.adapters import HTTPAdapter
 from datahub.ingestion.source.looker.looker_lib_wrapper import (
     LookerAPI,
     LookerAPIConfig,
+    TransportOptionsConfig,
     _DataHubLookerApiSettings,
 )
 
@@ -114,3 +115,16 @@ def test_http_adapter_pool_size_matches_max_threads():
         pool_maxsize=30,
     )
     assert mock_session.mount.call_count == 2
+
+
+def test_transport_options_headers_defaults_to_empty():
+    """Regression guard: headers was required-without-default, so a recipe
+    setting `transport_options: { timeout: 300 }` failed validation with
+    "transport_options.headers Field required" and aborted the ingestion run.
+    """
+    opts = TransportOptionsConfig(timeout=300)
+    assert opts.headers == {}
+    # TransportOptions is a TypedDict (dict subclass), so key access.
+    transport = opts.get_transport_options()
+    assert transport["timeout"] == 300
+    assert transport["headers"] == {}


### PR DESCRIPTION
## Summary

`TransportOptionsConfig.headers` was required-without-default, so a recipe that set `transport_options: { timeout: 300 }` failed pydantic validation (`transport_options.headers Field required`) and aborted the ingestion run before any dashboard was fetched. Default `headers` to an empty dict so the field is optional, matching the `Optional` intent of `transport_options` itself.

## Test plan
- [x] New unit test `test_transport_options_headers_defaults_to_empty` asserting `TransportOptionsConfig(timeout=300)` constructs without error, `headers` defaults to `{}`, and `get_transport_options()` round-trips correctly
- [x] `./gradlew :metadata-ingestion:lintFix`
- [x] `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/looker/test_looker_lib_wrapper.py` — 5 passed

## Checklist
- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added/updated
- [ ] Docs added/updated (n/a — no user-facing behavior change beyond a previously-hard-failing config now working)
- [ ] Breaking changes (none)