### PR TITLE
refactor(ui): consolidate app/glossary with the SaaS fork

### DIFF
--- a/datahub-web-react/src/app/glossary/__tests__/utils.test.ts
+++ b/datahub-web-react/src/app/glossary/__tests__/utils.test.ts
@@ -1,0 +1,42 @@
+import { ROOT_NODES, ROOT_TERMS, getGlossaryRootToUpdate, getParentNodeToUpdate } from '@app/glossary/utils';
+import { glossaryNode1, glossaryNode3, glossaryTerm1 } from '@src/Mocks';
+
+import { EntityType } from '@types';
+
+const glossaryTermWithParent = {
+    ...glossaryTerm1,
+    parentNodes: {
+        count: 1,
+        nodes: [glossaryNode1],
+    },
+};
+
+describe('glossary utils tests', () => {
+    it('should get the direct parent node urn in getParentNodeToUpdate for glossary nodes', () => {
+        const parentNode = getParentNodeToUpdate(glossaryNode3 as any, EntityType.GlossaryNode);
+        expect(parentNode).toBe(glossaryNode3.parentNodes?.nodes[0]?.urn);
+    });
+
+    it('should get the direct parent node urn in getParentNodeToUpdate for glossary terms', () => {
+        const parentNode = getParentNodeToUpdate(glossaryTermWithParent as any, EntityType.GlossaryTerm);
+        expect(parentNode).toBe(glossaryNode1.urn);
+    });
+
+    it('should return ROOT_NODES for glossary node with no parent nodes', () => {
+        const parentNode = getParentNodeToUpdate(glossaryNode1 as any, EntityType.GlossaryNode);
+        expect(parentNode).toBe(ROOT_NODES);
+    });
+
+    it('should return ROOT_TERMS for glossary term with no parent nodes', () => {
+        const parentNode = getParentNodeToUpdate(glossaryTerm1 as any, EntityType.GlossaryTerm);
+        expect(parentNode).toBe(ROOT_TERMS);
+    });
+
+    it('should return ROOT_NODES for glossary node', () => {
+        expect(getGlossaryRootToUpdate(EntityType.GlossaryNode)).toBe(ROOT_NODES);
+    });
+
+    it('should return ROOT_TERMS for glossary term', () => {
+        expect(getGlossaryRootToUpdate(EntityType.GlossaryTerm)).toBe(ROOT_TERMS);
+    });
+});

--- a/datahub-web-react/src/app/glossary/utils.ts
+++ b/datahub-web-react/src/app/glossary/utils.ts
@@ -1,7 +1,6 @@
-import EntityRegistry from '@app/entity/EntityRegistry';
 import { GenericEntityProperties } from '@app/entity/shared/types';
 
-import { Entity, EntityType } from '@types';
+import { EntityType } from '@types';
 
 export const ROOT_NODES = 'rootNodes';
 export const ROOT_TERMS = 'rootTerms';
@@ -26,9 +25,4 @@ export function updateGlossarySidebar(
     setUrnsToUpdate: (updatdUrns: string[]) => void,
 ) {
     setUrnsToUpdate([...urnsToUpdate, ...parentNodesToUpdate]);
-}
-
-export function getParentGlossary<T extends Entity>(node: T, entityRegistry: EntityRegistry) {
-    const props = entityRegistry.getGenericEntityProperties(EntityType.GlossaryNode, node);
-    return props?.parentNodes?.nodes ?? [];
 }


### PR DESCRIPTION
Port the SaaS-side changes under datahub-web-react/src/app/glossary so the OSS -> SaaS auto-merge has nothing left to conflict over in this directory.

- Add unit tests for getGlossaryRootToUpdate and getParentNodeToUpdate.
- Drop getParentGlossary along with the EntityRegistry / Entity imports it needed; it has no callers in either repo.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the SaaS-side changes under `datahub-web-react/src/app/glossary` so the OSS → SaaS auto-merge has nothing left to conflict over in this directory.

- Adds unit tests for `getGlossaryRootToUpdate` and `getParentNodeToUpdate`.
- Removes `getParentGlossary` and the `EntityRegistry` / `Entity` imports it needed; it has no callers.

<sup>Written for commit 9767d47146ec4b41c75035ffbda2788cd051219c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

