### PR TITLE
refactor(ui): consolidate app/browse with the SaaS fork

### DIFF
--- a/datahub-web-react/src/app/browse/LegacyBrowsePath.tsx
+++ b/datahub-web-react/src/app/browse/LegacyBrowsePath.tsx
@@ -26,22 +26,22 @@ const LineageIconGroup = styled.div`
     justify-content: space-between;
 `;
 
-const HoverableVscPreview = styled(({ isSelected: _, ...props }: IconBaseProps & { isSelected: boolean }) => (
+const HoverableVscPreview = styled(({ $isSelected: _, ...props }: IconBaseProps & { $isSelected: boolean }) => (
     <VscPreview {...props} />
 ))`
-    color: ${(props) => (props.isSelected ? props.theme.colors.text : props.theme.colors.textTertiary)};
+    color: ${(props) => (props.$isSelected ? props.theme.colors.text : props.theme.colors.textTertiary)};
     &:hover {
-        color: ${(props) => (props.isSelected ? props.theme.colors.text : props.theme.colors.textBrand)};
+        color: ${(props) => (props.$isSelected ? props.theme.colors.text : props.theme.colors.textBrand)};
         cursor: pointer;
     }
 `;
 
-const HoverableVscRepoForked = styled(({ isSelected: _, ...props }: IconBaseProps & { isSelected: boolean }) => (
+const HoverableVscRepoForked = styled(({ $isSelected: _, ...props }: IconBaseProps & { $isSelected: boolean }) => (
     <VscRepoForked {...props} />
 ))`
-    color: ${(props) => (props.isSelected ? props.theme.colors.text : props.theme.colors.textTertiary)};
+    color: ${(props) => (props.$isSelected ? props.theme.colors.text : props.theme.colors.textTertiary)};
     &:hover {
-        color: ${(props) => (props.isSelected ? props.theme.colors.text : props.theme.colors.textBrand)};
+        color: ${(props) => (props.$isSelected ? props.theme.colors.text : props.theme.colors.textBrand)};
         cursor: pointer;
     }
     transform: rotate(90deg);
@@ -95,13 +95,13 @@ export const LegacyBrowsePath = ({ type, path, lineageSupported, isProfilePage, 
             {lineageSupported && (
                 <LineageIconGroup>
                     <HoverableVscPreview
-                        isSelected={!isLineageMode}
+                        $isSelected={!isLineageMode}
                         size={26}
                         onClick={() => navigateToLineageUrl({ location, history, isLineageMode: false })}
                     />
                     <HoverableVscRepoForked
                         size={26}
-                        isSelected={isLineageMode}
+                        $isSelected={isLineageMode}
                         onClick={() => navigateToLineageUrl({ location, history, isLineageMode: true })}
                     />
                 </LineageIconGroup>


### PR DESCRIPTION
Port the non-SaaS-specific edits the Acryl fork accumulated under src/app/browse, so the OSS -> SaaS auto-merge has less to reconcile.

Only LegacyBrowsePath diverged, and only by a single fork commit that renamed the styled-components prop on the two hoverable lineage icons:

- LegacyBrowsePath: rename isSelected to $isSelected on HoverableVscPreview and HoverableVscRepoForked - the wrapper parameter, the prop type, the four color interpolations and both call sites. Both wrappers already destructured the prop out before spreading the rest onto the underlying icon, so no unknown attribute was reaching the DOM and behaviour is unchanged; this only brings the file in line with the transient-prop convention used across src (43 declarations over 27 other files).

The other four files under app/browse were already identical to the fork, and the directory now matches it byte for byte, so there is nothing to carry back in the other direction.

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames `isSelected` to `$isSelected` on the two hoverable lineage icons in `LegacyBrowsePath.tsx` to match the transient-prop convention used across `src` and bring the file in line with the Acryl SaaS fork, reducing OSS → SaaS auto-merge reconciliation.

Behavior is unchanged: the prop was already destructured before spreading onto the underlying icon, so no unknown attribute reaches the DOM. The other files under `app/browse` were already identical to the fork.

<sup>Written for commit 6e0064dc11212d0110449d265d673f573389e87c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

