### PR TITLE
refactor(ui): consolidate app/mfeframework with the fork

### DIFF
--- a/datahub-web-react/src/app/mfeframework/mfeConfigLoader.tsx
+++ b/datahub-web-react/src/app/mfeframework/mfeConfigLoader.tsx
@@ -6,7 +6,7 @@ import { MFEBaseConfigurablePage } from '@app/mfeframework/MFEConfigurableContai
 import { NoPageFound } from '@app/shared/NoPageFound';
 import { resolveRuntimePath } from '@utils/runtimeBasePath';
 
-export interface MFEFlags {
+interface MFEFlags {
     enabled: boolean;
     showInNav: boolean;
 }


### PR DESCRIPTION
Upstream the fork-side change so the auto-merge has less to conflict over. No behaviour change intended.

Decision: hunk 4915fa5da804 PORT_TO_OSS - MFEFlags has no consumers outside mfeConfigLoader.tsx, so dropping the export keyword is safe.

Ported: datahub-web-react/src/app/mfeframework/mfeConfigLoader.tsx
Addressable divergence in the scope: 0.14% -> 0.00%\

<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `export` keyword from the `MFEFlags` interface in `mfeConfigLoader.tsx` because it has no consumers outside that file. This aligns the file with the internal fork and reduces merge conflicts during auto-merge. No behavior change.

<sup>Written for commit 12fcd7338835312ac2d9bf6bbde02d9e097509a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

