### PR TITLE
refactor(ui): consolidate app/metrics with the fork

### DIFF
--- a/datahub-web-react/src/app/metrics/useSemanticModelRoots.ts
+++ b/datahub-web-react/src/app/metrics/useSemanticModelRoots.ts
@@ -11,7 +11,7 @@ import {
 import { useScrollSemanticModelsQuery } from '@graphql/metricsBrowse.generated';
 import { EntityType } from '@types';
 
-export const SEMANTIC_MODEL_COUNT = 50;
+const SEMANTIC_MODEL_COUNT = 50;
 
 function buildScrollInput(scrollId: string | null, sort: MetricsSidebarSortValue) {
     return {


### PR DESCRIPTION
Drop the unused `export` on SEMANTIC_MODEL_COUNT so the file matches the fork byte-for-byte, removing it as a recurring auto-merge conflict. The constant has no consumers outside its own module.

The remaining divergence in this directory (Sentry route wrapping, the chat page layout) is fork-specific and intentionally left alone.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops the unused `export` on `SEMANTIC_MODEL_COUNT` so `datahub-web-react/src/app/metrics/useSemanticModelRoots.ts` matches the fork byte-for-byte, removing a recurring auto-merge conflict.

- The constant has no consumers outside its module.
- Fork-specific divergence in this directory (Sentry route wrapping, chat page layout) is intentionally left alone.

<sup>Written for commit 42ea31bb54a2eac0d88815083835f1fa82dfaf04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

