### PR TITLE
refactor(ui): consolidate app/tags with the SaaS frontend 

### DIFF
--- a/datahub-web-react/src/app/tags/ManageTags.tsx
+++ b/datahub-web-react/src/app/tags/ManageTags.tsx
@@ -5,7 +5,12 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
 import { useUserContext } from '@app/context/useUserContext';
-import { PageContainer } from '@app/govern/structuredProperties/styledComponents';
+import {
+    ButtonContainer,
+    HeaderContainer,
+    HeaderContent,
+    PageContainer,
+} from '@app/govern/structuredProperties/styledComponents';
 import CreateNewTagModal from '@app/tags/CreateNewTagModal/CreateNewTagModal';
 import EmptyTags from '@app/tags/EmptyTags';
 import TagsTable from '@app/tags/TagsTable';
@@ -14,19 +19,6 @@ import { useEntityRegistry } from '@src/app/useEntityRegistry';
 import { useShowNavBarRedesign } from '@src/app/useShowNavBarRedesign';
 import { useGetSearchResultsForMultipleQuery } from '@src/graphql/search.generated';
 import { EntityType } from '@src/types.generated';
-
-const HeaderContainer = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 0px;
-`;
-
-const SearchContainer = styled.div`
-    display: flex;
-    align-items: center;
-    margin-bottom: 0px;
-`;
 
 // Simple loading indicator at the top of the page
 const LoadingBar = styled.div`
@@ -145,22 +137,19 @@ const ManageTags = () => {
     return (
         <PageContainer $isShowNavBarRedesign={isShowNavBarRedesign}>
             {searchLoading && <LoadingBar />}
-
             <HeaderContainer>
-                <PageTitle title={t('tags.pageTitle')} subTitle={t('tags.pageSubtitle')} />
-                {createButton}
+                <HeaderContent>
+                    <PageTitle title={t('tags.pageTitle')} subTitle={t('tags.pageSubtitle')} />
+                </HeaderContent>
+                <ButtonContainer>{createButton}</ButtonContainer>
             </HeaderContainer>
-
-            <SearchContainer>
-                <SearchBar
-                    placeholder={t('tags.searchPlaceholder')}
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e)}
-                    data-testid="tag-search-input"
-                    width="280px"
-                />
-            </SearchContainer>
-
+            <SearchBar
+                placeholder={t('tags.searchPlaceholder')}
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e)}
+                data-testid="tag-search-input"
+                width="280px"
+            />
             {!searchLoading && !hasSearchResults ? (
                 <EmptyTags isEmptySearch={debouncedSearchQuery.length > 0} />
             ) : (

--- a/datahub-web-react/src/app/tags/ManageTags.tsx
+++ b/datahub-web-react/src/app/tags/ManageTags.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable rulesdir/no-hardcoded-colors */
 import { Button, PageTitle, Pagination, SearchBar, StructuredPopover } from '@components';
 import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
 import React, { useEffect, useMemo, useState } from 'react';
@@ -65,20 +64,17 @@ const ManageTags = () => {
     const entityRegistry = useEntityRegistry();
     const [showCreateTagModal, setShowCreateTagModal] = useState(false);
 
-    // Check permissions using UserContext
     const userContext = useUserContext();
     const canCreateTags = userContext?.platformPrivileges?.createTags || userContext?.platformPrivileges?.manageTags;
 
-    // Debounce search query input to reduce unnecessary renders
     useEffect(() => {
         const timer = setTimeout(() => {
             setDebouncedSearchQuery(searchQuery);
-        }, 300); // 300ms delay
+        }, 300);
 
         return () => clearTimeout(timer);
     }, [searchQuery]);
 
-    // Search query configuration
     const searchInputs = useMemo(
         () => ({
             types: [EntityType.Tag],
@@ -98,24 +94,21 @@ const ManageTags = () => {
         networkStatus,
     } = useGetSearchResultsForMultipleQuery({
         variables: { input: searchInputs },
-        fetchPolicy: 'cache-first', // Changed from cache-and-network to prevent double loading
-        notifyOnNetworkStatusChange: false, // Changed to false to reduce unnecessary re-renders
+        fetchPolicy: 'cache-first',
+        notifyOnNetworkStatusChange: false,
     });
 
     const totalTags = searchData?.searchAcrossEntities?.total || 0;
 
-    // Check if we have results to display
     const hasSearchResults = useMemo(() => {
         const results = searchData?.searchAcrossEntities?.searchResults || [];
         if (debouncedSearchQuery) {
-            // If there's a search query, check if any tags match
             return results.some((result) => {
                 const tag = result.entity;
                 const displayName = entityRegistry.getDisplayName(EntityType.Tag, tag);
                 return displayName.toLowerCase().includes(debouncedSearchQuery.toLowerCase());
             });
         }
-        // Otherwise just check if we have any results
         return results.length > 0;
     }, [searchData, debouncedSearchQuery, entityRegistry]);
 
@@ -123,38 +116,31 @@ const ManageTags = () => {
         return <Message type="error" content={t('tags.loadError', { error: searchError.message })} />;
     }
 
-    // Create the Create Tag button with proper permissions handling
-    const renderCreateTagButton = () => {
-        if (!canCreateTags) {
-            return (
-                <StructuredPopover
-                    title={t('tags.noCreatePermissionTooltip')}
-                    placement="left"
-                    showArrow
-                    mouseEnterDelay={0.1}
-                    mouseLeaveDelay={0.1}
-                >
-                    <span>
-                        <Button size="md" color="violet" icon={{ icon: Plus }} disabled>
-                            {t('tags.createButton')}
-                        </Button>
-                    </span>
-                </StructuredPopover>
-            );
-        }
-
-        return (
-            <Button
-                onClick={() => setShowCreateTagModal(true)}
-                size="md"
-                color="violet"
-                icon={{ icon: Plus }}
-                data-testid="add-tag-button"
-            >
-                {t('tags.createButton')}
-            </Button>
-        );
-    };
+    const createButton = !canCreateTags ? (
+        <StructuredPopover
+            title={t('tags.noCreatePermissionTooltip')}
+            placement="left"
+            showArrow
+            mouseEnterDelay={0.1}
+            mouseLeaveDelay={0.1}
+        >
+            <span>
+                <Button size="md" color="primary" icon={{ icon: Plus }} disabled>
+                    {t('tags.createButton')}
+                </Button>
+            </span>
+        </StructuredPopover>
+    ) : (
+        <Button
+            onClick={() => setShowCreateTagModal(true)}
+            size="md"
+            color="primary"
+            icon={{ icon: Plus }}
+            data-testid="add-tag-button"
+        >
+            {t('tags.createButton')}
+        </Button>
+    );
 
     return (
         <PageContainer $isShowNavBarRedesign={isShowNavBarRedesign}>
@@ -162,7 +148,7 @@ const ManageTags = () => {
 
             <HeaderContainer>
                 <PageTitle title={t('tags.pageTitle')} subTitle={t('tags.pageSubtitle')} />
-                {renderCreateTagButton()}
+                {createButton}
             </HeaderContainer>
 
             <SearchContainer>

--- a/datahub-web-react/src/app/tags/TagsTableColumns.tsx
+++ b/datahub-web-react/src/app/tags/TagsTableColumns.tsx
@@ -151,7 +151,8 @@ export const TagAppliedToColumn = React.memo(({ tagUrn }: { tagUrn: string }) =>
             input: {
                 query: '*',
                 start: 0,
-                count: 1,
+                // Facets only — result body is unused.
+                count: 0,
                 orFilters: generateOrFilters(UnionType.OR, entityFilters),
             },
         },


### PR DESCRIPTION
Port the non-SaaS-specific edits the Acryl fork accumulated under
src/app/tags, so the OSS -> SaaS auto-merge has less to reconcile.

ManageTags:
- use the semantic `primary` brand token for the Create Tag button
  instead of the static `violet` palette. The violet palette bypasses
  the configurable ColorTheme, and suppressing it was the only reason
  this file carried an `eslint-disable rulesdir/no-hardcoded-colors`
  header, which is now gone. The sibling ManageApplications page
  already renders its button this way.
- collapse renderCreateTagButton() into a plain `createButton` const;
  it has no arguments and one call site.
- drop comments that restate the code they sit above.

TagsTableColumns:
- request `count: 0` in TagAppliedToColumn. The component reads only
  the entity facet's aggregations and never touches searchResults, so
  the previous `count: 1` fetched and discarded a full entity card for
  every row of the tags table.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates the OSS `app/tags` UI with the SaaS fork's accumulated edits so the OSS → SaaS auto-merge has less to reconcile.

**Refactors**
- Switches the Create Tag button from the hardcoded `violet` color to the semantic `primary` token, which removes the need for the `eslint-disable` header.
- Reuses the shared header and search container components from StructuredProperties instead of local near-copies; layout is unchanged.
- Collapses `renderCreateTagButton()` into a `createButton` const and removes comments that just restated the code.
- Sets `count: 0` in `TagAppliedToColumn` — the component only reads facet aggregations, so the old `count: 1` fetched and discarded an entity card per row.

<sup>Written for commit 9a2b9687254d68da14147a45ecbed0dc9095406a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

