### PR TITLE
fix(analytics): emit numeric date ranges and boolean terms for ES8

### DIFF
--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsService.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsService.java
@@ -461,7 +461,7 @@ public class AnalyticsService {
             .toArray(KeyedFilter[]::new);
     KeyedFilter[] facetFilters =
         facetFields.stream()
-            .map(field -> new KeyedFilter(field, QueryBuilders.termsQuery(field, TRUE)))
+            .map(field -> new KeyedFilter(field, termsQuery(field, List.of(TRUE))))
             .toArray(KeyedFilter[]::new);
 
     AggregationBuilder byEntityAgg = AggregationBuilders.filters(BY_ENTITY, entityFilters);
@@ -548,22 +548,20 @@ public class AnalyticsService {
       // extract results, validated against document model as well
       return searchResponse.getAggregations().<Filter>get(FILTERED);
     } catch (Exception e) {
-      log.error(String.format("Search query failed: %s", e.getMessage()));
+      log.error("Search query failed", e);
       throw new RuntimeException("Search query failed:", e);
     }
   }
 
-  // Make dateRangeField as customizable
-  private AggregationBuilder getFilteredAggregation(
+  AggregationBuilder getFilteredAggregation(
       Map<String, List<String>> mustFilters,
       Map<String, List<String>> mustNotFilters,
       Optional<DateRange> dateRange,
       String dateRangeField) {
     BoolQueryBuilder filteredQuery = QueryBuilders.boolQuery();
     filteredQuery.filter(getDefaultFilters());
-    mustFilters.forEach((key, values) -> filteredQuery.must(QueryBuilders.termsQuery(key, values)));
-    mustNotFilters.forEach(
-        (key, values) -> filteredQuery.mustNot(QueryBuilders.termsQuery(key, values)));
+    mustFilters.forEach((key, values) -> filteredQuery.must(termsQuery(key, values)));
+    mustNotFilters.forEach((key, values) -> filteredQuery.mustNot(termsQuery(key, values)));
     dateRange.ifPresent(range -> filteredQuery.must(dateRangeQuery(range, dateRangeField)));
     return AggregationBuilders.filter(FILTERED, filteredQuery);
   }
@@ -572,28 +570,54 @@ public class AnalyticsService {
       Map<String, List<String>> mustFilters,
       Map<String, List<String>> mustNotFilters,
       Optional<DateRange> dateRange) {
-    // Use timestamp as dateRangeField
     return getFilteredAggregation(mustFilters, mustNotFilters, dateRange, "timestamp");
   }
 
-  private QueryBuilder getDefaultFilters() {
+  QueryBuilder getDefaultFilters() {
     return QueryBuilders.boolQuery()
         .mustNot(
             QueryBuilders.termQuery(
-                DataHubUsageEventConstants.USAGE_SOURCE,
+                DataHubUsageEventConstants.USAGE_SOURCE + ".keyword",
                 DataHubUsageEventConstants.BACKEND_SOURCE));
   }
 
-  private QueryBuilder dateRangeQuery(DateRange dateRange) {
-    // Use timestamp as dateRangeField
+  QueryBuilder dateRangeQuery(DateRange dateRange) {
     return dateRangeQuery(dateRange, "timestamp");
   }
 
-  // Make dateRangeField as customizable
-  private QueryBuilder dateRangeQuery(DateRange dateRange, String dateRangeField) {
+  QueryBuilder dateRangeQuery(DateRange dateRange, String dateRangeField) {
     return QueryBuilders.rangeQuery(dateRangeField)
-        .gte(dateRange.getStart())
-        .lt(dateRange.getEnd());
+        .gte(parseEpochMillis(dateRange.getStart(), dateRangeField, "start"))
+        .lt(parseEpochMillis(dateRange.getEnd(), dateRangeField, "end"));
+  }
+
+  static QueryBuilder termsQuery(String field, List<String> values) {
+    return QueryBuilders.termsQuery(field, coerceTermValues(values));
+  }
+
+  static Object[] coerceTermValues(List<String> values) {
+    if (values != null
+        && !values.isEmpty()
+        && values.stream().allMatch(AnalyticsService::isBooleanString)) {
+      return values.stream().map(Boolean::parseBoolean).toArray();
+    }
+    return values == null ? new Object[0] : values.toArray(new String[0]);
+  }
+
+  private static boolean isBooleanString(String value) {
+    return "true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value);
+  }
+
+  private static long parseEpochMillis(String value, String dateRangeField, String bound) {
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Analytics DateRange %s for field %s must be epoch millis, got: %s",
+              bound, dateRangeField, value),
+          e);
+    }
   }
 
   private AggregationBuilder getUniqueQuery(String uniqueOn) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsService.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsService.java
@@ -612,16 +612,34 @@ public class AnalyticsService {
     return values.toArray(new String[0]);
   }
 
-  private Set<String> booleanSearchFields;
+  /**
+   * Plugin patches mutate the live {@link EntityRegistry} in place (new {@link EntitySpec}
+   * instances), so this snapshot is keyed by spec identity rather than built once.
+   */
+  private record BooleanFieldSnapshot(long generation, Set<String> fields) {}
+
+  private volatile BooleanFieldSnapshot booleanFieldSnapshot;
 
   private boolean isBooleanSearchField(String field) {
     return booleanSearchFields().contains(field.split("\\.")[0]);
   }
 
   private Set<String> booleanSearchFields() {
-    if (booleanSearchFields == null) {
+    Map<String, EntitySpec> specs = _entityRegistry.getEntitySpecs();
+    long generation = registryGeneration(specs);
+    BooleanFieldSnapshot snapshot = booleanFieldSnapshot;
+    if (snapshot != null && snapshot.generation() == generation) {
+      return snapshot.fields();
+    }
+    synchronized (this) {
+      specs = _entityRegistry.getEntitySpecs();
+      generation = registryGeneration(specs);
+      snapshot = booleanFieldSnapshot;
+      if (snapshot != null && snapshot.generation() == generation) {
+        return snapshot.fields();
+      }
       Set<String> fields = new HashSet<>();
-      for (EntitySpec entitySpec : _entityRegistry.getEntitySpecs().values()) {
+      for (EntitySpec entitySpec : specs.values()) {
         for (Map.Entry<String, Set<SearchableAnnotation.FieldType>> entry :
             entitySpec.getSearchableFieldTypes().entrySet()) {
           if (entry.getValue().contains(SearchableAnnotation.FieldType.BOOLEAN)) {
@@ -629,9 +647,18 @@ public class AnalyticsService {
           }
         }
       }
-      booleanSearchFields = Set.copyOf(fields);
+      Set<String> frozen = Set.copyOf(fields);
+      booleanFieldSnapshot = new BooleanFieldSnapshot(generation, frozen);
+      return frozen;
     }
-    return booleanSearchFields;
+  }
+
+  private static long registryGeneration(Map<String, EntitySpec> specs) {
+    long generation = specs.size();
+    for (EntitySpec spec : specs.values()) {
+      generation = 31 * generation + System.identityHashCode(spec);
+    }
+    return generation;
   }
 
   private static boolean parseBooleanTerm(String value) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsService.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsService.java
@@ -21,6 +21,9 @@ import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import io.datahubproject.metadata.context.OperationContext;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -74,6 +77,7 @@ public class AnalyticsService {
   private static final String INDEX_FIELD = "_index";
   private static final String REMOVED = "removed";
   private static final String TRUE = "true";
+  private static final Duration BOOLEAN_FIELD_CACHE_TTL = Duration.ofMinutes(5);
 
   public static final String NA = "N/A";
 
@@ -613,11 +617,16 @@ public class AnalyticsService {
   }
 
   /**
-   * Plugin patches mutate the live {@link EntityRegistry} in place (new {@link EntitySpec}
-   * instances), so this snapshot is keyed by spec identity rather than built once.
+   * Plugin patches mutate the live {@link EntityRegistry} in place. Readers keep an immutable field
+   * set and replace the whole snapshot after a TTL so the hot path never iterates the registry map.
    */
-  private record BooleanFieldSnapshot(long generation, Set<String> fields) {}
+  private record BooleanFieldSnapshot(Instant expiresAt, Set<String> fields) {
+    boolean isFresh(Instant now) {
+      return now.isBefore(expiresAt);
+    }
+  }
 
+  private final Clock clock = Clock.systemUTC();
   private volatile BooleanFieldSnapshot booleanFieldSnapshot;
 
   private boolean isBooleanSearchField(String field) {
@@ -625,40 +634,39 @@ public class AnalyticsService {
   }
 
   private Set<String> booleanSearchFields() {
-    Map<String, EntitySpec> specs = _entityRegistry.getEntitySpecs();
-    long generation = registryGeneration(specs);
+    Instant now = clock.instant();
     BooleanFieldSnapshot snapshot = booleanFieldSnapshot;
-    if (snapshot != null && snapshot.generation() == generation) {
+    if (snapshot != null && snapshot.isFresh(now)) {
       return snapshot.fields();
     }
     synchronized (this) {
-      specs = _entityRegistry.getEntitySpecs();
-      generation = registryGeneration(specs);
+      now = clock.instant();
       snapshot = booleanFieldSnapshot;
-      if (snapshot != null && snapshot.generation() == generation) {
+      if (snapshot != null && snapshot.isFresh(now)) {
         return snapshot.fields();
       }
-      Set<String> fields = new HashSet<>();
-      for (EntitySpec entitySpec : specs.values()) {
-        for (Map.Entry<String, Set<SearchableAnnotation.FieldType>> entry :
-            entitySpec.getSearchableFieldTypes().entrySet()) {
-          if (entry.getValue().contains(SearchableAnnotation.FieldType.BOOLEAN)) {
-            fields.add(entry.getKey());
-          }
-        }
-      }
-      Set<String> frozen = Set.copyOf(fields);
-      booleanFieldSnapshot = new BooleanFieldSnapshot(generation, frozen);
+      Set<String> frozen = collectBooleanSearchFields();
+      booleanFieldSnapshot = new BooleanFieldSnapshot(now.plus(BOOLEAN_FIELD_CACHE_TTL), frozen);
       return frozen;
     }
   }
 
-  private static long registryGeneration(Map<String, EntitySpec> specs) {
-    long generation = specs.size();
-    for (EntitySpec spec : specs.values()) {
-      generation = 31 * generation + System.identityHashCode(spec);
+  private Set<String> collectBooleanSearchFields() {
+    Set<String> fields = new HashSet<>();
+    for (EntitySpec entitySpec : _entityRegistry.getEntitySpecs().values()) {
+      for (Map.Entry<String, Set<SearchableAnnotation.FieldType>> entry :
+          entitySpec.getSearchableFieldTypes().entrySet()) {
+        if (entry.getValue().contains(SearchableAnnotation.FieldType.BOOLEAN)) {
+          fields.add(entry.getKey());
+        }
+      }
     }
-    return generation;
+    return Set.copyOf(fields);
+  }
+
+  @VisibleForTesting
+  void expireBooleanFieldCache() {
+    booleanFieldSnapshot = null;
   }
 
   private static boolean parseBooleanTerm(String value) {

--- a/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsService.java
+++ b/datahub-graphql-core/src/main/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsService.java
@@ -14,15 +14,20 @@ import com.linkedin.datahub.graphql.generated.NumericDataPoint;
 import com.linkedin.datahub.graphql.generated.Row;
 import com.linkedin.datahub.graphql.types.entitytype.EntityTypeMapper;
 import com.linkedin.metadata.datahubusage.DataHubUsageEventConstants;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.annotation.SearchableAnnotation;
+import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import io.datahubproject.metadata.context.OperationContext;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -56,6 +61,7 @@ public class AnalyticsService {
 
   private final SearchClientShim<?> _elasticClient;
   private final IndexConvention _indexConvention;
+  private final EntityRegistry _entityRegistry;
 
   private static final String FILTERED = "filtered";
   private static final String DATE_HISTOGRAM = "date_histogram";
@@ -68,6 +74,7 @@ public class AnalyticsService {
   private static final String INDEX_FIELD = "_index";
   private static final String REMOVED = "removed";
   private static final String TRUE = "true";
+
   public static final String NA = "N/A";
 
   public static final String DATAHUB_USAGE_EVENT_INDEX = "datahub_usage_event";
@@ -591,21 +598,51 @@ public class AnalyticsService {
         .lt(parseEpochMillis(dateRange.getEnd(), dateRangeField, "end"));
   }
 
-  static QueryBuilder termsQuery(String field, List<String> values) {
-    return QueryBuilders.termsQuery(field, coerceTermValues(values));
+  QueryBuilder termsQuery(String field, List<String> values) {
+    return QueryBuilders.termsQuery(field, coerceTermValues(field, values));
   }
 
-  static Object[] coerceTermValues(List<String> values) {
-    if (values != null
-        && !values.isEmpty()
-        && values.stream().allMatch(AnalyticsService::isBooleanString)) {
-      return values.stream().map(Boolean::parseBoolean).toArray();
+  Object[] coerceTermValues(String field, List<String> values) {
+    if (values == null || values.isEmpty()) {
+      return new Object[0];
     }
-    return values == null ? new Object[0] : values.toArray(new String[0]);
+    if (isBooleanSearchField(field)) {
+      return values.stream().map(AnalyticsService::parseBooleanTerm).toArray();
+    }
+    return values.toArray(new String[0]);
   }
 
-  private static boolean isBooleanString(String value) {
-    return "true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value);
+  private Set<String> booleanSearchFields;
+
+  private boolean isBooleanSearchField(String field) {
+    return booleanSearchFields().contains(field.split("\\.")[0]);
+  }
+
+  private Set<String> booleanSearchFields() {
+    if (booleanSearchFields == null) {
+      Set<String> fields = new HashSet<>();
+      for (EntitySpec entitySpec : _entityRegistry.getEntitySpecs().values()) {
+        for (Map.Entry<String, Set<SearchableAnnotation.FieldType>> entry :
+            entitySpec.getSearchableFieldTypes().entrySet()) {
+          if (entry.getValue().contains(SearchableAnnotation.FieldType.BOOLEAN)) {
+            fields.add(entry.getKey());
+          }
+        }
+      }
+      booleanSearchFields = Set.copyOf(fields);
+    }
+    return booleanSearchFields;
+  }
+
+  private static boolean parseBooleanTerm(String value) {
+    if ("true".equalsIgnoreCase(value)) {
+      return true;
+    }
+    if ("false".equalsIgnoreCase(value)) {
+      return false;
+    }
+    throw new IllegalArgumentException(
+        String.format("Boolean term field expected true/false, got: %s", value));
   }
 
   private static long parseEpochMillis(String value, String dateRangeField, String bound) {

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsServiceTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsServiceTest.java
@@ -17,11 +17,15 @@ import com.google.common.collect.ImmutableMap;
 import com.linkedin.datahub.graphql.generated.DateRange;
 import com.linkedin.datahub.graphql.generated.EntityType;
 import com.linkedin.metadata.datahubusage.DataHubUsageEventConstants;
+import com.linkedin.metadata.models.EntitySpec;
+import com.linkedin.metadata.models.annotation.SearchableAnnotation;
+import com.linkedin.metadata.models.registry.EntityRegistry;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +51,7 @@ public class AnalyticsServiceTest {
   private static final List<String> FACETS = List.of("hasOwners", "hasTags");
 
   private SearchClientShim<?> mockClient;
+  private IndexConvention mockIndexConvention;
   private OperationContext opContext;
   private AnalyticsService service;
 
@@ -57,7 +62,7 @@ public class AnalyticsServiceTest {
     // opContext.withSpan, which a bare mock would swallow without invoking.
     opContext = TestOperationContexts.systemContextNoSearchAuthorization();
 
-    IndexConvention mockIndexConvention = mock(IndexConvention.class);
+    mockIndexConvention = mock(IndexConvention.class);
     when(mockIndexConvention.getEntityIndexName(any(OperationFingerprint.class), any()))
         .thenAnswer(invocation -> invocation.getArgument(1).toString().toLowerCase() + "index_v2");
     when(mockIndexConvention.getIndexName(
@@ -181,6 +186,41 @@ public class AnalyticsServiceTest {
     assertEquals(removed[0], true);
     Object[] hasOwners = service.coerceTermValues("hasOwners", List.of("true"));
     assertEquals(hasOwners[0], true);
+  }
+
+  @Test
+  public void testCoerceTermValuesRejectsInvalidBooleanTerms() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.coerceTermValues("hasOwners", List.of("yes")));
+  }
+
+  @Test
+  public void testBooleanFieldCacheRefreshesWhenRegistrySpecsChange() {
+    EntitySpec initialSpec = mock(EntitySpec.class);
+    when(initialSpec.getSearchableFieldTypes())
+        .thenReturn(Map.of("hasOwners", Set.of(SearchableAnnotation.FieldType.BOOLEAN)));
+    EntitySpec patchedSpec = mock(EntitySpec.class);
+    when(patchedSpec.getSearchableFieldTypes())
+        .thenReturn(
+            Map.of(
+                "hasOwners",
+                Set.of(SearchableAnnotation.FieldType.BOOLEAN),
+                "hasCustomFlag",
+                Set.of(SearchableAnnotation.FieldType.BOOLEAN)));
+
+    Map<String, EntitySpec> specs = new HashMap<>();
+    specs.put("dataset", initialSpec);
+    EntityRegistry registry = mock(EntityRegistry.class);
+    when(registry.getEntitySpecs()).thenReturn(specs);
+
+    AnalyticsService patchedService =
+        new AnalyticsService(mockClient, mockIndexConvention, registry);
+
+    assertEquals(patchedService.coerceTermValues("hasCustomFlag", List.of("true"))[0], "true");
+
+    specs.put("dataset", patchedSpec);
+    assertEquals(patchedService.coerceTermValues("hasCustomFlag", List.of("true"))[0], true);
   }
 
   private static String compactJson(String json) {

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsServiceTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
@@ -15,6 +16,7 @@ import com.datahub.context.OperationFingerprint;
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.datahub.graphql.generated.DateRange;
 import com.linkedin.datahub.graphql.generated.EntityType;
+import com.linkedin.metadata.datahubusage.DataHubUsageEventConstants;
 import com.linkedin.metadata.utils.elasticsearch.IndexConvention;
 import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import io.datahubproject.metadata.context.OperationContext;
@@ -23,6 +25,7 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.opensearch.action.search.SearchRequest;
@@ -110,9 +113,63 @@ public class AnalyticsServiceTest {
     // The cardinality metric hangs off the range buckets rather than off separate queries.
     assertNotNull(subAggByName(byRange, "unique"));
 
-    String source = request.source().toString();
+    String source = compactJson(request.source().toString());
     assertTrue(source.contains(BROWSER_ID), "expected cardinality on browserId");
     assertTrue(source.contains("\"size\":0"), "aggregation-only request should fetch no hits");
+    assertTrue(source.contains("\"gte\":100") || source.contains("\"from\":100"));
+    assertFalse(source.contains("\"gte\":\"100\""));
+  }
+
+  @Test
+  public void testDateRangeQuerySerializesNumericEpochMillis() {
+    String json =
+        compactJson(service.dateRangeQuery(new DateRange("100", "200"), "timestamp").toString());
+
+    assertFalse(json.contains("\"gte\":\"100\""));
+    assertFalse(json.contains("\"lt\":\"200\""));
+    assertTrue(json.contains("\"gte\":100") || json.contains("\"from\":100"));
+    assertTrue(json.contains("\"lt\":200") || json.contains("\"to\":200"));
+  }
+
+  @Test
+  public void testDateRangeQueryRejectsNonNumericBounds() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> service.dateRangeQuery(new DateRange("not-a-timestamp", "200"), "timestamp"));
+  }
+
+  @Test
+  public void testFilteredAggregationUsesNumericRangeAndKeywordUsageSource() {
+    AggregationBuilder agg =
+        service.getFilteredAggregation(
+            Map.of(), Map.of(), Optional.of(new DateRange("100", "200")), "timestamp");
+    String json = compactJson(agg.toString());
+
+    assertTrue(json.contains("\"gte\":100") || json.contains("\"from\":100"));
+    assertFalse(json.contains("\"gte\":\"100\""));
+    assertTrue(json.contains("\"" + DataHubUsageEventConstants.USAGE_SOURCE + ".keyword\""));
+  }
+
+  @Test
+  public void testCoerceTermValuesConvertsBooleanStrings() {
+    Object[] coerced = AnalyticsService.coerceTermValues(List.of("true", "FALSE"));
+    assertEquals(coerced.length, 2);
+    assertEquals(coerced[0], true);
+    assertEquals(coerced[1], false);
+    assertFalse(
+        AnalyticsService.termsQuery("hasOwners", List.of("true")).toString().contains("\"true\""));
+    assertTrue(
+        AnalyticsService.termsQuery("hasOwners", List.of("true")).toString().contains("true"));
+  }
+
+  @Test
+  public void testCoerceTermValuesLeavesNonBooleanStrings() {
+    Object[] coerced = AnalyticsService.coerceTermValues(List.of("urn:li:corpuser:admin"));
+    assertEquals(coerced[0], "urn:li:corpuser:admin");
+  }
+
+  private static String compactJson(String json) {
+    return json.replaceAll("\\s+", "");
   }
 
   @Test

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsServiceTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsServiceTest.java
@@ -64,7 +64,7 @@ public class AnalyticsServiceTest {
             any(OperationFingerprint.class), eq(AnalyticsService.DATAHUB_USAGE_EVENT_INDEX)))
         .thenReturn(USAGE_INDEX);
 
-    service = new AnalyticsService(mockClient, mockIndexConvention);
+    service = new AnalyticsService(mockClient, mockIndexConvention, opContext.getEntityRegistry());
   }
 
   private Map<String, DateRange> twoRanges() {
@@ -151,21 +151,36 @@ public class AnalyticsServiceTest {
   }
 
   @Test
-  public void testCoerceTermValuesConvertsBooleanStrings() {
-    Object[] coerced = AnalyticsService.coerceTermValues(List.of("true", "FALSE"));
+  public void testCoerceTermValuesConvertsBooleanFields() {
+    Object[] coerced = service.coerceTermValues("hasOwners", List.of("true", "FALSE"));
     assertEquals(coerced.length, 2);
     assertEquals(coerced[0], true);
     assertEquals(coerced[1], false);
-    assertFalse(
-        AnalyticsService.termsQuery("hasOwners", List.of("true")).toString().contains("\"true\""));
-    assertTrue(
-        AnalyticsService.termsQuery("hasOwners", List.of("true")).toString().contains("true"));
+    String json = compactJson(service.termsQuery("hasOwners", List.of("true")).toString());
+    assertFalse(json.contains("\"true\""));
+    assertTrue(json.contains("true"));
   }
 
   @Test
-  public void testCoerceTermValuesLeavesNonBooleanStrings() {
-    Object[] coerced = AnalyticsService.coerceTermValues(List.of("urn:li:corpuser:admin"));
+  public void testCoerceTermValuesLeavesKeywordFieldsAsStrings() {
+    Object[] coerced = service.coerceTermValues("actor.urn", List.of("urn:li:corpuser:admin"));
     assertEquals(coerced[0], "urn:li:corpuser:admin");
+  }
+
+  @Test
+  public void testCoerceTermValuesDoesNotInferBooleanFromValueSpelling() {
+    Object[] coerced = service.coerceTermValues("eventType", List.of("true"));
+    assertEquals(coerced[0], "true");
+    String json = compactJson(service.termsQuery("eventType", List.of("true")).toString());
+    assertTrue(json.contains("\"true\""));
+  }
+
+  @Test
+  public void testCoerceTermValuesUsesEntityRegistryBooleanMapping() {
+    Object[] removed = service.coerceTermValues("removed", List.of("true"));
+    assertEquals(removed[0], true);
+    Object[] hasOwners = service.coerceTermValues("hasOwners", List.of("true"));
+    assertEquals(hasOwners[0], true);
   }
 
   private static String compactJson(String json) {
@@ -209,6 +224,9 @@ public class AnalyticsServiceTest {
     assertTrue(source.contains("\"_index\""), "entity buckets must be scoped by _index");
     assertTrue(source.contains("datasetindex_v2"), "expected the dataset index alias as the term");
     assertTrue(source.contains("hasOwners"), "expected the facet field as a term filter");
+    String compact = compactJson(source);
+    assertTrue(compact.contains("\"hasOwners\":[true]"));
+    assertFalse(compact.contains("\"hasOwners\":[\"true\"]"));
     assertTrue(source.contains("removed"), "soft-deleted entities must be excluded");
   }
 

--- a/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsServiceTest.java
+++ b/datahub-graphql-core/src/test/java/com/linkedin/datahub/graphql/analytics/service/AnalyticsServiceTest.java
@@ -220,6 +220,12 @@ public class AnalyticsServiceTest {
     assertEquals(patchedService.coerceTermValues("hasCustomFlag", List.of("true"))[0], "true");
 
     specs.put("dataset", patchedSpec);
+    assertEquals(
+        patchedService.coerceTermValues("hasCustomFlag", List.of("true"))[0],
+        "true",
+        "TTL-fresh snapshot must not observe a plugin patch immediately");
+
+    patchedService.expireBooleanFieldCache();
     assertEquals(patchedService.coerceTermValues("hasCustomFlag", List.of("true"))[0], true);
   }
 

--- a/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/client/shim/Es8SearchClientShimConversionTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/search/elasticsearch/client/shim/Es8SearchClientShimConversionTest.java
@@ -420,6 +420,37 @@ public class Es8SearchClientShimConversionTest {
     assertTrue(serialized.contains("\"lt\":200"));
   }
 
+  /**
+   * GraphQL DateRange bounds are strings. If they are passed through RangeQueryBuilder unchanged,
+   * ES8 conversion keeps quoted millis, which date-mapped {@code timestamp} fields reject.
+   * Analytics must emit numeric longs instead of relying on the shim.
+   */
+  @Test
+  public void testConvertAggregationsDoesNotCoerceQuotedEpochMillisToNumbers() throws Exception {
+    SearchSourceBuilder source = new SearchSourceBuilder();
+    source.aggregation(
+        AggregationBuilders.filter(
+            "filtered",
+            QueryBuilders.boolQuery()
+                .must(QueryBuilders.rangeQuery("timestamp").gte("100").lt("200"))));
+
+    Method convertAggregationsMethod =
+        Es8SearchClientShim.class.getDeclaredMethod(
+            "convertAggregations", AggregatorFactories.Builder.class);
+    convertAggregationsMethod.setAccessible(true);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Aggregation> aggregations =
+        (Map<String, Aggregation>) convertAggregationsMethod.invoke(shim, source.aggregations());
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    String serialized =
+        JsonpUtils.toJsonString(aggregations.get("filtered"), new JacksonJsonpMapper(objectMapper));
+    assertTrue(serialized.contains("\"gte\":\"100\""));
+    assertTrue(serialized.contains("\"lt\":\"200\""));
+    assertFalse(serialized.contains("\"gte\":100"));
+  }
+
   /** Helper method to invoke the private convertQuery method via reflection. */
   private Query invokeConvertQuery(QueryBuilder queryBuilder) throws Exception {
     Method convertQueryMethod =

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/graphql/GraphQLEngineFactory.java
@@ -277,7 +277,8 @@ public class GraphQLEngineFactory {
             configProvider.getCache().getClient().getUsageClient(),
             metricUtils));
     if (isAnalyticsEnabled) {
-      args.setAnalyticsService(new AnalyticsService(elasticClient, indexConvention));
+      args.setAnalyticsService(
+          new AnalyticsService(elasticClient, indexConvention, entityRegistry));
     }
     args.setEntityService(entityService);
     args.setRecommendationsService(recommendationsService);

--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/telemetry/DailyReport.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/telemetry/DailyReport.java
@@ -133,7 +133,9 @@ public class DailyReport {
   public void dailyReport() {
     AnalyticsService analyticsService =
         new AnalyticsService(
-            _elasticClient, systemOperationContext.getSearchContext().getIndexConvention());
+            _elasticClient,
+            systemOperationContext.getSearchContext().getIndexConvention(),
+            systemOperationContext.getEntityRegistry());
 
     DateTime endDate = DateTime.now();
     DateTime yesterday = endDate.minusDays(1);

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/telemetry/DailyReportTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/telemetry/DailyReportTest.java
@@ -13,6 +13,7 @@ import com.linkedin.metadata.utils.elasticsearch.SearchClientShim;
 import com.linkedin.metadata.version.GitVersion;
 import io.datahubproject.metadata.context.OperationContext;
 import io.datahubproject.metadata.context.SearchContext;
+import io.datahubproject.test.metadata.context.TestOperationContexts;
 import java.util.List;
 import java.util.Map;
 import org.json.JSONObject;
@@ -56,6 +57,8 @@ public class DailyReportTest {
     // Set up the operation context chain
     when(mockOperationContext.getSearchContext()).thenReturn(mockSearchContext);
     when(mockSearchContext.getIndexConvention()).thenReturn(mockIndexConvention);
+    when(mockOperationContext.getEntityRegistry())
+        .thenReturn(TestOperationContexts.defaultEntityRegistry());
     // A distinct index per entity name, mirroring the real convention. AnalyticsService
     // de-duplicates the batch's target indices, so stubbing one shared name for every type would
     // collapse the batch to a single index and hide whether it spans all reported types.
@@ -421,7 +424,10 @@ public class DailyReportTest {
     DailyReport dailyReport = createDailyReportForTesting();
     Map<String, Integer> counts =
         dailyReport.collectEntityCounts(
-            new AnalyticsService(mockElasticClient, mockIndexConvention));
+            new AnalyticsService(
+                mockElasticClient,
+                mockIndexConvention,
+                TestOperationContexts.defaultEntityRegistry()));
 
     org.mockito.ArgumentCaptor<SearchRequest> captor =
         org.mockito.ArgumentCaptor.forClass(SearchRequest.class);
@@ -448,7 +454,10 @@ public class DailyReportTest {
     DailyReport dailyReport = createDailyReportForTesting();
     Map<String, Integer> counts =
         dailyReport.collectEntityCounts(
-            new AnalyticsService(mockElasticClient, mockIndexConvention));
+            new AnalyticsService(
+                mockElasticClient,
+                mockIndexConvention,
+                TestOperationContexts.defaultEntityRegistry()));
 
     assertEquals(counts.size(), 1, "only the non-zero type should be reported");
     assertTrue(counts.containsKey("DATASET"));
@@ -475,7 +484,10 @@ public class DailyReportTest {
     DailyReport dailyReport = createDailyReportForTesting();
     Map<String, Integer> counts =
         dailyReport.collectEntityCounts(
-            new AnalyticsService(mockElasticClient, mockIndexConvention));
+            new AnalyticsService(
+                mockElasticClient,
+                mockIndexConvention,
+                TestOperationContexts.defaultEntityRegistry()));
 
     org.mockito.ArgumentCaptor<SearchRequest> captor =
         org.mockito.ArgumentCaptor.forClass(SearchRequest.class);


### PR DESCRIPTION
## Summary
- GraphQL DateRange bounds are strings; passing them through unchanged produces quoted epoch millis that date-mapped `timestamp` fields reject on ES8. Analytics now parses those bounds as numeric longs.
- Boolean facet filters (e.g. `hasOwners`) are sent as real booleans instead of `"true"`/`"false"` strings, and usage-source exclusion uses the `.keyword` field.
- Tests cover numeric range serialization, term coercion, and that the ES8 shim still does **not** coerce quoted millis (so Analytics must keep emitting numbers).

## Test plan
- [x] `./gradlew :datahub-graphql-core:test --tests com.linkedin.datahub.graphql.analytics.service.AnalyticsServiceTest`
- [x] `./gradlew :metadata-io:test --tests com.linkedin.metadata.search.elasticsearch.client.shim.Es8SearchClientShimConversionTest`
- [ ] Confirm analytics charts still load against ES8 / OpenSearch after merge


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes analytics queries against ES8 so date range bounds are sent as numeric epoch millis instead of quoted strings, and boolean facet filters are sent as real booleans instead of `"true"`/`"false"` strings.

**Bug Fixes**
- Converts `DateRange` start/end strings to longs at query build time; non-numeric bounds now throw an error.
- Coerces term values to booleans only for fields registered as `BOOLEAN` in the entity registry; keyword fields keep string values.
- Caches the boolean field set with a five-minute TTL so plugin patches to the live registry are picked up without scanning it on every query.
- Excludes usage source via the `.keyword` field in the default filter.
- `AnalyticsService` now requires an `EntityRegistry`; `GraphQLEngineFactory` and `DailyReport` pass it in.

<sup>Written for commit cc64ac26b2f77b92d840e4203e4fae1e4b3132b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

