### PR TITLE
docs(managed-datahub): release notes for v2.2.1

### DIFF
--- a/docs/managed-datahub/release-notes/v_2_2_0.md
+++ b/docs/managed-datahub/release-notes/v_2_2_0.md
@@ -12,15 +12,15 @@ This release rolls up hotfixes on top of v2.2.0.
 
 #### Release Availability Date
 
-TBD
+11-SEP-2206
 
 #### Recommended Versions
 
-- **CLI/SDK**: TBD
-- **Remote Executor**: TBD
+- **CLI/SDK**: 1.7.0.5
+- **Remote Executor**: v2.2.1-cloud, v2.2.0-cloud, v2.1.5-cloud, v2.1.4-cloud, v2.1.3-cloud, v2.1.2-cloud, v2.1.1-cloud, v2.1.0-cloud, v2.0.4-cloud, v2.0.3-cloud, v2.0.2-cloud, v2.0.1-cloud
 - **On-Prem Versions**:
-  - **Helm**: TBD
-  - **API Gateway**: TBD
+  - **Helm**: 2.0.35
+  - **API Gateway**: v0.7.3
 
 #### Product
 

--- a/docs/managed-datahub/release-notes/v_2_2_0.md
+++ b/docs/managed-datahub/release-notes/v_2_2_0.md
@@ -12,7 +12,7 @@ This release rolls up hotfixes on top of v2.2.0.
 
 #### Release Availability Date
 
-11-SEP-2206
+11-SEP-2026
 
 #### Recommended Versions
 

--- a/docs/managed-datahub/release-notes/v_2_2_0.md
+++ b/docs/managed-datahub/release-notes/v_2_2_0.md
@@ -31,6 +31,9 @@ TBD
 #### AI / Ask DataHub
 
 - **Agents in chat and on the home page** — agents with **Show in Ask DataHub Chat** enabled are visible to any user who can view metadata, not only users with Manage Agents. Creating, editing, and deleting agents still requires Manage Agents. Unconfigured and Draft agents stay on the management page.
+- **Observation-cluster proposals hidden by default** — Remediation / observation-cluster proposals stay created in the background but are excluded from the Task Center, inbox badge, and review page unless `SHOW_OBSERVATION_CLUSTER_PROPOSALS=true`.
+- **Metadata Gap Reporting Tool** — Settings → AI can disable the `note_metadata_observation` MCP tool at runtime (`mcpSettings.observationToolEnabled`). When off, the tool is omitted from MCP `tools/list`, stale clients record nothing, and chat agents drop gap-reporting instructions. The integrations-service `NOTE_METADATA_OBSERVATION_TOOL` env var remains a deploy-level kill switch ANDed with this setting.
+- **Legacy observation proposals cleaned up on upgrade** — a one-time system-update step (`SYSTEM_UPDATE_REMOVE_LEGACY_OBSERVATION_PROPOSALS_ENABLED`, default on) hard-deletes still-pending ANNOTATE proposals from the retired per-observation path and marks still-pending POST_ATTACHMENT proposals COMPLETED. Human-created document proposals are not touched.
 
 #### Platform
 
@@ -39,6 +42,9 @@ TBD
 - **Entity-consistency system-update** — non-blocking entity-consistency scans log progress and an ETA instead of appearing stuck. See [datahub-project/datahub#19388](https://github.com/datahub-project/datahub/pull/19388).
 - **Data Product membership writes** — large `dataProductProperties` replacements no longer time out on graph unset side effects; asset comparison is by destination URN and graph scrolls are batched. See [datahub-project/datahub#19465](https://github.com/datahub-project/datahub/pull/19465).
 - **Search indexing** — analyzed-text keyword surfaces use a byte-safe `ignore_above` (8191 characters) so multi-byte values no longer drop the entire search document. Applied as an in-place mapping update; no reindex required.
+- **Edit Domain privilege** — ingest-time domain writes on existing entities now accept **Edit Domain** or **Edit Entity**, matching GraphQL. Creating a new entity still requires Create/Edit Entity; a domains PATCH on a missing entity cannot be used with Edit Domain alone. See [datahub-project/datahub#19719](https://github.com/datahub-project/datahub/pull/19719).
+- **Structured-property mapping merge** — `ESIndexBuilder` no longer mutates caller-supplied mappings in place, so system-update BuildIndices no longer fails with "No index builder found" when semantic search is enabled.
+- **OpenTelemetry resource attributes** — `OTEL_RESOURCE_ATTRIBUTES` (for example `k8s.namespace.name`, `service.namespace`) are preserved on the factory `TracerProvider`; `service.name` is merged instead of replacing the autoconfigured resource.
 
 #### Ingestion
 
@@ -53,17 +59,22 @@ TBD
 #### Security / Dependencies
 
 - **CLI 1.7.0.9 / Remote Executor 0.3.20** — executor-managed ingestion reports no longer persist secrets on disk. No operator action beyond the version bump.
+- **transformers**: bumped to 5.17.0 to address CVE-2026-9856.
 
 #### Bug Fixes
 
 - Fixed home / usage highlights returning an empty list on Elasticsearch 8.
 - Fixed personal Microsoft Teams connect showing "not configured" when the tenant was already set.
 - Fixed non-admins seeing an empty Ask DataHub agent picker and home Agents module for published agents.
+- Fixed domain assignment/clear denied at ingest time for principals who have **Edit Domain** but not **Edit Entity**.
+- Fixed system-update BuildIndices failing when merging structured-property mappings into semantic-search indexes.
 
 #### Environment Variables
 
 - **`STRUCTURED_PROPERTY_GRAPH_EDGES_ENABLED` (default `false`)** — also gates _defining_ relationships (UI toggle, `isRelationship` writes, and `relationshipType` create). Existing relationship properties remain editable when the flag is off.
 - **`MCP_SIDE_EFFECTS_DATA_PRODUCT_ASSETS_ENABLED` (default `true`)**, **`MCP_SIDE_EFFECTS_DATA_PRODUCT_ASSETS_MAX_FANOUT` (default `500`)**, **`REPROCESS_DATA_PRODUCT_ASSETS` (default `false`)**, **`BOOTSTRAP_SYSTEM_UPDATE_DATA_PRODUCT_ASSETS_BATCH_SIZE` (default `1000`)** — control asset-side Data Product membership sync used by the new search filter.
+- **`SHOW_OBSERVATION_CLUSTER_PROPOSALS` (default `false`)** — when `false`, observation-cluster (Remediation) proposals are hidden from the Task Center, type facets, totals, inbox badge, and review page. The clustering job still runs.
+- **`SYSTEM_UPDATE_REMOVE_LEGACY_OBSERVATION_PROPOSALS_ENABLED` (default `true`)** — one-time cleanup of retired per-observation ANNOTATE / POST_ATTACHMENT proposals. Set `SYSTEM_UPDATE_REMOVE_LEGACY_OBSERVATION_PROPOSALS_REPROCESS=true` to force a re-run.
 
 ### v2.2.0
 

--- a/docs/managed-datahub/release-notes/v_2_2_0.md
+++ b/docs/managed-datahub/release-notes/v_2_2_0.md
@@ -6,6 +6,65 @@ description: "DataHub Cloud v2.2.0 release notes — Agents Private Beta, Agenti
 
 ## Release Changelog
 
+### v2.2.1
+
+This release rolls up hotfixes on top of v2.2.0.
+
+#### Release Availability Date
+
+TBD
+
+#### Recommended Versions
+
+- **CLI/SDK**: TBD
+- **Remote Executor**: TBD
+- **On-Prem Versions**:
+  - **Helm**: TBD
+  - **API Gateway**: TBD
+
+#### Product
+
+- **Ontology Explorer** — empty states, relationship-type filter fixes, and faster graph materialization when expanding glossary relationships. Defining a structured property as a relationship is now gated (see Platform and Breaking Changes).
+- **Data Product search filter** — Data Products are a first-class search filter and facet on their member assets, so you can combine a Data Product with other filters. Membership stays authoritative on the Data Product (`dataProductProperties.assets`); an asset-side `dataProducts` aspect is kept in sync. Existing memberships are populated by the MigrateAspects / ZDU sweep. Set `REPROCESS_DATA_PRODUCT_ASSETS=true` if you need to force a resync. See [datahub-project/datahub#18554](https://github.com/datahub-project/datahub/pull/18554).
+- **Microsoft Teams personal connect** — Settings → My Notifications → Connect to Teams reads the tenant ID from Teams integration status, so a configured tenant no longer shows a false "not configured" toast.
+
+#### AI / Ask DataHub
+
+- **Agents in chat and on the home page** — agents with **Show in Ask DataHub Chat** enabled are visible to any user who can view metadata, not only users with Manage Agents. Creating, editing, and deleting agents still requires Manage Agents. Unconfigured and Draft agents stay on the management page.
+
+#### Platform
+
+- **AWS IRSA credential providers** — shared S3, STS, and SQS clients no longer fall through to the AWS SDK default chain when only a region is set, which allocated a new IRSA STS provider per builder. GMS, MAE, and system-update reuse the shared credentials bean or skip construction. **Action:** none on IRSA tenants that already set `AWS_REGION`.
+- **Usage analytics on Elasticsearch 8** — usage-event range queries send numeric epoch-millis so date-mapped `timestamp` fields accept WAU/MAU aggregations. See [datahub-project/datahub#19676](https://github.com/datahub-project/datahub/pull/19676).
+- **Entity-consistency system-update** — non-blocking entity-consistency scans log progress and an ETA instead of appearing stuck. See [datahub-project/datahub#19388](https://github.com/datahub-project/datahub/pull/19388).
+- **Data Product membership writes** — large `dataProductProperties` replacements no longer time out on graph unset side effects; asset comparison is by destination URN and graph scrolls are batched. See [datahub-project/datahub#19465](https://github.com/datahub-project/datahub/pull/19465).
+- **Search indexing** — analyzed-text keyword surfaces use a byte-safe `ignore_above` (8191 characters) so multi-byte values no longer drop the entire search document. Applied as an in-place mapping update; no reindex required.
+
+#### Ingestion
+
+**Executor:**
+
+- Default managed CLI/SDK is **1.7.0.9** and Remote Executor **0.3.20**.
+
+#### Breaking Changes
+
+- **Defining custom relationships requires `STRUCTURED_PROPERTY_GRAPH_EDGES_ENABLED=true`.** Previously the flag only controlled whether graph edges were materialized from URN-valued structured-property assignments, so a property could be marked "treat as relationship" while the flag was off and produce no edges. With the flag off (the default), the UI hides that toggle, and writes that set `structuredPropertySettings.isRelationship` or create a `relationshipType` entity are rejected on every API. Properties that are already relationships stay fully editable. Turn the flag on to define new relationships.
+
+#### Security / Dependencies
+
+- **CLI 1.7.0.9 / Remote Executor 0.3.20** — executor-managed ingestion reports no longer persist secrets on disk. No operator action beyond the version bump.
+
+#### Bug Fixes
+
+- Fixed home / usage highlights returning an empty list on Elasticsearch 8.
+- Fixed personal Microsoft Teams connect showing "not configured" when the tenant was already set.
+- Fixed non-admins seeing an empty Ask DataHub agent picker and home Agents module for published agents.
+
+#### Environment Variables
+
+- **`STRUCTURED_PROPERTY_GRAPH_EDGES_ENABLED` (default `false`)** — also gates _defining_ relationships (UI toggle, `isRelationship` writes, and `relationshipType` create). Existing relationship properties remain editable when the flag is off.
+- **`MCP_SIDE_EFFECTS_DATA_PRODUCT_ASSETS_ENABLED` (default `true`)**, **`MCP_SIDE_EFFECTS_DATA_PRODUCT_ASSETS_MAX_FANOUT` (default `500`)**, **`REPROCESS_DATA_PRODUCT_ASSETS` (default `false`)**, **`BOOTSTRAP_SYSTEM_UPDATE_DATA_PRODUCT_ASSETS_BATCH_SIZE` (default `1000`)** — control asset-side Data Product membership sync used by the new search filter.
+
 ### v2.2.0
 
 #### Release Availability Date


### PR DESCRIPTION
DataHub Cloud v2.2.1 release notes.

Patch rollup on `docs/managed-datahub/release-notes/v_2_2_0.md` (`### v2.2.1`). `sidebars.js` is unchanged.

## Test plan
- [ ] `### v2.2.1` appears at the top of DataHub Cloud Release History for v2.2.0
- [ ] `markdown_format / markdown_format_check (pull_request)` passes
- [ ] Release Availability Date and Recommended Versions filled in before marking ready

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds release notes for DataHub Cloud v2.2.1, a docs-only changelog on `docs/managed-datahub/release-notes/v_2_2_0.md` covering the hotfix rollup on top of v2.2.0, including the release availability date and recommended versions.

<sup>Written for commit e0c64c058ee741da873282742424736ef205ae6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

