### PR TITLE
fix(i18n): route entity tabs by stable id so non-English locales work

### DIFF
--- a/datahub-web-react/src/app/entityV2/application/ApplicationEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/application/ApplicationEntity.tsx
@@ -10,7 +10,7 @@ import { ApplicationSummaryTab } from '@app/entityV2/application/ApplicationSumm
 import { Preview } from '@app/entityV2/application/preview/Preview';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
-import { EntityProfileTab } from '@app/entityV2/shared/constants';
+import { DOCUMENTATION_TAB_ID, EntityProfileTab } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarDomainSection } from '@app/entityV2/shared/containers/profile/sidebar/Domain/SidebarDomainSection';
@@ -144,6 +144,7 @@ export class ApplicationEntity implements Entity<Application> {
             ...(!showSummaryTab
                 ? [
                       {
+                          id: DOCUMENTATION_TAB_ID,
                           name: i18next.t('entity.types:tab.documentation'),
                           component: DocumentationTab,
                           icon: FileOutlined,

--- a/datahub-web-react/src/app/entityV2/businessAttribute/BusinessAttributeEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/businessAttribute/BusinessAttributeEntity.tsx
@@ -8,6 +8,7 @@ import { BusinessAttributeDataTypeSection } from '@app/entityV2/businessAttribut
 import BusinessAttributeRelatedEntity from '@app/entityV2/businessAttribute/profile/BusinessAttributeRelatedEntity';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarOwnerSection } from '@app/entityV2/shared/containers/profile/sidebar/Ownership/sidebar/SidebarOwnerSection';
@@ -104,6 +105,7 @@ export class BusinessAttributeEntity implements Entity<BusinessAttribute> {
                 isNameEditable
                 tabs={[
                     {
+                        id: DOCUMENTATION_TAB_ID,
                         name: i18next.t('entity.types:tab.documentation'),
                         component: DocumentationTab,
                     },

--- a/datahub-web-react/src/app/entityV2/chart/ChartEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/chart/ChartEntity.tsx
@@ -20,6 +20,7 @@ import { ChartStatsSummarySubHeader } from '@app/entityV2/chart/profile/stats/Ch
 import ChartSummaryTab from '@app/entityV2/chart/summary/ChartSummaryTab';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { SubType, TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID, INCIDENTS_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarApplicationSection } from '@app/entityV2/shared/containers/profile/sidebar/Applications/SidebarApplicationSection';
@@ -142,6 +143,7 @@ export class ChartEntity implements Entity<Chart> {
             ...(!showSummaryTab
                 ? [
                       {
+                          id: DOCUMENTATION_TAB_ID,
                           name: i18next.t('entity.types:tab.documentation'),
                           component: DocumentationTab,
                           icon: FileOutlined,
@@ -194,6 +196,7 @@ export class ChartEntity implements Entity<Chart> {
                 },
             },
             {
+                id: INCIDENTS_TAB_ID,
                 name: i18next.t('entity.types:tab.incidents'),
                 getCount: (_, chart, loading) => {
                     return !loading ? chart?.chart?.activeIncidents?.total : undefined;

--- a/datahub-web-react/src/app/entityV2/container/ContainerEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/container/ContainerEntity.tsx
@@ -10,6 +10,7 @@ import ContainerSummaryTab from '@app/entityV2/container/ContainerSummaryTab';
 import { Preview } from '@app/entityV2/container/preview/Preview';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { SubType, TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import SidebarContentsSection from '@app/entityV2/shared/containers/profile/sidebar/Container/SidebarContentsSection';
@@ -125,6 +126,7 @@ export class ContainerEntity implements Entity<Container> {
             ...(!showSummaryTab
                 ? [
                       {
+                          id: DOCUMENTATION_TAB_ID,
                           name: i18next.t('entity.types:tab.documentation'),
                           component: DocumentationTab,
                           icon: FileOutlined,

--- a/datahub-web-react/src/app/entityV2/dashboard/DashboardEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dashboard/DashboardEntity.tsx
@@ -21,6 +21,7 @@ import { DashboardStatsSummarySubHeader } from '@app/entityV2/dashboard/profile/
 import DashboardSummaryTab from '@app/entityV2/dashboard/summary/DashboardSummaryTab';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID, INCIDENTS_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarApplicationSection } from '@app/entityV2/shared/containers/profile/sidebar/Applications/SidebarApplicationSection';
@@ -158,6 +159,7 @@ export class DashboardEntity implements Entity<Dashboard> {
             ...(!showSummaryTab
                 ? [
                       {
+                          id: DOCUMENTATION_TAB_ID,
                           name: i18next.t('entity.types:tab.documentation'),
                           component: DocumentationTab,
                           icon: FileOutlined,
@@ -201,6 +203,7 @@ export class DashboardEntity implements Entity<Dashboard> {
                 icon: UnorderedListOutlined,
             },
             {
+                id: INCIDENTS_TAB_ID,
                 name: i18next.t('entity.types:tab.incidents'),
                 icon: WarningOutlined,
                 component: IncidentTab,

--- a/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataFlow/DataFlowEntity.tsx
@@ -14,6 +14,7 @@ import { Preview } from '@app/entityV2/dataFlow/preview/Preview';
 import { RunsTab } from '@app/entityV2/dataJob/tabs/RunsTab';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID, INCIDENTS_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarApplicationSection } from '@app/entityV2/shared/containers/profile/sidebar/Applications/SidebarApplicationSection';
@@ -89,6 +90,7 @@ export class DataFlowEntity implements Entity<DataFlow> {
             headerDropdownItems={headerDropdownItems}
             tabs={[
                 {
+                    id: DOCUMENTATION_TAB_ID,
                     name: i18next.t('entity.types:tab.documentation'),
                     component: DocumentationTab,
                     icon: FileText,
@@ -108,6 +110,7 @@ export class DataFlowEntity implements Entity<DataFlow> {
                     },
                 },
                 {
+                    id: INCIDENTS_TAB_ID,
                     name: i18next.t('entity.types:tab.incidents'),
                     icon: WarningCircle,
                     component: IncidentTab,

--- a/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataJob/DataJobEntity.tsx
@@ -15,6 +15,7 @@ import { Preview } from '@app/entityV2/dataJob/preview/Preview';
 import { RunsTab } from '@app/entityV2/dataJob/tabs/RunsTab';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID, INCIDENTS_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarApplicationSection } from '@app/entityV2/shared/containers/profile/sidebar/Applications/SidebarApplicationSection';
@@ -103,6 +104,7 @@ export class DataJobEntity implements Entity<DataJob> {
             headerDropdownItems={headerDropdownItems}
             tabs={[
                 {
+                    id: DOCUMENTATION_TAB_ID,
                     name: i18next.t('entity.types:tab.documentation'),
                     component: DocumentationTab,
                     icon: FileText,
@@ -133,6 +135,7 @@ export class DataJobEntity implements Entity<DataJob> {
                     },
                 },
                 {
+                    id: INCIDENTS_TAB_ID,
                     name: i18next.t('entity.types:tab.incidents'),
                     icon: WarningCircle,
                     component: IncidentTab,

--- a/datahub-web-react/src/app/entityV2/dataset/DatasetEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/dataset/DatasetEntity.tsx
@@ -27,6 +27,7 @@ import { DatasetStatsSummarySubHeader } from '@app/entityV2/dataset/profile/stat
 import { useGetColumnTabCount } from '@app/entityV2/dataset/profile/useGetColumnTabCount';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { SubType, TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID, INCIDENTS_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarApplicationSection } from '@app/entityV2/shared/containers/profile/sidebar/Applications/SidebarApplicationSection';
@@ -283,6 +284,7 @@ export class DatasetEntity implements Entity<Dataset> {
             ...(!showSummaryTab
                 ? [
                       {
+                          id: DOCUMENTATION_TAB_ID,
                           name: i18next.t('entity.types:tab.documentation'),
                           component: DocumentationTab,
                           icon: FileOutlined,
@@ -382,6 +384,7 @@ export class DatasetEntity implements Entity<Dataset> {
                 },
             },
             {
+                id: INCIDENTS_TAB_ID,
                 name: i18next.t('entity.types:tab.incidents'),
                 icon: WarningOutlined,
                 component: IncidentTab,

--- a/datahub-web-react/src/app/entityV2/domain/DomainEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/domain/DomainEntity.tsx
@@ -11,7 +11,7 @@ import { Preview } from '@app/entityV2/domain/preview/Preview';
 import { DomainSummaryTab } from '@app/entityV2/domain/summary/DomainSummaryTab';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
-import { EntityProfileTab } from '@app/entityV2/shared/constants';
+import { DOCUMENTATION_TAB_ID, EntityProfileTab } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import SidebarEntitiesSection from '@app/entityV2/shared/containers/profile/sidebar/Domain/SidebarEntitiesSection';
@@ -159,7 +159,7 @@ export class DomainEntity implements Entity<Domain> {
             ...(!showSummaryTab
                 ? [
                       {
-                          id: EntityProfileTab.DOCUMENTATION_TAB,
+                          id: DOCUMENTATION_TAB_ID,
                           name: i18next.t('entity.types:tab.documentation'),
                           component: DocumentationTab,
                           icon: FileOutlined,

--- a/datahub-web-react/src/app/entityV2/glossaryNode/GlossaryNodeEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryNode/GlossaryNodeEntity.tsx
@@ -10,6 +10,7 @@ import ChildrenTabWrapper from '@app/entityV2/glossaryNode/ChildrenTabWrapper';
 import { Preview } from '@app/entityV2/glossaryNode/preview/Preview';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarApplicationSection } from '@app/entityV2/shared/containers/profile/sidebar/Applications/SidebarApplicationSection';
@@ -145,6 +146,7 @@ class GlossaryNodeEntity implements Entity<GlossaryNode> {
             ...(!showSummaryTab
                 ? [
                       {
+                          id: DOCUMENTATION_TAB_ID,
                           name: i18next.t('entity.types:tab.documentation'),
                           component: DocumentationTab,
                           icon: FileText,

--- a/datahub-web-react/src/app/entityV2/glossaryTerm/GlossaryTermEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/glossaryTerm/GlossaryTermEntity.tsx
@@ -15,6 +15,7 @@ import { RelatedTermTypes } from '@app/entityV2/glossaryTerm/profile/GlossaryRel
 import useGlossaryRelatedAssetsTabCount from '@app/entityV2/glossaryTerm/profile/useGlossaryRelatedAssetsTabCount';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarApplicationSection } from '@app/entityV2/shared/containers/profile/sidebar/Applications/SidebarApplicationSection';
@@ -149,6 +150,7 @@ export class GlossaryTermEntity implements Entity<GlossaryTerm> {
             ...(!showSummaryTab
                 ? [
                       {
+                          id: DOCUMENTATION_TAB_ID,
                           name: i18next.t('entity.types:tab.documentation'),
                           component: DocumentationTab,
                           icon: FileText,

--- a/datahub-web-react/src/app/entityV2/mlFeature/MLFeatureEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeature/MLFeatureEntity.tsx
@@ -12,6 +12,7 @@ import { Entity, EntityCapabilityType, IconStyleType, PreviewType } from '@app/e
 import { Preview } from '@app/entityV2/mlFeature/preview/Preview';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID, INCIDENTS_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarApplicationSection } from '@app/entityV2/shared/containers/profile/sidebar/Applications/SidebarApplicationSection';
@@ -98,6 +99,7 @@ export class MLFeatureEntity implements Entity<MlFeature> {
                     icon: Infinity,
                 },
                 {
+                    id: DOCUMENTATION_TAB_ID,
                     name: i18next.t('entity.types:tab.documentation'),
                     component: DocumentationTab,
                     icon: FileText,
@@ -114,6 +116,7 @@ export class MLFeatureEntity implements Entity<MlFeature> {
                     icon: ListBullets,
                 },
                 {
+                    id: INCIDENTS_TAB_ID,
                     name: i18next.t('entity.types:tab.incidents'),
                     icon: WarningCircle,
                     component: IncidentTab,

--- a/datahub-web-react/src/app/entityV2/mlFeatureTable/MLFeatureTableEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlFeatureTable/MLFeatureTableEntity.tsx
@@ -14,6 +14,7 @@ import Sources from '@app/entityV2/mlFeatureTable/profile/Sources';
 import MlFeatureTableFeatures from '@app/entityV2/mlFeatureTable/profile/features/MlFeatureTableFeatures';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID, INCIDENTS_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarApplicationSection } from '@app/entityV2/shared/containers/profile/sidebar/Applications/SidebarApplicationSection';
@@ -101,6 +102,7 @@ export class MLFeatureTableEntity implements Entity<MlFeatureTable> {
                     icon: Database,
                 },
                 {
+                    id: DOCUMENTATION_TAB_ID,
                     name: i18next.t('entity.types:tab.documentation'),
                     component: DocumentationTab,
                     icon: FileText,
@@ -111,6 +113,7 @@ export class MLFeatureTableEntity implements Entity<MlFeatureTable> {
                     icon: ListBullets,
                 },
                 {
+                    id: INCIDENTS_TAB_ID,
                     name: i18next.t('entity.types:tab.incidents'),
                     icon: WarningCircle,
                     component: IncidentTab,

--- a/datahub-web-react/src/app/entityV2/mlModel/MLModelEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModel/MLModelEntity.tsx
@@ -13,6 +13,7 @@ import MLModelSummary from '@app/entityV2/mlModel/profile/MLModelSummary';
 import MlModelFeaturesTab from '@app/entityV2/mlModel/profile/MlModelFeaturesTab';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID, INCIDENTS_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarApplicationSection } from '@app/entityV2/shared/containers/profile/sidebar/Applications/SidebarApplicationSection';
@@ -100,6 +101,7 @@ export class MLModelEntity implements Entity<MlModel> {
                     component: MLModelSummary,
                 },
                 {
+                    id: DOCUMENTATION_TAB_ID,
                     name: i18next.t('entity.types:tab.documentation'),
                     component: DocumentationTab,
                 },
@@ -122,6 +124,7 @@ export class MLModelEntity implements Entity<MlModel> {
                     component: MlModelFeaturesTab,
                 },
                 {
+                    id: INCIDENTS_TAB_ID,
                     name: i18next.t('entity.types:tab.incidents'),
                     icon: WarningOutlined,
                     component: IncidentTab,

--- a/datahub-web-react/src/app/entityV2/mlModelGroup/MLModelGroupEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlModelGroup/MLModelGroupEntity.tsx
@@ -10,6 +10,7 @@ import { Preview } from '@app/entityV2/mlModelGroup/preview/Preview';
 import ModelGroupModels from '@app/entityV2/mlModelGroup/profile/ModelGroupModels';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import { SidebarApplicationSection } from '@app/entityV2/shared/containers/profile/sidebar/Applications/SidebarApplicationSection';
@@ -92,6 +93,7 @@ export class MLModelGroupEntity implements Entity<MlModelGroup> {
                     component: ModelGroupModels,
                 },
                 {
+                    id: DOCUMENTATION_TAB_ID,
                     name: i18next.t('entity.types:tab.documentation'),
                     component: DocumentationTab,
                 },

--- a/datahub-web-react/src/app/entityV2/mlPrimaryKey/MLPrimaryKeyEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/mlPrimaryKey/MLPrimaryKeyEntity.tsx
@@ -8,6 +8,7 @@ import { Entity, EntityCapabilityType, IconStyleType, PreviewType } from '@app/e
 import { Preview } from '@app/entityV2/mlPrimaryKey/preview/Preview';
 import { EntityMenuItems } from '@app/entityV2/shared/EntityDropdown/EntityMenuActions';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import { SidebarAboutSection } from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection';
 import DataProductSection from '@app/entityV2/shared/containers/profile/sidebar/DataProduct/DataProductSection';
@@ -90,6 +91,7 @@ export class MLPrimaryKeyEntity implements Entity<MlPrimaryKey> {
                     component: FeatureTableTab,
                 },
                 {
+                    id: DOCUMENTATION_TAB_ID,
                     name: i18next.t('entity.types:tab.documentation'),
                     component: DocumentationTab,
                 },

--- a/datahub-web-react/src/app/entityV2/query/QueryEntity.tsx
+++ b/datahub-web-react/src/app/entityV2/query/QueryEntity.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { GenericEntityProperties } from '@app/entity/shared/types';
 import { Entity, IconStyleType } from '@app/entityV2/Entity';
 import { TYPE_ICON_CLASS_NAME } from '@app/entityV2/shared/components/subtypes';
+import { DOCUMENTATION_TAB_ID } from '@app/entityV2/shared/constants';
 import { EntityProfile } from '@app/entityV2/shared/containers/profile/EntityProfile';
 import SidebarQueryDefinitionSection from '@app/entityV2/shared/containers/profile/sidebar/Query/SidebarQueryDefinitionSection';
 import SidebarQueryDescriptionSection from '@app/entityV2/shared/containers/profile/sidebar/Query/SidebarQueryDescriptionSection';
@@ -60,6 +61,7 @@ export class QueryEntity implements Entity<Query> {
                 useEntityQuery={useGetQueryQuery}
                 tabs={[
                     {
+                        id: DOCUMENTATION_TAB_ID,
                         name: i18next.t('entity.types:tab.documentation'),
                         component: DocumentationTab,
                         icon: FileOutlined,

--- a/datahub-web-react/src/app/entityV2/shared/EntityDropdown/EntityDropdown.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/EntityDropdown/EntityDropdown.tsx
@@ -45,6 +45,7 @@ import {
 import LinkAssetVersionModal from '@app/entityV2/shared/EntityDropdown/versioning/LinkAssetVersionModal';
 import UnlinkAssetVersionModal from '@app/entityV2/shared/EntityDropdown/versioning/UnlinkAssetVersionModal';
 import CreateEntityAnnouncementModal from '@app/entityV2/shared/announce/CreateEntityAnnouncementModal';
+import { INCIDENTS_TAB_ID } from '@app/entityV2/shared/constants';
 import { getEntityPath } from '@app/entityV2/shared/containers/profile/utils';
 import HistorySidebar from '@app/entityV2/shared/tabs/Dataset/Schema/history/HistorySidebar';
 import { IncidentDetailDrawer } from '@app/entityV2/shared/tabs/Incident/AcrylComponents/IncidentDetailDrawer';
@@ -59,8 +60,8 @@ import { resolveRuntimePath } from '@utils/runtimeBasePath';
 import { useUpdateDeprecationMutation } from '@graphql/mutations.generated';
 import { Deprecation, EntityType } from '@types';
 
-// Tab path segment passed to getEntityPath — a route identifier, not user-visible copy.
-const INCIDENTS_TAB_NAME = 'Incidents';
+// Stable, locale-independent tab id passed to getEntityPath as the URL segment (see issue #19658).
+const INCIDENTS_TAB_NAME = INCIDENTS_TAB_ID;
 
 interface Options {
     hideDeleteMessage?: boolean;

--- a/datahub-web-react/src/app/entityV2/shared/EntityDropdown/RaiseIncidentMenuAction.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/EntityDropdown/RaiseIncidentMenuAction.tsx
@@ -10,13 +10,14 @@ import {
     ENTITY_HEADER_ACTION_ICON_SIZE,
     ENTITY_HEADER_ACTION_ICON_WEIGHT,
 } from '@app/entityV2/shared/EntityDropdown/styledComponents';
+import { INCIDENTS_TAB_ID } from '@app/entityV2/shared/constants';
 import { getEntityPath } from '@app/entityV2/shared/containers/profile/utils';
 import { AddIncidentModal } from '@app/entityV2/shared/tabs/Incident/components/AddIncidentModal';
 import { useIsSeparateSiblingsMode } from '@app/entityV2/shared/useIsSeparateSiblingsMode';
 import { useEntityRegistry } from '@app/useEntityRegistry';
 
-// Tab path segment passed to getEntityPath — a route identifier, not user-visible copy.
-const INCIDENTS_TAB_NAME = 'Incidents';
+// Stable, locale-independent tab id passed to getEntityPath as the URL segment (see issue #19658).
+const INCIDENTS_TAB_NAME = INCIDENTS_TAB_ID;
 
 export default function RaiseIncidentMenuAction() {
     const { t } = useTranslation('entity.shared.entityDropdown');

--- a/datahub-web-react/src/app/entityV2/shared/constants.ts
+++ b/datahub-web-react/src/app/entityV2/shared/constants.ts
@@ -250,6 +250,18 @@ export enum EntityProfileTab {
     SUMMARY_TAB = 'SUMMARY_TAB',
 }
 
+/**
+ * Stable, locale-independent identifiers for entity profile tabs.
+ *
+ * Tab `name` values are translated via i18next, but routing resolves the active tab by matching the
+ * URL path segment. Routing on the translated `name` breaks under non-English locales (see issue
+ * datahub-project/datahub#19658). These ids are assigned to a tab's `id` and passed as the `tabName`
+ * (URL segment) by callers so routing is independent of the UI language. The values match the legacy
+ * English `name` literals so existing English URLs keep resolving.
+ */
+export const DOCUMENTATION_TAB_ID = 'Documentation';
+export const INCIDENTS_TAB_ID = 'Incidents';
+
 export const EDITING_DOCUMENTATION_URL_PARAM = 'editing';
 
 export const UNKNOWN_DATA_PLATFORM = 'urn:li:dataPlatform:unknown';

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/__tests__/utils.test.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/__tests__/utils.test.tsx
@@ -1,6 +1,10 @@
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getEntityPath } from '@app/entityV2/shared/containers/profile/utils';
+import { getEntityPath, useRoutedTab } from '@app/entityV2/shared/containers/profile/utils';
+import { EntityTab } from '@app/entityV2/shared/types';
 
 import { EntityType } from '@types';
 
@@ -121,5 +125,73 @@ describe('getEntityPath', () => {
         expect(result).toBe(
             '/dataset/urn:li:dataset:(urn:li:dataPlatform:snowflake,test_dataset,PROD)/properties?is_lineage_mode=true&separate_siblings=true&sort=name&view=list',
         );
+    });
+});
+
+const noopComponent = () => null;
+
+function makeTab(overrides: Partial<EntityTab>): EntityTab {
+    return {
+        name: 'Tab',
+        component: noopComponent,
+        ...overrides,
+    };
+}
+
+function renderUseRoutedTab(path: string, tabs: EntityTab[]) {
+    return renderHook(() => useRoutedTab(tabs), {
+        wrapper: ({ children }) => <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>,
+    });
+}
+
+describe('useRoutedTab', () => {
+    // Regression test for issue #19658: tab `name` is i18next-translated, so routing must resolve
+    // the active tab by a stable, locale-independent `id` rather than the displayed name.
+    it('resolves a tab by its stable id when the URL segment does not match the translated name', () => {
+        const documentationTab = makeTab({ id: 'Documentation', name: 'Dokumentation' });
+        const schemaTab = makeTab({ name: 'Columns' });
+
+        const { result } = renderUseRoutedTab(
+            '/dataset/urn:li:dataset:(urn:li:dataPlatform:snowflake,test,PROD)/Documentation',
+            [schemaTab, documentationTab],
+        );
+
+        expect(result.current).toBe(documentationTab);
+    });
+
+    it('falls back to matching on name for tabs that do not declare an id', () => {
+        const schemaTab = makeTab({ name: 'Columns' });
+        const propertiesTab = makeTab({ name: 'Properties' });
+
+        const { result } = renderUseRoutedTab(
+            '/dataset/urn:li:dataset:(urn:li:dataPlatform:snowflake,test,PROD)/Properties',
+            [schemaTab, propertiesTab],
+        );
+
+        expect(result.current).toBe(propertiesTab);
+    });
+
+    it('prefers an id match over a name match', () => {
+        // A tab whose name happens to equal another tab's id must not shadow the id match.
+        const nameCollisionTab = makeTab({ name: 'Documentation' });
+        const documentationTab = makeTab({ id: 'Documentation', name: 'Dokumentation' });
+
+        const { result } = renderUseRoutedTab(
+            '/dataset/urn:li:dataset:(urn:li:dataPlatform:snowflake,test,PROD)/Documentation',
+            [nameCollisionTab, documentationTab],
+        );
+
+        expect(result.current).toBe(documentationTab);
+    });
+
+    it('returns undefined when no tab matches the URL segment', () => {
+        const schemaTab = makeTab({ name: 'Columns' });
+
+        const { result } = renderUseRoutedTab(
+            '/dataset/urn:li:dataset:(urn:li:dataPlatform:snowflake,test,PROD)/DoesNotExist',
+            [schemaTab],
+        );
+
+        expect(result.current).toBeUndefined();
     });
 });

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/sidebar/AboutSection/SidebarAboutSection.tsx
@@ -4,7 +4,11 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useEntityData, useMutationUrn, useRouteToTab } from '@app/entity/shared/EntityContext';
-import { EMPTY_MESSAGES, ENTITY_TYPES_WITH_NEW_SUMMARY_TAB } from '@app/entityV2/shared/constants';
+import {
+    DOCUMENTATION_TAB_ID,
+    EMPTY_MESSAGES,
+    ENTITY_TYPES_WITH_NEW_SUMMARY_TAB,
+} from '@app/entityV2/shared/constants';
 import DescriptionSection from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/DescriptionSection';
 import LinksSection from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/LinksSection';
 import SourceRefSection from '@app/entityV2/shared/containers/profile/sidebar/AboutSection/SourceRefSection';
@@ -24,8 +28,9 @@ const LINE_LIMIT = 5;
 
 /* eslint-disable i18next/no-literal-string -- route tab name identifiers, not UI text */
 const SUMMARY_TAB = 'Summary';
-const DOCUMENTATION_TAB = 'Documentation';
 /* eslint-enable i18next/no-literal-string */
+// Stable, locale-independent tab id used for routing (see issue #19658). Must match the tab's `id`.
+const DOCUMENTATION_TAB = DOCUMENTATION_TAB_ID;
 
 interface Properties {
     hideLinksButton?: boolean;

--- a/datahub-web-react/src/app/entityV2/shared/containers/profile/utils.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/containers/profile/utils.tsx
@@ -141,7 +141,11 @@ export function useRoutedTab(tabs: EntityTab[]): EntityTab | undefined {
     const match = trimmedPathName.match(ENTITY_TAB_NAME_REGEX_PATTERN);
     if (match && match[1]) {
         const selectedTabPath = match[1];
-        const routedTab = tabs.find((tab) => tab.name === selectedTabPath);
+        // Prefer matching on the stable, locale-independent `id`; fall back to `name` for tabs that
+        // don't declare an id. Matching on the translated `name` alone breaks routing under
+        // non-English locales (issue datahub-project/datahub#19658).
+        const routedTab =
+            tabs.find((tab) => tab.id === selectedTabPath) ?? tabs.find((tab) => tab.name === selectedTabPath);
         return routedTab;
     }
     // No match found!

--- a/datahub-web-react/src/app/entityV2/shared/summary/SummaryAboutSection.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/summary/SummaryAboutSection.tsx
@@ -9,12 +9,14 @@ import { EditLinkModal } from '@app/entityV2/shared/components/links/EditLinkMod
 import { useLinkListActions } from '@app/entityV2/shared/components/links/useLinkListActions';
 import { AddLinkModal } from '@app/entityV2/shared/components/styled/AddLinkModal';
 import { EmptyTab } from '@app/entityV2/shared/components/styled/EmptyTab';
+import { DOCUMENTATION_TAB_ID } from '@app/entityV2/shared/constants';
 import { SectionContainer, SummaryTabHeaderTitle } from '@app/entityV2/shared/summary/HeaderComponents';
 import { ResourceLinkPill } from '@app/entityV2/shared/tabs/Documentation/components/ResourceLinkPill';
 import { Button, Editor } from '@src/alchemy-components';
 
 const UNEXPANDED_HEIGHT = 2000;
-const DOCUMENTATION_TAB_NAME = 'Documentation';
+// Stable, locale-independent tab id used for routing (see issue #19658). Must match the tab's `id`.
+const DOCUMENTATION_TAB_NAME = DOCUMENTATION_TAB_ID;
 
 const DocumentationWrapper = styled.div<{ canExpand?: boolean }>`
     position: relative;

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/DocumentationTab.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/DocumentationTab.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import { useEntityData, useRouteToTab } from '@app/entity/shared/EntityContext';
 import { EmptyTab } from '@app/entityV2/shared/components/styled/EmptyTab';
 import TabToolbar from '@app/entityV2/shared/components/styled/TabToolbar';
+import { DOCUMENTATION_TAB_ID } from '@app/entityV2/shared/constants';
 import { DescriptionEditor } from '@app/entityV2/shared/tabs/Documentation/components/DescriptionEditor';
 import { DescriptionPreviewModal } from '@app/entityV2/shared/tabs/Documentation/components/DescriptionPreviewModal';
 import { RelatedSection } from '@app/entityV2/shared/tabs/Documentation/components/RelatedSection';
@@ -17,7 +18,8 @@ import { getAssetDescriptionDetails } from '@app/entityV2/shared/tabs/Documentat
 import { EDITED_DESCRIPTIONS_CACHE_NAME } from '@app/entityV2/shared/utils';
 import { Button, Editor, Text } from '@src/alchemy-components';
 
-const DOCUMENTATION_TAB_NAME = 'Documentation';
+// Stable, locale-independent tab id used for routing (see issue #19658). Must match the tab's `id`.
+const DOCUMENTATION_TAB_NAME = DOCUMENTATION_TAB_ID;
 const DOCUMENTATION_TAB = 'documentation';
 
 const DocumentationContainer = styled.div`

--- a/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/DescriptionPreviewModal.tsx
+++ b/datahub-web-react/src/app/entityV2/shared/tabs/Documentation/components/DescriptionPreviewModal.tsx
@@ -3,12 +3,14 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useRouteToTab } from '@app/entity/shared/EntityContext';
+import { DOCUMENTATION_TAB_ID } from '@app/entityV2/shared/constants';
 import { DescriptionEditor } from '@app/entityV2/shared/tabs/Documentation/components/DescriptionEditor';
 import { DescriptionPreview } from '@app/entityV2/shared/tabs/Documentation/components/DescriptionPreview';
 import ClickOutside from '@app/shared/ClickOutside';
 import { ConfirmationModal } from '@app/sharedV2/modals/ConfirmationModal';
 
-const DOCUMENTATION_TAB_NAME = 'Documentation';
+// Stable, locale-independent tab id used for routing (see issue #19658). Must match the tab's `id`.
+const DOCUMENTATION_TAB_NAME = DOCUMENTATION_TAB_ID;
 
 const modalStyle = {
     top: '5%',


### PR DESCRIPTION
## Summary

Fixes #19658.

After the i18n extraction of entity tab names, clicking **Add Documentation** / **Edit** on a non-English UI (e.g. German) navigated to the default tab instead of opening the documentation editor. The **Incidents** tab (e.g. "Raise Incident") broke the same way. English users were unaffected.

### Root cause

`useRoutedTab` resolved the active tab by strict `name` equality, but tab `name` values are now `i18next`-translated while the routing callers passed hardcoded English literals (`'Documentation'`, `'Incidents'`) as the URL segment. In non-English locales the translated name no longer equals the routed literal, so `useRoutedTab` returned `undefined` and the profile fell back to the default tab.

### Fix

Route by a stable, locale-independent tab **id**:

- Add `DOCUMENTATION_TAB_ID` / `INCIDENTS_TAB_ID` constants.
- `useRoutedTab` matches `tab.id` first, falling back to `tab.name` (keeps existing English URLs and untouched tabs working).
- Assign the ids to the Documentation and Incidents tabs across the `entityV2` entity configs, and reference the shared constants from the routing callers.

The id values equal the legacy English `name` literals, so existing URLs resolve regardless of UI language.

## Testing

Added `useRoutedTab` unit tests (id-first match, name fallback, id-over-name precedence, no-match). All 10 tests in the file pass. `eslint`, `prettier --check`, and `tsc --noEmit` are clean for `datahub-web-react`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes entity tab routing for non-English locales so actions like Add Documentation and Raise Incident navigate to the correct tab instead of falling back to the default tab. Tab names are now i18next-translated, but routing previously matched the English literal, which broke under non-English UIs. Routing now resolves tabs by stable, locale-independent IDs with a name fallback, so existing English URLs keep working.

- Introduces `DOCUMENTATION_TAB_ID` and `INCIDENTS_TAB_ID` constants whose values match the legacy English literals.
- Assigns these IDs to the Documentation and Incidents tabs across `entityV2` entity configs and uses them in routing callers.

<sup>Written for commit 8b4139d9c41647a6bcb20c0dc8310a7e50261678. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

