### PR TITLE
ci: skip collect-metrics on forks

### DIFF
--- a/.github/workflows/post-workflow-actions.yml
+++ b/.github/workflows/post-workflow-actions.yml
@@ -75,14 +75,18 @@ permissions:
 
 jobs:
   collect-metrics:
+    # Never on forks: the publish step needs the org's POSTHOG_API_KEY secret, which
+    # forks do not have, so the job fails on every push to every fork otherwise.
     # For push events: only collect metrics for default/release/hotfix branches.
     # All other event types (pull_request, schedule, release, etc.) and workflow_dispatch pass through.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.event != 'push' ||
-      github.event.workflow_run.head_branch == github.event.repository.default_branch ||
-      startsWith(github.event.workflow_run.head_branch, 'releases/') ||
-      startsWith(github.event.workflow_run.head_branch, 'hotfixes/')
+      github.repository_owner == 'datahub-project' && (
+        github.event_name == 'workflow_dispatch' ||
+        github.event.workflow_run.event != 'push' ||
+        github.event.workflow_run.head_branch == github.event.repository.default_branch ||
+        startsWith(github.event.workflow_run.head_branch, 'releases/') ||
+        startsWith(github.event.workflow_run.head_branch, 'hotfixes/')
+      )
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository


### PR DESCRIPTION
### What happens today

`post-workflow-actions.yml` runs on forks too (it is triggered by `workflow_run`, which fires wherever the upstream workflows run). Its `collect-metrics` job filters by event and branch but not by repository, and its publish step needs the org secret `POSTHOG_API_KEY`. Forks do not have that secret, so on every push to every fork the job fails:

```
Publish metrics to PostHog
  POSTHOG_API_KEY:
  Error: POSTHOG_API_KEY environment variable is not set
  ##[error]Process completed with exit code 1.
```

One failed "Post Workflow Actions for <workflow>" run per triggering workflow — a dozen per push — and a notification for each. Example from a fork, one push: https://github.com/NexuChat/datahub/actions/runs/34276832842 (and eleven siblings in the same minute: ingestion smoke, Dagster, GX, Quickstart, OAuth smoke, Agent Context, …).

### Change

One condition added to the job:

```yaml
if: >-
  github.repository_owner == 'datahub-project' && (
    ...existing event/branch conditions...
  )
```

Skipped on forks, unchanged in `datahub-project/datahub`. Nothing else in the workflow is touched.

### Not in this PR

`notify-slack-failure` also relies on org secrets and would fail the same way if a fork's default branch had a failing scheduled or push run; it did not fire in the runs above, so it is left as is. The same one-line guard would apply if that is wanted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips the `collect-metrics` job on forks so the PostHog publish step no longer fails there.

Forks lack the org's `POSTHOG_API_KEY` secret, so every push to a fork produced a failed run and notification for each triggering workflow. The job now checks `github.repository_owner == 'datahub-project'` in addition to its existing event and branch filters; behavior in `datahub-project/datahub` is unchanged.

<sup>Written for commit 7a839ec1f2fa377d869028b2fdc4015440f716b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

