### PR TITLE
feat(release): optional SHA input for Cut Branch workflow

### DIFF
--- a/.github/scripts/release/test/test_validate_inputs.py
+++ b/.github/scripts/release/test/test_validate_inputs.py
@@ -56,3 +56,20 @@ def test_emit_parsed_ref_invalid_exits_without_output(tmp_path, monkeypatch):
         vi.emit_parsed_ref(DEFAULT_BRANCH)
 
     assert not (tmp_path / "gh_output").exists()
+
+
+def test_validate_cut_branch_accepts_empty_sha():
+    vi.validate_cut_branch("1.0.0", "release", sha="")
+
+
+def test_validate_cut_branch_accepts_full_sha():
+    vi.validate_cut_branch(
+        "1.0.0", "hotfix", sha="0123456789abcdef0123456789ABCDEF01234567"
+    )
+
+
+@pytest.mark.parametrize("sha", ["abc", "not-a-sha", "a" * 39, "g" * 40])
+def test_validate_cut_branch_rejects_invalid_sha(sha):
+    with pytest.raises(SystemExit) as exc:
+        vi.validate_cut_branch("1.0.0", "release", sha=sha)
+    assert exc.value.code == 1

--- a/.github/scripts/release/test/test_validate_inputs.py
+++ b/.github/scripts/release/test/test_validate_inputs.py
@@ -1,13 +1,31 @@
 """Tests for validate_inputs.py branch-ref parsing."""
 
+import json
+import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import validate_inputs as vi
 from release_variables import DEFAULT_BRANCH
+
+_SHA = "0123456789abcdef0123456789ABCDEF01234567"
+_REPO = "datahub-project/datahub"
+
+
+def _make_proc(returncode: int, stdout: str = "", stderr: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+def _compare_payload(ahead_by: int) -> str:
+    return json.dumps({"ahead_by": ahead_by})
 
 
 def test_parse_release_ref_release_branch():
@@ -58,14 +76,61 @@ def test_emit_parsed_ref_invalid_exits_without_output(tmp_path, monkeypatch):
     assert not (tmp_path / "gh_output").exists()
 
 
-def test_validate_cut_branch_accepts_empty_sha():
+def test_validate_cut_branch_accepts_empty_sha(monkeypatch):
+    called = False
+
+    def fake_run(*_a, **_kw):
+        nonlocal called
+        called = True
+        return _make_proc(0, stdout=_compare_payload(0))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
     vi.validate_cut_branch("1.0.0", "release", sha="")
+    assert called is False
 
 
-def test_validate_cut_branch_accepts_full_sha():
-    vi.validate_cut_branch(
-        "1.0.0", "hotfix", sha="0123456789abcdef0123456789ABCDEF01234567"
+def test_validate_cut_branch_accepts_sha_on_source(monkeypatch):
+    captured = {}
+
+    def fake_run(args, **_kw):
+        captured["args"] = args
+        return _make_proc(0, stdout=_compare_payload(0))
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", _REPO)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    vi.validate_cut_branch("1.0.0", "hotfix", sha=_SHA, source="releases/v1.0.0")
+
+    url = captured["args"][2]
+    assert f"repos/{_REPO}/compare/" in url
+    assert "releases%2Fv1.0.0" in url
+    assert _SHA in url
+
+
+def test_validate_cut_branch_rejects_sha_not_on_source(monkeypatch):
+    monkeypatch.setenv("GITHUB_REPOSITORY", _REPO)
+    monkeypatch.setattr(
+        subprocess, "run", lambda *_a, **_kw: _make_proc(0, stdout=_compare_payload(3))
     )
+    with pytest.raises(SystemExit) as exc:
+        vi.validate_cut_branch("1.0.0", "release", sha=_SHA, source="master")
+    assert exc.value.code == 1
+
+
+def test_validate_cut_branch_rejects_unknown_sha(monkeypatch):
+    def fake_run(*_a, **_kw):
+        raise subprocess.CalledProcessError(1, ["gh"], stderr="Not Found (HTTP 404)")
+
+    monkeypatch.setenv("GITHUB_REPOSITORY", _REPO)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(SystemExit) as exc:
+        vi.validate_cut_branch("1.0.0", "release", sha=_SHA, source="master")
+    assert exc.value.code == 1
+
+
+def test_validate_cut_branch_requires_source_when_sha_set():
+    with pytest.raises(SystemExit) as exc:
+        vi.validate_cut_branch("1.0.0", "release", sha=_SHA)
+    assert exc.value.code == 1
 
 
 @pytest.mark.parametrize("sha", ["abc", "not-a-sha", "a" * 39, "g" * 40])

--- a/.github/scripts/release/validate_inputs.py
+++ b/.github/scripts/release/validate_inputs.py
@@ -4,7 +4,7 @@ Validate workflow_dispatch inputs for the Cut Branch and Cut Tag workflows.
 
 Usage:
   python3 validate_inputs.py cut-branch --version 1.0.0 --branch-type release
-  python3 validate_inputs.py cut-branch --version 1.0.0 --branch-type release --sha <40-char hex>
+  python3 validate_inputs.py cut-branch --version 1.0.0 --branch-type release --sha <40-char hex> --source master
   python3 validate_inputs.py cut-tag --version 1.0.0 --branch-type release --release-type rc
   python3 validate_inputs.py cut-tag --version 1.0.0 --branch-type hotfix --release-type final --hotfix-version 1.0.1
   python3 validate_inputs.py parse-ref --ref releases/v1.0.0
@@ -19,6 +19,7 @@ Environment variables (parse-ref):
 """
 
 import argparse
+import json
 import os
 import re
 import subprocess
@@ -64,9 +65,51 @@ def validate_sha(sha: str) -> None:
         sys.exit(1)
 
 
-def validate_cut_branch(version: str, branch_type: str, sha: str = "") -> None:
+def sha_is_on_source(sha: str, source: str, repo: str) -> None:
+    """Reject a SHA that is not an ancestor of ``source`` (GitHub compare)."""
+    encoded_source = source.replace("/", "%2F")
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/compare/{encoded_source}...{sha}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr or ""
+        if "404" in stderr or "Not Found" in stderr:
+            print(
+                f"Error: sha '{sha}' was not found, or source branch '{source}' "
+                "does not exist."
+            )
+        else:
+            print(f"Error calling GitHub API: {stderr or exc}")
+        sys.exit(1)
+
+    try:
+        ahead_by = json.loads(result.stdout).get("ahead_by", 0)
+    except json.JSONDecodeError:
+        print(f"Error: GitHub API returned unexpected response: {result.stdout[:200]!r}")
+        sys.exit(1)
+
+    if ahead_by != 0:
+        print(
+            f"Error: sha '{sha}' is not on source branch '{source}'. "
+            "Cut Branch can only start from a commit that is already on the source branch."
+        )
+        sys.exit(1)
+
+
+def validate_cut_branch(
+    version: str, branch_type: str, sha: str = "", source: str = ""
+) -> None:
     validate_version_format(version, "version")
     validate_sha(sha)
+    if sha:
+        if not source:
+            print("Error: --source is required when --sha is set.")
+            sys.exit(1)
+        sha_is_on_source(sha, source, os.environ["GITHUB_REPOSITORY"])
 
     print(
         f"Inputs valid: branch_type={branch_type}, version={version}, "
@@ -187,6 +230,11 @@ def build_parser() -> argparse.ArgumentParser:
         default="",
         help="Full 40-character commit SHA to cut from; empty uses the source branch tip",
     )
+    branch.add_argument(
+        "--source",
+        default="",
+        help="Source branch to check --sha against (required when --sha is set)",
+    )
 
     tag = sub.add_parser("cut-tag", help="Validate Cut Tag inputs")
     tag.add_argument("--version", required=True, help="e.g. 1.0.0")
@@ -207,7 +255,7 @@ def main() -> None:
     args = build_parser().parse_args()
 
     if args.command == "cut-branch":
-        validate_cut_branch(args.version, args.branch_type, args.sha)
+        validate_cut_branch(args.version, args.branch_type, args.sha, args.source)
     elif args.command == "parse-ref":
         emit_parsed_ref(args.ref)
     else:

--- a/.github/scripts/release/validate_inputs.py
+++ b/.github/scripts/release/validate_inputs.py
@@ -4,6 +4,7 @@ Validate workflow_dispatch inputs for the Cut Branch and Cut Tag workflows.
 
 Usage:
   python3 validate_inputs.py cut-branch --version 1.0.0 --branch-type release
+  python3 validate_inputs.py cut-branch --version 1.0.0 --branch-type release --sha <40-char hex>
   python3 validate_inputs.py cut-tag --version 1.0.0 --branch-type release --release-type rc
   python3 validate_inputs.py cut-tag --version 1.0.0 --branch-type hotfix --release-type final --hotfix-version 1.0.1
   python3 validate_inputs.py parse-ref --ref releases/v1.0.0
@@ -19,6 +20,7 @@ Environment variables (parse-ref):
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 
@@ -50,10 +52,26 @@ def release_exists(tag: str, repo: str) -> bool:
     return result.returncode == 0
 
 
-def validate_cut_branch(version: str, branch_type: str) -> None:
-    validate_version_format(version, "version")
+_FULL_SHA_PATTERN = re.compile(r"[0-9a-fA-F]{40}")
 
-    print(f"Inputs valid: branch_type={branch_type}, version={version}")
+
+def validate_sha(sha: str) -> None:
+    if sha and not _FULL_SHA_PATTERN.fullmatch(sha):
+        print(
+            f"Error: sha '{sha}' is not valid. "
+            "Expected a 40-character hex commit SHA, or leave empty for the source branch tip."
+        )
+        sys.exit(1)
+
+
+def validate_cut_branch(version: str, branch_type: str, sha: str = "") -> None:
+    validate_version_format(version, "version")
+    validate_sha(sha)
+
+    print(
+        f"Inputs valid: branch_type={branch_type}, version={version}, "
+        f"sha={sha or '(source tip)'}"
+    )
 
 
 def validate_cut_tag(
@@ -164,6 +182,11 @@ def build_parser() -> argparse.ArgumentParser:
     branch.add_argument(
         "--branch-type", required=True, choices=["release", "hotfix"]
     )
+    branch.add_argument(
+        "--sha",
+        default="",
+        help="Full 40-character commit SHA to cut from; empty uses the source branch tip",
+    )
 
     tag = sub.add_parser("cut-tag", help="Validate Cut Tag inputs")
     tag.add_argument("--version", required=True, help="e.g. 1.0.0")
@@ -184,7 +207,7 @@ def main() -> None:
     args = build_parser().parse_args()
 
     if args.command == "cut-branch":
-        validate_cut_branch(args.version, args.branch_type)
+        validate_cut_branch(args.version, args.branch_type, args.sha)
     elif args.command == "parse-ref":
         emit_parsed_ref(args.ref)
     else:

--- a/.github/workflows/release-process-cut-branch.yml
+++ b/.github/workflows/release-process-cut-branch.yml
@@ -15,6 +15,11 @@ on:
       version:
         description: "Version without 'v' prefix (e.g. 1.0.0)"
         required: true
+      sha:
+        description: "Full 40-character commit SHA to cut from. Leave empty to use the tip of the source branch (master for release, releases/v{version} for hotfix)."
+        required: false
+        type: string
+        default: ""
 
 permissions: {}
 
@@ -43,7 +48,8 @@ jobs:
         run: |
           python3 .github/scripts/release/validate_inputs.py cut-branch \
             --version "${{ inputs.version }}" \
-            --branch-type "${{ inputs.branch_type }}"
+            --branch-type "${{ inputs.branch_type }}" \
+            --sha "${{ inputs.sha }}"
 
       - name: Resolve source and target branches
         id: branches
@@ -64,10 +70,10 @@ jobs:
           client-id: ${{ vars.RELEASE_TEAM_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_TEAM_GH_APP_PRIVATE_KEY }}
 
-      - name: Check out source branch
+      - name: Check out source commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ steps.branches.outputs.source }}
+          ref: ${{ inputs.sha != '' && inputs.sha || steps.branches.outputs.source }}
           # PAT required: GITHUB_TOKEN pushes do not trigger push-event workflows
           # (e.g. docker-unified.yml on releases/** and hotfixes/**).
           token: ${{ steps.app-token.outputs.token }}
@@ -77,6 +83,19 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Validate SHA is on the source branch
+        if: ${{ inputs.sha != '' }}
+        env:
+          SOURCE: ${{ steps.branches.outputs.source }}
+          SHA: ${{ inputs.sha }}
+        run: |
+          git fetch origin "$SOURCE"
+          if ! git merge-base --is-ancestor "$SHA" "origin/$SOURCE"; then
+            echo "Error: sha '$SHA' is not an ancestor of origin/$SOURCE."
+            echo "Cut Branch can only start from a commit that is already on the source branch."
+            exit 1
+          fi
 
       - name: Validate target branch does not already exist
         run: |
@@ -108,6 +127,7 @@ jobs:
           | Field         | Value                                        |
           |---------------|----------------------------------------------|
           | Source branch | \`${{ steps.branches.outputs.source }}\`     |
+          | Requested SHA | \`${{ inputs.sha != '' && inputs.sha || '(source tip)' }}\` |
           | Target branch | \`${{ steps.branches.outputs.target }}\`     |
           | Commit SHA    | \`${{ steps.create_branch.outputs.commit_sha }}\` |
           EOF

--- a/.github/workflows/release-process-cut-branch.yml
+++ b/.github/workflows/release-process-cut-branch.yml
@@ -44,24 +44,34 @@ jobs:
           sparse-checkout-cone-mode: true
           fetch-depth: 1
 
-      - name: Validate inputs
-        run: |
-          python3 .github/scripts/release/validate_inputs.py cut-branch \
-            --version "${{ inputs.version }}" \
-            --branch-type "${{ inputs.branch_type }}" \
-            --sha "${{ inputs.sha }}"
-
       - name: Resolve source and target branches
         id: branches
+        env:
+          BRANCH_TYPE: ${{ inputs.branch_type }}
+          VERSION: ${{ inputs.version }}
         run: |
-          if [ "${{ inputs.branch_type }}" == "release" ]; then
+          if [ "$BRANCH_TYPE" == "release" ]; then
             SOURCE=$(PYTHONPATH=.github/scripts:.github/scripts/release python3 -c "from release_variables import DEFAULT_BRANCH; print(DEFAULT_BRANCH)")
             echo "source=${SOURCE}" >> "$GITHUB_OUTPUT"
-            echo "target=releases/v${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "target=releases/v${VERSION}" >> "$GITHUB_OUTPUT"
           else
-            echo "source=releases/v${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-            echo "target=hotfixes/v${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "source=releases/v${VERSION}" >> "$GITHUB_OUTPUT"
+            echo "target=hotfixes/v${VERSION}" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Validate inputs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          BRANCH_TYPE: ${{ inputs.branch_type }}
+          SHA: ${{ inputs.sha }}
+          SOURCE: ${{ steps.branches.outputs.source }}
+        run: |
+          python3 .github/scripts/release/validate_inputs.py cut-branch \
+            --version "$VERSION" \
+            --branch-type "$BRANCH_TYPE" \
+            --sha "$SHA" \
+            --source "$SOURCE"
 
       - name: Generate GitHub App token
         id: app-token
@@ -83,19 +93,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Validate SHA is on the source branch
-        if: ${{ inputs.sha != '' }}
-        env:
-          SOURCE: ${{ steps.branches.outputs.source }}
-          SHA: ${{ inputs.sha }}
-        run: |
-          git fetch origin "$SOURCE"
-          if ! git merge-base --is-ancestor "$SHA" "origin/$SOURCE"; then
-            echo "Error: sha '$SHA' is not an ancestor of origin/$SOURCE."
-            echo "Cut Branch can only start from a commit that is already on the source branch."
-            exit 1
-          fi
 
       - name: Validate target branch does not already exist
         run: |
@@ -120,16 +117,22 @@ jobs:
           echo "Created branch: $TARGET"
 
       - name: Write job summary
+        env:
+          SOURCE: ${{ steps.branches.outputs.source }}
+          TARGET: ${{ steps.branches.outputs.target }}
+          COMMIT_SHA: ${{ steps.create_branch.outputs.commit_sha }}
+          SHA: ${{ inputs.sha }}
         run: |
+          REQUESTED="${SHA:-"(source tip)"}"
           cat >> "$GITHUB_STEP_SUMMARY" << EOF
           ## Branch Cut Summary
 
           | Field         | Value                                        |
           |---------------|----------------------------------------------|
-          | Source branch | \`${{ steps.branches.outputs.source }}\`     |
-          | Requested SHA | \`${{ inputs.sha != '' && inputs.sha || '(source tip)' }}\` |
-          | Target branch | \`${{ steps.branches.outputs.target }}\`     |
-          | Commit SHA    | \`${{ steps.create_branch.outputs.commit_sha }}\` |
+          | Source branch | \`${SOURCE}\`                                |
+          | Requested SHA | \`${REQUESTED}\`                             |
+          | Target branch | \`${TARGET}\`                                |
+          | Commit SHA    | \`${COMMIT_SHA}\`                            |
           EOF
 
   notify_release_channel:

--- a/.github/workflows/release-process-cut-branch.yml
+++ b/.github/workflows/release-process-cut-branch.yml
@@ -16,7 +16,7 @@ on:
         description: "Version without 'v' prefix (e.g. 1.0.0)"
         required: true
       sha:
-        description: "Full 40-character commit SHA to cut from. Leave empty to use the tip of the source branch (master for release, releases/v{version} for hotfix)."
+        description: "Full 40-character commit SHA to cut from. Leave empty to use the tip of the source branch."
         required: false
         type: string
         default: ""


### PR DESCRIPTION
## Summary

- **Optional `sha` on Cut Branch** — leave it empty to cut `releases/v*` / `hotfixes/v*` from the source branch tip (same as today). Pass a 40-character commit SHA to cut from that commit instead.
- **Guards** — invalid SHA format fails in `validate_inputs.py`; a SHA that is not on the source branch (`master` for release, `releases/v{version}` for hotfix) fails before the new branch is pushed.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `sha` input to the Cut Branch workflow so release and hotfix branches can be cut from a specific commit instead of always from the source branch tip. Leaving `sha` empty keeps the existing behavior of cutting from the source tip; providing a 40-character SHA pins the new branch to that commit.

- Invalid SHA formats fail in `validate_inputs.py` before anything is pushed.
- A SHA that isn't an ancestor of the source branch fails before the branch is created; ancestry is verified via the GitHub compare API because a shallow checkout can't prove it.
- The workflow summary now shows the requested SHA (or "source tip") alongside the resolved branches.

<sup>Written for commit 228ae26b76e9ef8cb7e7407022f09f4e7785dff6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

