### PR TITLE
refactor(ui): consolidate app/recommendations

### DIFF
--- a/datahub-web-react/src/app/entityV2/Entity.tsx
+++ b/datahub-web-react/src/app/entityV2/Entity.tsx
@@ -3,7 +3,6 @@ import { QueryHookOptions, QueryResult } from '@apollo/client';
 import { GenericEntityProperties } from '@app/entity/shared/types';
 import { EntitySidebarSection, EntitySidebarTab } from '@app/entityV2/shared/types';
 import { FetchedEntity } from '@app/lineage/types';
-import { AttributionDetails } from '@app/sharedV2/propagation/types';
 
 import { EntityType, Exact, FeatureFlagsConfig, SearchResult } from '@types';
 
@@ -120,10 +119,6 @@ export interface EntityMenuActions {
     onEdit?: () => void;
 }
 
-export interface PreviewContext {
-    propagationDetails?: AttributionDetails;
-}
-
 /**
  * Base interface used for authoring DataHub Entities on the client side.
  *
@@ -183,12 +178,7 @@ export interface Entity<T> {
      *
      * TODO: Explore using getGenericEntityProperties for rendering previews.
      */
-    renderPreview: (
-        type: PreviewType,
-        data: T,
-        actions?: EntityMenuActions,
-        extraContext?: PreviewContext,
-    ) => JSX.Element;
+    renderPreview: (type: PreviewType, data: T, actions?: EntityMenuActions) => JSX.Element;
 
     /**
      * Renders a search result

--- a/datahub-web-react/src/app/entityV2/EntityRegistry.tsx
+++ b/datahub-web-react/src/app/entityV2/EntityRegistry.tsx
@@ -3,15 +3,8 @@ import React from 'react';
 
 import { GenericEntityProperties } from '@app/entity/shared/types';
 import DefaultEntity from '@app/entityV2/DefaultEntity';
-import {
-    Entity,
-    EntityCapabilityType,
-    EntityMenuActions,
-    IconStyleType,
-    PreviewContext as PreviewContextProps,
-    PreviewType,
-} from '@app/entityV2/Entity';
-import PreviewContext from '@app/entityV2/shared/PreviewContext';
+import { Entity, EntityCapabilityType, EntityMenuActions, IconStyleType, PreviewType } from '@app/entityV2/Entity';
+import PreviewContext, { PreviewContextProps } from '@app/entityV2/shared/PreviewContext';
 import { GLOSSARY_ENTITY_TYPES } from '@app/entityV2/shared/constants';
 import { EntitySidebarSection, EntitySidebarTab } from '@app/entityV2/shared/types';
 import { dictToQueryStringParams, getFineGrainedLineageWithSiblings, urlEncodeUrn } from '@app/entityV2/shared/utils';
@@ -143,20 +136,20 @@ export default class EntityRegistry {
         extraContext?: PreviewContextProps,
     ): JSX.Element {
         const entity = validatedGet(entityType, this.entityTypeToEntity, DefaultEntity);
-        const genericEntityData = entity.getGenericEntityProperties(data);
+        const previewData = entity.getGenericEntityProperties(data);
         return (
-            <PreviewContext.Provider value={genericEntityData}>
-                {entity.renderPreview(type, data, actions, extraContext)}
+            <PreviewContext.Provider value={{ previewData, previewType: type, ...extraContext }}>
+                {entity.renderPreview(type, data, actions)}
             </PreviewContext.Provider>
         );
     }
 
     renderSearchResult(type: EntityType, searchResult: SearchResult): JSX.Element {
         const entity = validatedGet(type, this.entityTypeToEntity, DefaultEntity);
-        const genericEntityData = entity.getGenericEntityProperties(searchResult.entity);
+        const previewData = entity.getGenericEntityProperties(searchResult.entity);
         return (
             <SearchResultProvider searchResult={searchResult}>
-                <PreviewContext.Provider value={genericEntityData}>
+                <PreviewContext.Provider value={{ previewData }}>
                     {entity.renderSearch(searchResult)}
                 </PreviewContext.Provider>
             </SearchResultProvider>

--- a/datahub-web-react/src/app/entityV2/glossaryTerm/GlossaryTermEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryTerm/GlossaryTermEntity.tsx
@@ -7,7 +7,7 @@ import i18next from 'i18next';
 import * as React from 'react';
 
 import { GenericEntityProperties } from '@app/entity/shared/types';
-import { Entity, EntityCapabilityType, IconStyleType, PreviewContext, PreviewType } from '@app/entityV2/Entity';
+import { Entity, EntityCapabilityType, IconStyleType, PreviewType } from '@app/entityV2/Entity';
 import { Preview } from '@app/entityV2/glossaryTerm/preview/Preview';
 import GlossaryRelatedEntity from '@app/entityV2/glossaryTerm/profile/GlossaryRelatedEntity';
 import GlossayRelatedTerms from '@app/entityV2/glossaryTerm/profile/GlossaryRelatedTerms';
@@ -211,10 +211,10 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
     };
 
     renderSearch = (result: SearchResult) => {
-        return this.renderPreview(PreviewType.SEARCH, result.entity as GlossaryTerm, undefined, undefined);
+        return this.renderPreview(PreviewType.SEARCH, result.entity as GlossaryTerm);
     };
 
-    renderPreview = (previewType: PreviewType, data: GlossaryTerm, _actions, extraContext?: PreviewContext) => {
+    renderPreview = (previewType: PreviewType, data: GlossaryTerm) => {
         const genericProperties = this.getGenericEntityProperties(data);
         return (
             <Preview
@@ -228,7 +228,6 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
                 deprecation={data?.deprecation}
                 domain={data.domain?.domain}
                 headerDropdownItems={headerDropdownItems}
-                propagationDetails={extraContext?.propagationDetails}
             />
         );
     };

--- a/datahub-web-react/src/app/entityV2/glossaryTerm/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryTerm/preview/Preview.tsx
@@ -8,7 +8,6 @@ import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuA
 import UrlButton from '@app/entityV2/shared/UrlButton';
 import GlossaryEntityIcon from '@app/glossaryV2/GlossaryEntityIcon';
 import DefaultPreviewCard from '@app/previewV2/DefaultPreviewCard';
-import { AttributionDetails } from '@app/sharedV2/propagation/types';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 import { resolveRuntimePath } from '@utils/runtimeBasePath';
 
@@ -25,7 +24,6 @@ export const Preview = ({
     previewType,
     domain,
     headerDropdownItems,
-    propagationDetails,
 }: {
     urn: string;
     data: GenericEntityProperties | null;
@@ -37,7 +35,6 @@ export const Preview = ({
     previewType: PreviewType;
     domain?: Domain | undefined;
     headerDropdownItems?: Set<EntityMenuItems>;
-    propagationDetails?: AttributionDetails;
 }): JSX.Element => {
     const { t } = useTranslation('entity.types');
     const entityRegistry = useEntityRegistry();
@@ -72,7 +69,6 @@ export const Preview = ({
                 </UrlButton>
             }
             headerDropdownItems={headerDropdownItems}
-            propagationDetails={propagationDetails}
         />
     );
 };

--- a/datahub-web-react/src/app/entityV2/shared/PreviewContext.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/PreviewContext.tsx
@@ -1,8 +1,20 @@
 import React from 'react';
 
 import { GenericEntityProperties } from '@app/entity/shared/types';
+import { PreviewType } from '@app/entityV2/Entity';
+import { AttributionDetails } from '@app/sharedV2/propagation/types';
 
-const PreviewContext = React.createContext<GenericEntityProperties | null>(null);
+type PreviewContextType = {
+    previewData: GenericEntityProperties | null;
+    previewType?: PreviewType;
+    propagationDetails?: AttributionDetails;
+};
+
+export type PreviewContextProps = Omit<PreviewContextType, 'previewData' | 'previewType'>;
+
+const PreviewContext = React.createContext<PreviewContextType>({
+    previewData: null,
+});
 export default PreviewContext;
 
 export function usePreviewData() {

--- a/datahub-web-react/src/app/entityV2/tag/Tag.tsx
+++ b/datahub-web-react/src/app/entityV2/tag/Tag.tsx
@@ -2,7 +2,7 @@ import { Tag as TagIcon } from '@phosphor-icons/react/dist/csr/Tag';
 import i18next from 'i18next';
 import * as React from 'react';
 
-import { Entity, EntityCapabilityType, IconStyleType, PreviewContext, PreviewType } from '@app/entityV2/Entity';
+import { Entity, EntityCapabilityType, IconStyleType, PreviewType } from '@app/entityV2/Entity';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
 import { getDataForEntityType } from '@app/entityV2/shared/containers/profile/utils';
 import { urlEncodeUrn } from '@app/entityV2/shared/utils';
@@ -46,7 +46,7 @@ export class TagEntity implements Entity<Tag> {
 
     renderProfile: (urn: string) => JSX.Element = (urn) => <TagProfile urn={urn} />;
 
-    renderPreview = (previewType: PreviewType, data: Tag, _actions, extraContext?: PreviewContext) => {
+    renderPreview = (previewType: PreviewType, data: Tag) => {
         const genericProperties = this.getGenericEntityProperties(data);
         return (
             <DefaultPreviewCard
@@ -60,13 +60,12 @@ export class TagEntity implements Entity<Tag> {
                 typeIcon={this.icon(14, IconStyleType.ACCENT)}
                 previewType={previewType}
                 deprecation={data.deprecation}
-                propagationDetails={extraContext?.propagationDetails}
             />
         );
     };
 
     renderSearch = (result: SearchResult) => {
-        return this.renderPreview(PreviewType.SEARCH, result.entity as Tag, undefined, undefined);
+        return this.renderPreview(PreviewType.SEARCH, result.entity as Tag);
     };
 
     displayName = (data: Tag) => {

--- a/datahub-web-react/src/app/entityV2/user/User.tsx
+++ b/datahub-web-react/src/app/entityV2/user/User.tsx
@@ -3,7 +3,7 @@ import i18next from 'i18next';
 import * as React from 'react';
 
 import { INGESTION_ACTOR_URN } from '@app/entity/shared/constants';
-import { Entity, EntityCapabilityType, IconStyleType, PreviewContext, PreviewType } from '@app/entityV2/Entity';
+import { Entity, EntityCapabilityType, IconStyleType, PreviewType } from '@app/entityV2/Entity';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
 import { getDataForEntityType } from '@app/entityV2/shared/containers/profile/utils';
 import UserProfile from '@app/entityV2/user/UserProfile';
@@ -46,17 +46,16 @@ export class UserEntity implements Entity<CorpUser> {
 
     renderProfile = (urn: string) => <UserProfile urn={urn} />;
 
-    renderPreview = (_: PreviewType, data: CorpUser, _actions, extraContext?: PreviewContext) => (
+    renderPreview = (_: PreviewType, data: CorpUser) => (
         <Preview
             urn={data.urn}
             name={this.displayName(data)}
             title={data.editableProperties?.title || data.info?.title || ''}
-            propagationDetails={extraContext?.propagationDetails}
         />
     );
 
     renderSearch = (result: SearchResult) => {
-        return this.renderPreview(PreviewType.SEARCH, result.entity as CorpUser, undefined, undefined);
+        return this.renderPreview(PreviewType.SEARCH, result.entity as CorpUser);
     };
 
     displayName = (data: CorpUser) => {

--- a/datahub-web-react/src/app/entityV2/user/preview/Preview.tsx
+++ b/datahub-web-react/src/app/entityV2/user/preview/Preview.tsx
@@ -4,9 +4,9 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { IconStyleType } from '@app/entityV2/Entity';
+import { usePreviewData } from '@app/entityV2/shared/PreviewContext';
 import SearchTextHighlighter from '@app/searchV2/matches/SearchTextHighlighter';
 import HoverCardAttributionDetails from '@app/sharedV2/propagation/HoverCardAttributionDetails';
-import { AttributionDetails } from '@app/sharedV2/propagation/types';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { EntityType } from '@types';
@@ -57,15 +57,14 @@ export const Preview = ({
     urn,
     name,
     title,
-    propagationDetails,
 }: {
     urn: string;
     name: string;
     title?: string | undefined;
-    propagationDetails?: AttributionDetails;
 }): JSX.Element => {
     const entityRegistry = useEntityRegistry();
     const url = entityRegistry.getEntityUrl(EntityType.CorpUser, urn);
+    const { propagationDetails } = usePreviewData();
 
     return (
         <PreviewContainer>

--- a/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
+++ b/datahub-web-react/src/app/previewV2/DefaultPreviewCard.tsx
@@ -31,7 +31,6 @@ import {
 } from '@app/previewV2/utils';
 import { useSearchContext } from '@app/search/context/SearchContext';
 import HoverCardAttributionDetails from '@app/sharedV2/propagation/HoverCardAttributionDetails';
-import { AttributionDetails } from '@app/sharedV2/propagation/types';
 import { useAppConfig } from '@app/useAppConfig';
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 import DataProcessInstanceInfo from '@src/app/preview/DataProcessInstanceInfo';
@@ -69,6 +68,7 @@ const PreviewContainer = styled.div`
     width: 100%;
     justify-content: space-between;
     align-items: start;
+
     .entityCount {
         margin-bottom: 2px;
     }
@@ -173,7 +173,6 @@ interface Props {
     statsSummary?: any;
     actions?: EntityMenuActions;
     browsePaths?: BrowsePathV2 | undefined;
-    propagationDetails?: AttributionDetails;
     refetchDeprecation?: (formData?: DeprecationFormData) => void;
 }
 
@@ -221,7 +220,6 @@ export default function DefaultPreviewCard({
     actions,
     browsePaths,
     description,
-    propagationDetails,
     refetchDeprecation,
 }: Props) {
     const entityRegistry = useEntityRegistryV2();
@@ -238,7 +236,9 @@ export default function DefaultPreviewCard({
 
     // sometimes these lists will be rendered inside an entity container (for example, in the case of impact analysis)
     // in those cases, we may want to enrich the preview w/ context about the container entity
-    const previewData = usePreviewData();
+    // Passing previewType via context because not all entities pass it via props
+    // But not using previewContextType everywhere to avoid regressions... sorry
+    const { previewData, propagationDetails } = usePreviewData();
     const insightViews: Array<ReactNode> =
         insights?.map((insight) => (
             <>
@@ -412,7 +412,7 @@ function useRemoveRelationship(entityType: EntityType) {
     const { removeDataProduct } = useRemoveDataProductAssets(setShouldRefetchEmbeddedListSearch);
     const { removeApplication } = useRemoveApplicationAssets(setShouldRefetchEmbeddedListSearch);
 
-    const previewData = usePreviewData();
+    const { previewData } = usePreviewData();
     const entityData = useEntityData();
     const pageEntityType = entityData.entityType;
 

--- a/datahub-web-react/src/app/previewV2/HealthPopover.tsx
+++ b/datahub-web-react/src/app/previewV2/HealthPopover.tsx
@@ -1,6 +1,6 @@
-import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined';
 import ErrorOutlineOutlinedIcon from '@mui/icons-material/ErrorOutlineOutlined';
 import ReportProblemOutlinedIcon from '@mui/icons-material/ReportProblemOutlined';
+import VerifiedOutlinedIcon from '@mui/icons-material/VerifiedOutlined';
 import { Typography } from 'antd';
 import i18next from 'i18next';
 import React from 'react';
@@ -85,20 +85,20 @@ function healthIcon({ type }: Health) {
         case HealthStatusType.Assertions:
             return <ErrorOutlineOutlinedIcon fontSize="inherit" />;
         case HealthStatusType.Tests:
-            return <AssignmentOutlinedIcon fontSize="inherit" />;
+            return <VerifiedOutlinedIcon fontSize="inherit" />;
         default:
             return null;
     }
 }
 
-function healthUrlSuffix({ type }: Health) {
+export function healthUrlSuffix({ type }: Pick<Health, 'type'>) {
     switch (type) {
         case HealthStatusType.Incidents:
             return '/Incidents';
         case HealthStatusType.Assertions:
             return '/Quality/List';
         case HealthStatusType.Tests:
-            return '/Governance';
+            return '/Governance/Tests';
         default:
             return null;
     }
@@ -113,7 +113,7 @@ function healthMessage({ message, status, type }: Health) {
             case HealthStatusType.Incidents:
                 return i18next.t('entity.preview:health.noActiveIncidents');
             case HealthStatusType.Tests:
-                return i18next.t('entity.preview:health.testsPassing');
+                return i18next.t('entity.preview:health.noFailingGovernanceTests');
             default:
                 return null;
         }

--- a/datahub-web-react/src/app/previewV2/PreviewCardFooterRightSection.tsx
+++ b/datahub-web-react/src/app/previewV2/PreviewCardFooterRightSection.tsx
@@ -48,7 +48,7 @@ const PreviewCardFooterRightSection = ({
     tier,
     statsSummary,
 }: Props) => {
-    const previewData = usePreviewData();
+    const { previewData } = usePreviewData();
 
     const status = tier !== undefined ? getBarsStatusFromPopularityTier(tier) : 0;
 

--- a/datahub-web-react/src/app/previewV2/QueryStat.tsx
+++ b/datahub-web-react/src/app/previewV2/QueryStat.tsx
@@ -7,7 +7,6 @@ import { formatNumber } from '@app/shared/formatNumber';
 const Container = styled.div`
     color: ${(props) => props.theme.colors.textTertiary};
     font-size: 12px;
-    white-space: nowrap;
 `;
 
 interface Props {

--- a/datahub-web-react/src/app/recommendations/renderer/component/CompactEntityNameComponent.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/CompactEntityNameComponent.tsx
@@ -3,11 +3,12 @@ import { TooltipPlacement } from 'antd/es/tooltip';
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { IconStyleType } from '@app/entity/Entity';
+import { PreviewContextProps } from '@app/entityV2/shared/PreviewContext';
 import { decodeSchemaField } from '@app/lineage/utils/columnLineageUtils';
 import { downgradeV2FieldPath } from '@app/lineageV3/utils/lineageUtils';
 import { EntityPreviewTag } from '@app/recommendations/renderer/component/EntityPreviewTag';
 import { HoverEntityTooltip } from '@app/recommendations/renderer/component/HoverEntityTooltip';
+import PlatformIcon from '@app/sharedV2/icons/PlatformIcon';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
 import { Entity, EntityType, SchemaFieldEntity } from '@types';
@@ -24,6 +25,14 @@ const StyledArrow = styled(ArrowRightOutlined)`
     margin: 0 4px;
 `;
 
+const FullWidthContainer = styled.span`
+    max-width: 100%;
+`;
+
+const StyledPlatformIcon = styled(PlatformIcon)`
+    padding: 0;
+`;
+
 type CompactEntityNameProps = {
     entity: Entity;
     showFullTooltip?: boolean;
@@ -32,6 +41,7 @@ type CompactEntityNameProps = {
     onClick?: () => void;
     linkUrlParams?: Record<string, string | boolean>;
     showMargin?: boolean;
+    previewContext?: PreviewContextProps;
 };
 
 export const CompactEntityNameComponent = ({
@@ -42,6 +52,7 @@ export const CompactEntityNameComponent = ({
     onClick,
     linkUrlParams,
     showMargin = true,
+    previewContext,
 }: CompactEntityNameProps) => {
     const entityRegistry = useEntityRegistry();
 
@@ -52,14 +63,16 @@ export const CompactEntityNameComponent = ({
 
     if (entity.type === EntityType.SchemaField) {
         const { parent, fieldPath } = entity as SchemaFieldEntity;
-        processedEntity = parent;
+        processedEntity = parent ?? { urn: entity.urn, type: EntityType.Dataset };
         columnName = decodeSchemaField(downgradeV2FieldPath(fieldPath) || '');
     }
 
     const genericProps = entityRegistry.getGenericEntityProperties(processedEntity.type, processedEntity);
     const platformLogoUrl = genericProps?.platform?.properties?.logoUrl;
     const displayName = entityRegistry.getDisplayName(processedEntity.type, processedEntity);
-    const fallbackIcon = entityRegistry.getIcon(processedEntity.type, 12, IconStyleType.ACCENT);
+    const fallbackIcon = (
+        <StyledPlatformIcon platform={genericProps?.platform} size={12} alt={genericProps?.platform?.name} />
+    );
     const url = entityRegistry.getEntityUrl(processedEntity.type, processedEntity.urn, linkUrlParams);
 
     return (
@@ -69,8 +82,9 @@ export const CompactEntityNameComponent = ({
                 canOpen={showFullTooltip}
                 placement={placement}
                 showArrow={false}
+                previewContext={previewContext}
             >
-                <span>
+                <FullWidthContainer>
                     <EntityPreviewTag
                         showNameTooltip={!showFullTooltip}
                         displayName={displayName}
@@ -85,7 +99,7 @@ export const CompactEntityNameComponent = ({
                         dataTestId={`compact-entity-link-${processedEntity.urn}`}
                         showMargin={showMargin}
                     />
-                </span>
+                </FullWidthContainer>
             </HoverEntityTooltip>
             {showArrow && <StyledArrow />}
         </NameWrapper>

--- a/datahub-web-react/src/app/recommendations/renderer/component/EntityPreviewTag.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/EntityPreviewTag.tsx
@@ -57,6 +57,7 @@ const DisplayNameContainer = styled.span`
 `;
 
 const ColumnName = styled.span`
+    color: ${(props) => props.theme.colors.textSecondary};
     font-family: 'Roboto Mono', monospace;
     font-weight: bold;
 `;

--- a/datahub-web-react/src/app/recommendations/renderer/component/HoverEntityTooltip.tsx
+++ b/datahub-web-react/src/app/recommendations/renderer/component/HoverEntityTooltip.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useTheme } from 'styled-components';
 
 import { PreviewType } from '@app/entity/Entity';
-import { PreviewContext } from '@app/entityV2/Entity';
+import { PreviewContextProps } from '@app/entityV2/shared/PreviewContext';
 import { HoverEntityTooltipContext } from '@app/recommendations/HoverEntityTooltipContext';
 import { useEntityRegistryV2 } from '@app/useEntityRegistry';
 
@@ -20,7 +20,7 @@ type Props = {
     width?: number;
     maxWidth?: number;
     entityCount?: number;
-    previewContext?: PreviewContext;
+    previewContext?: PreviewContextProps;
 };
 
 export const HoverEntityTooltip = ({

--- a/datahub-web-react/src/i18n/locales/de/entity.preview.json
+++ b/datahub-web-react/src/i18n/locales/de/entity.preview.json
@@ -35,7 +35,7 @@
     "freshness.popoverContent": "{{updateType}} {{lastUpdatedAgo}}",
     "health.assertionsPassing": "Alle Assertions sind erfolgreich",
     "health.noActiveIncidents": "Keine aktiven Vorfälle",
-    "health.testsPassing": "Alle Tests sind erfolgreich",
+    "health.noFailingGovernanceTests": "Keine fehlgeschlagenen Governance-Tests",
     "lineage.downstreamCount_one": "{{count}} Downstream",
     "lineage.downstreamCount_other": "{{count}} Downstreams",
     "lineage.upstreamCount_one": "{{count}} Upstream",

--- a/datahub-web-react/src/i18n/locales/en/entity.preview.json
+++ b/datahub-web-react/src/i18n/locales/en/entity.preview.json
@@ -35,7 +35,7 @@
     "freshness.popoverContent": "{{updateType}} {{lastUpdatedAgo}}",
     "health.assertionsPassing": "All assertions are passing",
     "health.noActiveIncidents": "No active incidents",
-    "health.testsPassing": "All tests are passing",
+    "health.noFailingGovernanceTests": "No failing governance tests",
     "lineage.downstreamCount_one": "{{count}} downstream",
     "lineage.downstreamCount_other": "{{count}} downstreams",
     "lineage.upstreamCount_one": "{{count}} upstream",

--- a/datahub-web-react/src/i18n/locales/es/entity.preview.json
+++ b/datahub-web-react/src/i18n/locales/es/entity.preview.json
@@ -35,7 +35,7 @@
     "freshness.popoverContent": "{{updateType}} {{lastUpdatedAgo}}",
     "health.assertionsPassing": "Todas las Assertions están pasando",
     "health.noActiveIncidents": "No hay incidencias activas",
-    "health.testsPassing": "Todas las pruebas están pasando",
+    "health.noFailingGovernanceTests": "No hay pruebas de gobernanza fallidas",
     "lineage.downstreamCount_one": "{{count}} downstream",
     "lineage.downstreamCount_other": "{{count}} downstreams",
     "lineage.upstreamCount_one": "{{count}} upstream",

--- a/datahub-web-react/src/i18n/locales/fi/entity.preview.json
+++ b/datahub-web-react/src/i18n/locales/fi/entity.preview.json
@@ -35,7 +35,7 @@
     "freshness.popoverContent": "{{updateType}} {{lastUpdatedAgo}}",
     "health.assertionsPassing": "Kaikki assertionit läpäisevät",
     "health.noActiveIncidents": "Ei aktiivisia häiriöitä",
-    "health.testsPassing": "Kaikki testit läpäisevät",
+    "health.noFailingGovernanceTests": "Ei epäonnistuneita Governance-testejä",
     "lineage.downstreamCount_one": "{{count}} alavirta",
     "lineage.downstreamCount_other": "{{count}} alavirtaa",
     "lineage.upstreamCount_one": "{{count}} ylävirta",

--- a/datahub-web-react/src/i18n/locales/fr/entity.preview.json
+++ b/datahub-web-react/src/i18n/locales/fr/entity.preview.json
@@ -35,7 +35,7 @@
     "freshness.popoverContent": "{{updateType}} {{lastUpdatedAgo}}",
     "health.assertionsPassing": "Toutes les assertions réussissent",
     "health.noActiveIncidents": "Aucun incident actif",
-    "health.testsPassing": "Tous les tests réussissent",
+    "health.noFailingGovernanceTests": "Aucun test de gouvernance en échec",
     "lineage.downstreamCount_one": "{{count}} en aval",
     "lineage.downstreamCount_other": "{{count}} en aval",
     "lineage.upstreamCount_one": "{{count}} en amont",

--- a/datahub-web-react/src/i18n/locales/hu/entity.preview.json
+++ b/datahub-web-react/src/i18n/locales/hu/entity.preview.json
@@ -35,7 +35,7 @@
     "freshness.popoverContent": "{{updateType}} {{lastUpdatedAgo}}",
     "health.assertionsPassing": "Minden Assertion teljesül",
     "health.noActiveIncidents": "Nincsenek aktív incidensek",
-    "health.testsPassing": "Minden teszt sikeres",
+    "health.noFailingGovernanceTests": "Nincsenek sikertelen Governance-tesztek",
     "lineage.downstreamCount_one": "{{count}} céloldali",
     "lineage.downstreamCount_other": "{{count}} céloldali",
     "lineage.upstreamCount_one": "{{count}} forrásoldali",

--- a/datahub-web-react/src/i18n/locales/it/entity.preview.json
+++ b/datahub-web-react/src/i18n/locales/it/entity.preview.json
@@ -35,7 +35,7 @@
     "freshness.popoverContent": "{{updateType}} {{lastUpdatedAgo}}",
     "health.assertionsPassing": "Tutte le asserzioni sono soddisfatte",
     "health.noActiveIncidents": "Nessun incidente attivo",
-    "health.testsPassing": "Tutti i test sono superati",
+    "health.noFailingGovernanceTests": "Nessun test di governance non riuscito",
     "lineage.downstreamCount_one": "{{count}} elemento a valle",
     "lineage.downstreamCount_other": "{{count}} elementi a valle",
     "lineage.upstreamCount_one": "{{count}} elemento a monte",

--- a/datahub-web-react/src/i18n/locales/ja/entity.preview.json
+++ b/datahub-web-react/src/i18n/locales/ja/entity.preview.json
@@ -31,7 +31,7 @@
     "freshness.popoverContent": "{{updateType}} {{lastUpdatedAgo}}",
     "health.assertionsPassing": "すべてのAssertionに問題はありません",
     "health.noActiveIncidents": "対応中のIncidentはありません",
-    "health.testsPassing": "すべてのテストに問題はありません",
+    "health.noFailingGovernanceTests": "失敗したガバナンステストはありません",
     "lineage.downstreamCount_other": "{{count}}件の下流",
     "lineage.upstreamCount_other": "{{count}}件の上流",
     "notesCount_other": "{{count}}件のメモ",

--- a/datahub-web-react/src/i18n/locales/nb/entity.preview.json
+++ b/datahub-web-react/src/i18n/locales/nb/entity.preview.json
@@ -35,7 +35,7 @@
     "freshness.popoverContent": "{{updateType}} {{lastUpdatedAgo}}",
     "health.assertionsPassing": "Alle assertioner består",
     "health.noActiveIncidents": "Ingen aktive hendelser",
-    "health.testsPassing": "Alle tester består",
+    "health.noFailingGovernanceTests": "Ingen feilende styringstester",
     "lineage.downstreamCount_one": "{{count}} nedstrøms",
     "lineage.downstreamCount_other": "{{count}} nedstrøms",
     "lineage.upstreamCount_one": "{{count}} oppstrøms",

--- a/datahub-web-react/src/i18n/locales/pt-BR/entity.preview.json
+++ b/datahub-web-react/src/i18n/locales/pt-BR/entity.preview.json
@@ -35,7 +35,7 @@
     "freshness.popoverContent": "{{updateType}} {{lastUpdatedAgo}}",
     "health.assertionsPassing": "Todas as assertions estão passando",
     "health.noActiveIncidents": "Nenhum incident ativo",
-    "health.testsPassing": "Todos os testes estão passando",
+    "health.noFailingGovernanceTests": "Nenhum teste de governança reprovando",
     "lineage.downstreamCount_one": "{{count}} downstream",
     "lineage.downstreamCount_other": "{{count}} downstreams",
     "lineage.upstreamCount_one": "{{count}} upstream",

--- a/datahub-web-react/src/i18n/locales/sv/entity.preview.json
+++ b/datahub-web-react/src/i18n/locales/sv/entity.preview.json
@@ -35,7 +35,7 @@
     "freshness.popoverContent": "{{updateType}} {{lastUpdatedAgo}}",
     "health.assertionsPassing": "Alla kontroller är godkända",
     "health.noActiveIncidents": "Inga aktiva incidents",
-    "health.testsPassing": "Alla test är godkända",
+    "health.noFailingGovernanceTests": "Inga misslyckade styrningstester",
     "lineage.downstreamCount_one": "{{count}} downstream",
     "lineage.downstreamCount_other": "{{count}} downstream",
     "lineage.upstreamCount_one": "{{count}} upstream",

--- a/datahub-web-react/src/i18n/locales/zh-CN/entity.preview.json
+++ b/datahub-web-react/src/i18n/locales/zh-CN/entity.preview.json
@@ -31,7 +31,7 @@
     "freshness.popoverContent": "{{updateType}} {{lastUpdatedAgo}}",
     "health.assertionsPassing": "所有断言均已通过",
     "health.noActiveIncidents": "没有活跃的事件",
-    "health.testsPassing": "所有测试均已通过",
+    "health.noFailingGovernanceTests": "所有测试均已通过",
     "lineage.downstreamCount_other": "{{count}} 个下游",
     "lineage.upstreamCount_other": "{{count}} 个上游",
     "notesCount_other": "{{count}} 条备注",


### PR DESCRIPTION
Upstream the fork-side changes under datahub-web-react/src/app/recommendations
so the regular merge has less to conflict over.

- CompactEntityNameComponent: fall back to the schema field's own urn as a
  Dataset when a SchemaField entity carries no parent, instead of assigning
  undefined and dereferencing it a line later.
- CompactEntityNameComponent: build the platform fallback icon from
  PlatformIcon rather than entityRegistry.getIcon, so the pill picks up the
  same default platform icon as the rest of the app.
- CompactEntityNameComponent: wrap the pill in a max-width: 100% container so
  a long display name ellipsizes instead of overflowing its parent.
- CompactEntityNameComponent: thread previewContext through to
  HoverEntityTooltip, which already accepted the prop.
- EntityPreviewTag: color the monospace column name with the textSecondary
  token.

Depends on https://github.com/datahub-project/datahub/pull/19648

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates fork-side changes under `datahub-web-react/src/app/recommendations` and `datahub-web-react/src/app/previewV2` to reduce merge conflicts. Moves `propagationDetails` out of the `renderPreview` extraContext prop chain into `PreviewContext`, which now carries `previewData`, `previewType`, and `propagationDetails`; `Entity.renderPreview` drops its fourth argument.

- `CompactEntityNameComponent` falls back to the schema field's own urn as a `Dataset` when no parent exists, instead of dereferencing undefined.
- The fallback platform icon now comes from `PlatformIcon` rather than `entityRegistry.getIcon`.
- The pill wraps in a `max-width: 100%` container so long display names ellipsize instead of overflowing.
- `HoverEntityTooltip` now receives `previewContext`.
- `EntityPreviewTag` colors the monospace column name with the `textSecondary` token.
- `HealthPopover` uses `VerifiedOutlinedIcon` for the Tests status, points the link at `/Governance/Tests`, and renames the `health.testsPassing` key to `health.noFailingGovernanceTests` across all locales.
- `QueryStat` drops `white-space: nowrap` so long translated labels wrap.

Depends on datahub-project/datahub#19648.

<sup>Written for commit 93880467e68e3e7b4c424b8710881f8dba24c70e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

