### PR TITLE
refactor(ui): consolidate app/applications with the SaaS fork

### DIFF
--- a/datahub-web-react/src/app/applications/ManageApplications.tsx
+++ b/datahub-web-react/src/app/applications/ManageApplications.tsx
@@ -1,4 +1,4 @@
-import { Button, PageTitle, Pagination, SearchBar, StructuredPopover } from '@components';
+import { Button, PageTitle, Pagination, SearchBar, StructuredPopover, Text } from '@components';
 import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -53,32 +53,41 @@ const LoadingBar = styled.div`
     }
 `;
 
-const PAGE_SIZE = 10;
+const DEFAULT_PAGE_SIZE = 10;
+const MIN_SEARCH_LENGTH = 3;
 
 const ManageApplications = () => {
     const { t } = useTranslation('misc');
     const isShowNavBarRedesign = useShowNavBarRedesign();
     const [searchQuery, setSearchQuery] = useState('');
     const [currentPage, setCurrentPage] = useState(1);
-    const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('*');
+    const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+    const [debouncedSearchQuery, setDebouncedSearchQuery] = useState('');
     const [showCreateApplicationModal, setShowCreateApplicationModal] = useState(false);
 
     const userContext = useUserContext();
     const canManageApplications = userContext?.platformPrivileges?.manageApplications;
 
-    useDebounce(() => setDebouncedSearchQuery(searchQuery), DEBOUNCE_SEARCH_MS, [searchQuery]);
+    useDebounce(
+        () => {
+            setDebouncedSearchQuery(searchQuery);
+            setCurrentPage(1);
+        },
+        DEBOUNCE_SEARCH_MS,
+        [searchQuery],
+    );
 
     // Search query configuration
     const searchInputs = useMemo(
         () => ({
             types: [EntityType.Application],
-            query: debouncedSearchQuery,
-            start: (currentPage - 1) * PAGE_SIZE,
-            count: PAGE_SIZE,
+            query: debouncedSearchQuery.length >= MIN_SEARCH_LENGTH ? debouncedSearchQuery : '',
+            start: (currentPage - 1) * pageSize,
+            count: pageSize,
             filters: [],
             searchFlags: { skipCache: true },
         }),
-        [currentPage, debouncedSearchQuery],
+        [currentPage, pageSize, debouncedSearchQuery],
     );
 
     const {
@@ -148,10 +157,15 @@ const ManageApplications = () => {
                     data-testid="application-search-input"
                     width="280px"
                 />
+                {searchQuery.length > 0 && searchQuery.length < MIN_SEARCH_LENGTH && (
+                    <Text size="xs" color="gray" style={{ marginTop: '4px' }}>
+                        {t('applications.searchMinCharsHint', { minLength: MIN_SEARCH_LENGTH })}
+                    </Text>
+                )}
             </SearchContainer>
 
             {!searchLoading && totalApplications === 0 ? (
-                <EmptyApplications isEmptySearch={debouncedSearchQuery.length > 0} />
+                <EmptyApplications isEmptySearch={searchQuery.length > 0} />
             ) : (
                 <>
                     <ApplicationsTable
@@ -163,10 +177,18 @@ const ManageApplications = () => {
                     />
                     <Pagination
                         currentPage={currentPage}
-                        itemsPerPage={PAGE_SIZE}
+                        itemsPerPage={pageSize}
                         total={totalApplications}
                         loading={searchLoading}
-                        onPageChange={(page) => setCurrentPage(page)}
+                        onPageChange={(page, newPageSize) => {
+                            setCurrentPage(page);
+                            if (newPageSize && newPageSize !== pageSize) {
+                                setPageSize(newPageSize);
+                                setCurrentPage(1);
+                            }
+                        }}
+                        showSizeChanger
+                        pageSizeOptions={[10, 20, 50, 100]}
                     />
                 </>
             )}

--- a/datahub-web-react/src/i18n/locales/de/misc.json
+++ b/datahub-web-react/src/i18n/locales/de/misc.json
@@ -22,6 +22,7 @@
     "applications.noCreatePermissionTooltip": "Du hast keine Berechtigung, Anwendungen zu erstellen",
     "applications.pageSubtitle": "Anwendungen erstellen und bearbeiten",
     "applications.pageTitle": "Anwendungen verwalten",
+    "applications.searchMinCharsHint": "Gib mindestens {{minLength}} Zeichen ein, um zu suchen",
     "applications.searchPlaceholder": "Anwendungen suchen...",
     "authorization.unauthorizedSubtitle": "Leider bist du nicht berechtigt, auf diese Seite zuzugreifen.",
     "authorization.unauthorizedTitle": "Nicht autorisiert",

--- a/datahub-web-react/src/i18n/locales/en/misc.json
+++ b/datahub-web-react/src/i18n/locales/en/misc.json
@@ -22,6 +22,7 @@
     "applications.noCreatePermissionTooltip": "You do not have permission to create applications",
     "applications.pageSubtitle": "Create and edit applications",
     "applications.pageTitle": "Manage Applications",
+    "applications.searchMinCharsHint": "Enter at least {{minLength}} characters to search",
     "applications.searchPlaceholder": "Search applications...",
     "authorization.unauthorizedSubtitle": "Sorry, you are not authorized to access this page.",
     "authorization.unauthorizedTitle": "Unauthorized",

--- a/datahub-web-react/src/i18n/locales/es/misc.json
+++ b/datahub-web-react/src/i18n/locales/es/misc.json
@@ -22,6 +22,7 @@
     "applications.noCreatePermissionTooltip": "No tiene permiso para crear aplicaciones",
     "applications.pageSubtitle": "Crear y editar aplicaciones",
     "applications.pageTitle": "Gestionar aplicaciones",
+    "applications.searchMinCharsHint": "Introduzca al menos {{minLength}} caracteres para buscar",
     "applications.searchPlaceholder": "Buscar aplicaciones...",
     "authorization.unauthorizedSubtitle": "Lo sentimos, no está autorizado para acceder a esta página.",
     "authorization.unauthorizedTitle": "No autorizado",

--- a/datahub-web-react/src/i18n/locales/fi/misc.json
+++ b/datahub-web-react/src/i18n/locales/fi/misc.json
@@ -22,6 +22,7 @@
     "applications.noCreatePermissionTooltip": "Sinulla ei ole käyttöoikeutta luoda sovelluksia",
     "applications.pageSubtitle": "Luo ja muokkaa sovelluksia",
     "applications.pageTitle": "Hallitse sovelluksia",
+    "applications.searchMinCharsHint": "Anna vähintään {{minLength}} merkkiä hakeaksesi",
     "applications.searchPlaceholder": "Hae sovelluksia...",
     "authorization.unauthorizedSubtitle": "Valitettavasti sinulla ei ole oikeutta käyttää tätä sivua.",
     "authorization.unauthorizedTitle": "Ei käyttöoikeutta",

--- a/datahub-web-react/src/i18n/locales/fr/misc.json
+++ b/datahub-web-react/src/i18n/locales/fr/misc.json
@@ -22,6 +22,7 @@
     "applications.noCreatePermissionTooltip": "Vous n'avez pas l'autorisation de créer des applications",
     "applications.pageSubtitle": "Créer et modifier des applications",
     "applications.pageTitle": "Gérer les applications",
+    "applications.searchMinCharsHint": "Saisir au moins {{minLength}} caractères pour rechercher",
     "applications.searchPlaceholder": "Rechercher des applications...",
     "authorization.unauthorizedSubtitle": "Désolé, vous n'êtes pas autorisé à accéder à cette page.",
     "authorization.unauthorizedTitle": "Non autorisé",

--- a/datahub-web-react/src/i18n/locales/hu/misc.json
+++ b/datahub-web-react/src/i18n/locales/hu/misc.json
@@ -22,6 +22,7 @@
     "applications.noCreatePermissionTooltip": "Nincs jogosultsága alkalmazások létrehozására",
     "applications.pageSubtitle": "Alkalmazások létrehozása és szerkesztése",
     "applications.pageTitle": "Alkalmazások kezelése",
+    "applications.searchMinCharsHint": "A kereséshez adjon meg legalább {{minLength}} karaktert",
     "applications.searchPlaceholder": "Alkalmazások keresése...",
     "authorization.unauthorizedSubtitle": "Sajnáljuk, nincs jogosultsága az oldal megtekintéséhez.",
     "authorization.unauthorizedTitle": "Nincs jogosultság",

--- a/datahub-web-react/src/i18n/locales/it/misc.json
+++ b/datahub-web-react/src/i18n/locales/it/misc.json
@@ -22,6 +22,7 @@
     "applications.noCreatePermissionTooltip": "Non dispone dell'autorizzazione per creare applicazioni",
     "applications.pageSubtitle": "Crea e modifica le applicazioni",
     "applications.pageTitle": "Gestisci applicazioni",
+    "applications.searchMinCharsHint": "Inserisci almeno {{minLength}} caratteri per la ricerca",
     "applications.searchPlaceholder": "Cerca applicazioni...",
     "authorization.unauthorizedSubtitle": "Spiacenti, l'accesso a questa pagina non è autorizzato.",
     "authorization.unauthorizedTitle": "Non autorizzato",

--- a/datahub-web-react/src/i18n/locales/ja/misc.json
+++ b/datahub-web-react/src/i18n/locales/ja/misc.json
@@ -22,6 +22,7 @@
     "applications.noCreatePermissionTooltip": "Applicationを作成する権限がありません",
     "applications.pageSubtitle": "Applicationを作成・編集します",
     "applications.pageTitle": "Applicationを管理",
+    "applications.searchMinCharsHint": "検索するには少なくとも{{minLength}}文字を入力してください",
     "applications.searchPlaceholder": "Applicationを検索...",
     "authorization.unauthorizedSubtitle": "このページにアクセスする権限がありません。",
     "authorization.unauthorizedTitle": "権限がありません",

--- a/datahub-web-react/src/i18n/locales/nb/misc.json
+++ b/datahub-web-react/src/i18n/locales/nb/misc.json
@@ -22,6 +22,7 @@
     "applications.noCreatePermissionTooltip": "Du har ikke tillatelse til å opprette applikasjoner",
     "applications.pageSubtitle": "Opprett og rediger applikasjoner",
     "applications.pageTitle": "Administrer applikasjoner",
+    "applications.searchMinCharsHint": "Skriv inn minst {{minLength}} tegn for å søke",
     "applications.searchPlaceholder": "Søk i applikasjoner...",
     "authorization.unauthorizedSubtitle": "Beklager, du har ikke tilgang til denne siden.",
     "authorization.unauthorizedTitle": "Ikke autorisert",

--- a/datahub-web-react/src/i18n/locales/pt-BR/misc.json
+++ b/datahub-web-react/src/i18n/locales/pt-BR/misc.json
@@ -22,6 +22,7 @@
     "applications.noCreatePermissionTooltip": "Você não tem permissão para criar aplicações",
     "applications.pageSubtitle": "Criar e editar aplicações",
     "applications.pageTitle": "Gerenciar Aplicações",
+    "applications.searchMinCharsHint": "Digite pelo menos {{minLength}} caracteres para pesquisar",
     "applications.searchPlaceholder": "Pesquisar aplicações...",
     "authorization.unauthorizedSubtitle": "Desculpe, você não tem autorização para acessar esta página.",
     "authorization.unauthorizedTitle": "Não Autorizado",

--- a/datahub-web-react/src/i18n/locales/sv/misc.json
+++ b/datahub-web-react/src/i18n/locales/sv/misc.json
@@ -22,6 +22,7 @@
     "applications.noCreatePermissionTooltip": "Du har inte behörighet att skapa applikationer",
     "applications.pageSubtitle": "Skapa och redigera applikationer",
     "applications.pageTitle": "Hantera applikationer",
+    "applications.searchMinCharsHint": "Ange minst {{minLength}} tecken för att söka",
     "applications.searchPlaceholder": "Sök applikationer...",
     "authorization.unauthorizedSubtitle": "Du har tyvärr inte behörighet att komma åt den här sidan.",
     "authorization.unauthorizedTitle": "Obehörig",


### PR DESCRIPTION
Port the non-SaaS-specific edits the Acryl fork accumulated under src/app/applications, so the OSS -> SaaS auto-merge has less to reconcile.

The one diverging file, ManageApplications, had picked up two unrelated fork commits that overlapped in a single hunk: server-side search and pagination fixes, and the Ask DataHub sidebar. Only the former is ported.

ManageApplications:
- hold the page size in state instead of a PAGE_SIZE constant, and let Pagination change it (showSizeChanger, pageSizeOptions 10/20/50/100). The alchemy Pagination already extends antd's props and already passed pageSize to onPageChange, so nothing under alchemy-components had to move for this.
- reset to the first page when the debounced query changes. Typing a new search while on page 3 was requesting offset 20 of the new result set, so a search with fewer than 21 matches came back empty.
- require three characters before searching, and hint as much under the search bar while fewer are typed. Below that the query goes out empty, which is match-all, so the table keeps showing everything.
- take isEmptySearch from the live query rather than the debounced one, so the empty state describes what the user has typed and not what was last sent.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the non-SaaS-specific changes from the Acryl fork's `src/app/applications` back into OSS, so the OSS → SaaS auto-merge reconciles less. `ManageApplications` picks up server-side search and pagination fixes; the fork's SaaS-only Ask DataHub sidebar is left out.

**Refactors**
- Page size moved from a fixed constant to state, switchable via the pagination control (10/20/50/100).
- Search resets to the first page when the query changes, avoiding out-of-range offsets on a new result set.
- Queries under three characters aren't sent and show a hint under the search bar.
- Empty state uses the live query instead of the debounced one.
- The fork's Ask DataHub sidebar and chat wrapper are not ported; `app/chat` doesn't exist in OSS.
- Adds the `applications.searchMinCharsHint` key to the misc locale in 11 languages; zh-CN falls back to English.

<sup>Written for commit 7fd6cde76e677db995e226486e434b60e65b14dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

