### PR TITLE
refactor(ui): consolidate app/domain with the SaaS frontend

### DIFF
--- a/datahub-web-react/src/app/domain/DomainIcon.tsx
+++ b/datahub-web-react/src/app/domain/DomainIcon.tsx
@@ -1,12 +1,10 @@
-import Icon from '@ant-design/icons/lib/components/Icon';
+import { Globe } from '@phosphor-icons/react/dist/csr/Globe';
 import React from 'react';
-
-import DomainsIcon from '@images/domain.svg?react';
 
 type Props = {
     style?: React.CSSProperties;
 };
 
 export default function DomainIcon({ style }: Props) {
-    return <Icon component={DomainsIcon} style={style} />;
+    return <Globe style={style} />;
 }

--- a/datahub-web-react/src/app/domain/nestedDomains/domainNavigator/DomainNavigator.tsx
+++ b/datahub-web-react/src/app/domain/nestedDomains/domainNavigator/DomainNavigator.tsx
@@ -1,3 +1,4 @@
+import { LoadingOutlined } from '@ant-design/icons';
 import { Alert, Empty } from 'antd';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -15,6 +16,18 @@ const NavigatorWrapper = styled.div`
     overflow: auto;
 `;
 
+const LoadingWrapper = styled.div`
+    padding: 8px;
+    display: flex;
+    justify-content: center;
+
+    svg {
+        height: 15px;
+        width: 15px;
+        color: ${(props) => props.theme.colors.textSecondary};
+    }
+`;
+
 interface Props {
     domainUrnToHide?: string;
     displayDomainColoredIcon?: boolean;
@@ -24,30 +37,39 @@ interface Props {
 export default function DomainNavigator({ domainUrnToHide, selectDomainOverride, displayDomainColoredIcon }: Props) {
     const { t } = useTranslation('governance.domain');
     const theme = useTheme();
-    const { sortedDomains, error } = useListDomains({});
+    const { sortedDomains, loading, error } = useListDomains({});
     const noDomainsFound: boolean = !sortedDomains || sortedDomains.length === 0;
+
+    const domainNavigatorNodes = noDomainsFound
+        ? [
+              <Empty
+                  key="empty"
+                  description={t('navigator.empty')}
+                  image={Empty.PRESENTED_IMAGE_SIMPLE}
+                  style={{ color: theme.colors.textSecondary }}
+              />,
+          ]
+        : sortedDomains?.map((domain) => (
+              <DomainNode
+                  key={domain.urn}
+                  domain={domain as Domain}
+                  numDomainChildren={domain.children?.total || 0}
+                  domainUrnToHide={domainUrnToHide}
+                  selectDomainOverride={selectDomainOverride}
+                  displayDomainColoredIcon={displayDomainColoredIcon}
+              />
+          ));
 
     return (
         <NavigatorWrapper>
             {error && <Alert message={t('navigator.loadError')} showIcon type="error" />}
-            {noDomainsFound && (
-                <Empty
-                    description={t('navigator.empty')}
-                    image={Empty.PRESENTED_IMAGE_SIMPLE}
-                    style={{ color: theme.colors.textSecondary }}
-                />
+            {loading ? (
+                <LoadingWrapper>
+                    <LoadingOutlined />
+                </LoadingWrapper>
+            ) : (
+                domainNavigatorNodes
             )}
-            {!noDomainsFound &&
-                sortedDomains?.map((domain) => (
-                    <DomainNode
-                        key={domain.urn}
-                        domain={domain as Domain}
-                        numDomainChildren={domain.children?.total || 0}
-                        domainUrnToHide={domainUrnToHide}
-                        selectDomainOverride={selectDomainOverride}
-                        displayDomainColoredIcon={displayDomainColoredIcon}
-                    />
-                ))}
         </NavigatorWrapper>
     );
 }

--- a/datahub-web-react/src/app/domain/nestedDomains/domainNavigator/DomainNode.tsx
+++ b/datahub-web-react/src/app/domain/nestedDomains/domainNavigator/DomainNode.tsx
@@ -22,15 +22,21 @@ const RowWrapper = styled.div`
     overflow: hidden;
 `;
 
-const NameWrapper = styled(Typography.Text)<{ isSelected: boolean; addLeftPadding: boolean }>`
+const NameWrapper = styled(Typography.Text)<{ $isSelected: boolean; $addLeftPadding: boolean }>`
+    && {
+        display: flex;
+        align-items: center;
+        vertical-align: middle;
+    }
+
     flex: 1;
     overflow: hidden;
     padding: 2px;
-    ${(props) => props.isSelected && `background-color: ${props.theme.colors.bgSelected};`}
-    ${(props) => props.addLeftPadding && 'padding-left: 22px;'}
+    ${(props) => props.$isSelected && `background-color: ${props.theme.colors.bgSelected};`}
+    ${(props) => props.$addLeftPadding && 'padding-left: 22px;'}
 
     &:hover {
-        ${(props) => !props.isSelected && `background-color: ${props.theme.colors.bgSurface};`}
+        ${(props) => !props.$isSelected && `background-color: ${props.theme.colors.bgSurface};`}
         cursor: pointer;
     }
 
@@ -123,8 +129,8 @@ export default function DomainNode({
                 <NameWrapper
                     ellipsis={{ tooltip: displayName }}
                     onClick={handleSelectDomain}
-                    isSelected={!!isOnEntityPage && !isInSelectMode}
-                    addLeftPadding={!hasDomainChildren}
+                    $isSelected={!!isOnEntityPage && !isInSelectMode}
+                    $addLeftPadding={!hasDomainChildren}
                     data-testid={`domain-option-${displayName}`}
                 >
                     {!isInSelectMode && !displayDomainColoredIcon && <DomainIcon />}


### PR DESCRIPTION
Port the non-SaaS-specific edits the Acryl fork accumulated under src/app/domain, so the OSS -> SaaS auto-merge has less to reconcile.

DomainIcon:
- render the phosphor Globe instead of wrapping images/domain.svg in an antd Icon. The fork made this swap in its icon design review, and the same Globe is already the domain glyph elsewhere in OSS - the home page module list, the module menu and the search field filters all import it. This changes the icon at the two DomainIcon call sites, DomainLink and DomainNode. images/domain.svg has no other importer and is left in place, now unused.

DomainNavigator:
- show a spinner while useListDomains is in flight. The list was rendering the "no domains" empty state during the first fetch, so an instance that does have domains flashed the empty state on every mount. useListDomains already returned `loading`; nothing else was needed to read it.
- lift the branch out of JSX into a `domainNavigatorNodes` const, which is what makes the loading ternary readable.

DomainNode:
- mark the NameWrapper style props transient ($isSelected, $addLeftPadding). styled-components was forwarding both to the DOM, where React rejects them as unknown attributes and logs a warning per row.
- center the row contents, so the domain glyph sits on the text baseline rather than riding above it.

One line departs from the fork: the Empty element moved into an array literal and needs a `key`, which the fork omits and React warns about.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates `app/domain` with the SaaS frontend to reduce auto-merge friction, and fixes a few UI bugs along the way.

- DomainIcon now renders the phosphor Globe instead of wrapping `domain.svg`.
- DomainNavigator shows a spinner while loading, preventing a flash of the empty state.
- DomainNode marks style props as transient and centers row contents.
- Adds the missing `key` to the Empty element.

<sup>Written for commit e5a808ff954e7fca8f4427772cfebb43d47d8db6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

