### PR TITLE
fix(cli): allow ingest-sample-data without ~/.datahubenv

### DIFF
--- a/metadata-ingestion/src/datahub/cli/datapack/loader.py
+++ b/metadata-ingestion/src/datahub/cli/datapack/loader.py
@@ -21,9 +21,15 @@ from requests.adapters import HTTPAdapter
 from typing_extensions import NotRequired, TypedDict
 from urllib3.util.retry import Retry
 
-from datahub.cli.config_utils import DATAHUB_ROOT_FOLDER, load_client_config
+from datahub.cli.config_utils import (
+    DATAHUB_ROOT_FOLDER,
+    MissingConfigError,
+    load_client_config,
+)
 from datahub.cli.datapack.models import DataPackInfo, LoadRecord, TrustTier
 from datahub.cli.datapack.time_shift import time_shift_file
+from datahub.configuration.env_vars import get_skip_config
+from datahub.ingestion.auth.env import build_auth_config_from_env
 from datahub.ingestion.auth.registry import AuthConfig
 from datahub.ingestion.graph.config import DatahubClientConfig
 from datahub.ingestion.graph.entity_aspect_specs import EntityAspectSpecs
@@ -32,6 +38,9 @@ logger = logging.getLogger(__name__)
 
 CACHE_DIR = os.path.join(DATAHUB_ROOT_FOLDER, "datapack-cache")
 LOADS_DIR = os.path.join(DATAHUB_ROOT_FOLDER, "datapack-loads")
+
+# Used when demo-data / ingest-sample-data has no env and no ~/.datahubenv.
+QUICKSTART_DEFAULT_GMS_SERVER = "http://localhost:8080"
 
 EMIT_MODE_ENV = "DATAHUB_EMIT_MODE"
 
@@ -732,12 +741,51 @@ def _run_pipeline_for_file(
         pipeline.raise_from_status()
 
 
+def _can_fallback_to_quickstart_gms() -> bool:
+    """True only when nothing is configured — not OAuth or DATAHUB_SKIP_CONFIG."""
+    if get_skip_config():
+        return False
+    if build_auth_config_from_env() is not None:
+        return False
+    return True
+
+
+def _resolve_datapack_client_config(
+    client_config: Optional[DatahubClientConfig] = None,
+    *,
+    server: Optional[str] = None,
+    token: Optional[str] = None,
+) -> DatahubClientConfig:
+    if client_config is not None:
+        return client_config
+    if server:
+        return DatahubClientConfig(server=server, token=token)
+
+    try:
+        resolved = load_client_config()
+    except MissingConfigError:
+        if not _can_fallback_to_quickstart_gms():
+            raise
+        logger.warning(
+            "No DataHub client config found; ingesting to %s. "
+            "Set DATAHUB_GMS_URL or run `datahub init` to target another instance.",
+            QUICKSTART_DEFAULT_GMS_SERVER,
+        )
+        resolved = DatahubClientConfig(server=QUICKSTART_DEFAULT_GMS_SERVER)
+
+    if token:
+        return resolved.model_copy(update={"token": token, "auth": None})
+    return resolved
+
+
 def ingest_datapack_file_entries(
     pack: DataPackInfo,
     file_entries: List[IndexFileEntry],
     run_id: str,
     *,
     client_config: Optional[DatahubClientConfig] = None,
+    server: Optional[str] = None,
+    token: Optional[str] = None,
     no_time_shift: bool = False,
     as_of: Optional[datetime] = None,
     log_progress: bool = True,
@@ -747,8 +795,9 @@ def ingest_datapack_file_entries(
     Uses OpenAPI async_batch for all files. Index entries with wait_for_completion
     use async_wait (trace blocking) before the next file starts.
     """
-    if client_config is None:
-        client_config = load_client_config()
+    client_config = _resolve_datapack_client_config(
+        client_config, server=server, token=token
+    )
 
     sink_config = _build_datapack_sink_config(client_config)
 

--- a/metadata-ingestion/src/datahub/cli/docker_cli.py
+++ b/metadata-ingestion/src/datahub/cli/docker_cli.py
@@ -962,10 +962,17 @@ def ingest_sample_data(token: Optional[str], pack: Optional[str]) -> None:
 
     # Run ingestion.
     click.echo("Starting ingestion...")
-    source_config: dict = {}
+    gms_server = "http://localhost:8080"
+    source_config: dict = {"server": gms_server}
     if pack:
         source_config["pack_name"] = pack
         source_config["no_time_shift"] = False
+    if token is not None:
+        source_config["token"] = token
+
+    sink_config: dict = {"server": gms_server}
+    if token is not None:
+        sink_config["token"] = token
 
     recipe: dict = {
         "source": {
@@ -974,12 +981,9 @@ def ingest_sample_data(token: Optional[str], pack: Optional[str]) -> None:
         },
         "sink": {
             "type": "datahub-rest",
-            "config": {"server": "http://localhost:8080"},
+            "config": sink_config,
         },
     }
-
-    if token is not None:
-        recipe["sink"]["config"]["token"] = token
 
     pipeline = Pipeline.create(recipe)
     pipeline.run()

--- a/metadata-ingestion/src/datahub/ingestion/source/demo_data.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/demo_data.py
@@ -72,6 +72,20 @@ class DemoDataConfig(ConfigModel):
         default=False,
         description="Force re-download even if the pack is cached.",
     )
+    server: Optional[str] = Field(
+        default=None,
+        description=(
+            "GMS URL for datapack ingest. When omitted, uses DATAHUB_GMS_URL, "
+            "~/.datahubenv, or http://localhost:8080."
+        ),
+    )
+    token: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional GMS token. Combined with server when set; otherwise applied "
+            "on top of env/~/.datahubenv or the localhost quickstart default."
+        ),
+    )
 
 
 @platform_name("Demo Data")
@@ -130,6 +144,8 @@ class DemoDataSource(Source):
             pack,
             file_entries,
             run_id,
+            server=config.server,
+            token=config.token,
             no_time_shift=config.no_time_shift,
             as_of=as_of_dt,
             log_progress=False,

--- a/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
+++ b/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
@@ -343,6 +343,163 @@ class TestIngestDatapackFileEntries:
         mock_run.assert_called_once()
         assert mock_run.call_args.args[2]["server"] == "http://gms:8080"
 
+    @patch("datahub.cli.datapack.loader.build_auth_config_from_env", return_value=None)
+    @patch("datahub.cli.datapack.loader.get_skip_config", return_value=False)
+    @patch("datahub.cli.datapack.loader.load_client_config")
+    @patch("datahub.cli.datapack.loader._run_pipeline_for_file")
+    @patch("datahub.cli.datapack.loader._check_referential_integrity")
+    @patch("datahub.cli.datapack.loader._apply_schema_filter")
+    def test_ingest_defaults_localhost_when_client_config_missing(
+        self,
+        mock_filter: MagicMock,
+        mock_ref: MagicMock,
+        mock_run: MagicMock,
+        mock_load_config: MagicMock,
+        mock_skip: MagicMock,
+        mock_auth: MagicMock,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        from datahub.cli.config_utils import MissingConfigError
+
+        mock_filter.side_effect = lambda path, **_: path
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        mock_load_config.side_effect = MissingConfigError("No ~/.datahubenv file found")
+
+        ingest_datapack_file_entries(
+            DataPackInfo(
+                name="bootstrap",
+                description="test",
+                url="https://example.com/bootstrap.json",
+                trust=TrustTier.VERIFIED,
+            ),
+            [IndexFileEntry(data_file)],
+            "run-xyz",
+            log_progress=False,
+        )
+
+        mock_load_config.assert_called_once()
+        mock_run.assert_called_once()
+        sink_config = mock_run.call_args.args[2]
+        assert sink_config["server"] == "http://localhost:8080"
+        assert "token" not in sink_config
+
+    @patch(
+        "datahub.cli.datapack.loader.build_auth_config_from_env", return_value=object()
+    )
+    @patch("datahub.cli.datapack.loader.load_client_config")
+    @patch("datahub.cli.datapack.loader._run_pipeline_for_file")
+    @patch("datahub.cli.datapack.loader._check_referential_integrity")
+    @patch("datahub.cli.datapack.loader._apply_schema_filter")
+    def test_ingest_does_not_fallback_when_oauth_env_is_set(
+        self,
+        mock_filter: MagicMock,
+        mock_ref: MagicMock,
+        mock_run: MagicMock,
+        mock_load_config: MagicMock,
+        mock_auth: MagicMock,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        from datahub.cli.config_utils import MissingConfigError
+
+        mock_filter.side_effect = lambda path, **_: path
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        mock_load_config.side_effect = MissingConfigError(
+            "DATAHUB_AUTH_TYPE is set but no GMS server was provided."
+        )
+
+        with pytest.raises(MissingConfigError, match="DATAHUB_AUTH_TYPE"):
+            ingest_datapack_file_entries(
+                DataPackInfo(
+                    name="bootstrap",
+                    description="test",
+                    url="https://example.com/bootstrap.json",
+                    trust=TrustTier.VERIFIED,
+                ),
+                [IndexFileEntry(data_file)],
+                "run-xyz",
+                log_progress=False,
+            )
+        mock_run.assert_not_called()
+
+    @patch("datahub.cli.datapack.loader.get_skip_config", return_value=True)
+    @patch("datahub.cli.datapack.loader.load_client_config")
+    @patch("datahub.cli.datapack.loader._run_pipeline_for_file")
+    @patch("datahub.cli.datapack.loader._check_referential_integrity")
+    @patch("datahub.cli.datapack.loader._apply_schema_filter")
+    def test_ingest_does_not_fallback_when_skip_config_is_set(
+        self,
+        mock_filter: MagicMock,
+        mock_ref: MagicMock,
+        mock_run: MagicMock,
+        mock_load_config: MagicMock,
+        mock_skip: MagicMock,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        from datahub.cli.config_utils import MissingConfigError
+
+        mock_filter.side_effect = lambda path, **_: path
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        mock_load_config.side_effect = MissingConfigError(
+            "You have set the skip config flag"
+        )
+
+        with pytest.raises(MissingConfigError, match="skip config"):
+            ingest_datapack_file_entries(
+                DataPackInfo(
+                    name="bootstrap",
+                    description="test",
+                    url="https://example.com/bootstrap.json",
+                    trust=TrustTier.VERIFIED,
+                ),
+                [IndexFileEntry(data_file)],
+                "run-xyz",
+                log_progress=False,
+            )
+        mock_run.assert_not_called()
+
+    @patch("datahub.cli.datapack.loader.build_auth_config_from_env", return_value=None)
+    @patch("datahub.cli.datapack.loader.get_skip_config", return_value=False)
+    @patch("datahub.cli.datapack.loader.load_client_config")
+    @patch("datahub.cli.datapack.loader._run_pipeline_for_file")
+    @patch("datahub.cli.datapack.loader._check_referential_integrity")
+    @patch("datahub.cli.datapack.loader._apply_schema_filter")
+    def test_ingest_applies_token_without_server_on_localhost_fallback(
+        self,
+        mock_filter: MagicMock,
+        mock_ref: MagicMock,
+        mock_run: MagicMock,
+        mock_load_config: MagicMock,
+        mock_skip: MagicMock,
+        mock_auth: MagicMock,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        from datahub.cli.config_utils import MissingConfigError
+
+        mock_filter.side_effect = lambda path, **_: path
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        mock_load_config.side_effect = MissingConfigError("No ~/.datahubenv file found")
+
+        ingest_datapack_file_entries(
+            DataPackInfo(
+                name="bootstrap",
+                description="test",
+                url="https://example.com/bootstrap.json",
+                trust=TrustTier.VERIFIED,
+            ),
+            [IndexFileEntry(data_file)],
+            "run-xyz",
+            token="sample-token",
+            log_progress=False,
+        )
+
+        sink_config = mock_run.call_args.args[2]
+        assert sink_config["server"] == "http://localhost:8080"
+        assert sink_config["token"] == "sample-token"
+
 
 class TestLoadPackIntoDatahub:
     @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")

--- a/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
+++ b/metadata-ingestion/tests/unit/cli/docker/test_docker_cli.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import click
 import pytest
+from click.testing import CliRunner
 from docker import DockerClient
 
 from datahub.cli.docker_check import DockerComposeVersionError
@@ -14,6 +15,7 @@ from datahub.cli.docker_cli import (
     check,
     download_compose_files,
     get_github_file_url,
+    ingest_sample_data,
 )
 
 
@@ -471,3 +473,28 @@ def test_resolve_secrets_generated_values_are_unique(tmp_path: Path) -> None:
 
     assert results[0][0] != results[1][0]
     assert results[0][1] != results[1][1]
+
+
+@patch("datahub.cli.docker_cli.Pipeline.create")
+@patch("datahub.cli.docker_cli.check_docker_quickstart")
+@patch("datahub.upgrade.upgrade.check_upgrade_post")
+def test_ingest_sample_data_puts_server_and_token_on_source(
+    mock_upgrade: MagicMock,
+    mock_check: MagicMock,
+    mock_pipeline_create: MagicMock,
+) -> None:
+    status = MagicMock()
+    status.is_ok.return_value = True
+    mock_check.return_value = status
+    pipeline = MagicMock()
+    pipeline.pretty_print_summary.return_value = 0
+    mock_pipeline_create.return_value = pipeline
+
+    result = CliRunner().invoke(ingest_sample_data, ["--token", "sample-token"])
+
+    assert result.exit_code == 0, result.output
+    recipe = mock_pipeline_create.call_args.args[0]
+    assert recipe["source"]["config"]["server"] == "http://localhost:8080"
+    assert recipe["source"]["config"]["token"] == "sample-token"
+    assert recipe["sink"]["config"]["server"] == "http://localhost:8080"
+    assert recipe["sink"]["config"]["token"] == "sample-token"

--- a/metadata-ingestion/tests/unit/test_demo_data_source.py
+++ b/metadata-ingestion/tests/unit/test_demo_data_source.py
@@ -70,6 +70,8 @@ class TestDemoDataSource:
             mock_download.assert_called_once()
             mock_ingest.assert_called_once()
             assert source.file_source is not None
+            assert mock_ingest.call_args.kwargs.get("server") is None
+            assert mock_ingest.call_args.kwargs.get("token") is None
 
     @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
     @patch("datahub.cli.datapack.loader.download_pack")
@@ -186,6 +188,66 @@ class TestDemoDataSource:
             assert as_of is not None
             assert as_of.year == 2024
             assert as_of.month == 6
+
+    @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
+    @patch("datahub.cli.datapack.registry.get_pack")
+    @patch("datahub.cli.datapack.loader.download_pack")
+    @patch("datahub.cli.datapack.loader.check_trust")
+    def test_server_and_token_passed_as_client_config(
+        self, mock_trust, mock_download, mock_get_pack, mock_ingest
+    ):
+        from datahub.cli.datapack.models import DataPackInfo, TrustTier
+
+        mock_get_pack.return_value = DataPackInfo(
+            name="bootstrap",
+            description="test",
+            url="https://example.com/bootstrap.json",
+            trust=TrustTier.VERIFIED,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w") as f:
+            json.dump([], f)
+            f.flush()
+            mock_download.return_value = [IndexFileEntry(path=Path(f.name))]
+
+            ctx = MagicMock()
+            config = DemoDataConfig(
+                server="http://localhost:8080",
+                token="sample-token",
+            )
+            DemoDataSource(ctx, config)
+
+            mock_ingest.assert_called_once()
+            assert mock_ingest.call_args.kwargs["server"] == "http://localhost:8080"
+            assert mock_ingest.call_args.kwargs["token"] == "sample-token"
+
+    @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
+    @patch("datahub.cli.datapack.registry.get_pack")
+    @patch("datahub.cli.datapack.loader.download_pack")
+    @patch("datahub.cli.datapack.loader.check_trust")
+    def test_token_without_server_is_passed(
+        self, mock_trust, mock_download, mock_get_pack, mock_ingest
+    ):
+        from datahub.cli.datapack.models import DataPackInfo, TrustTier
+
+        mock_get_pack.return_value = DataPackInfo(
+            name="bootstrap",
+            description="test",
+            url="https://example.com/bootstrap.json",
+            trust=TrustTier.VERIFIED,
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".json", mode="w") as f:
+            json.dump([], f)
+            f.flush()
+            mock_download.return_value = [IndexFileEntry(path=Path(f.name))]
+
+            ctx = MagicMock()
+            DemoDataSource(ctx, DemoDataConfig(token="sample-token"))
+
+            mock_ingest.assert_called_once()
+            assert mock_ingest.call_args.kwargs.get("server") is None
+            assert mock_ingest.call_args.kwargs["token"] == "sample-token"
 
     @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
     @patch("datahub.cli.datapack.registry.get_pack")


### PR DESCRIPTION
## Summary
- `datahub docker ingest-sample-data` no longer requires `datahub init` / `~/.datahubenv`. The local GMS URL and optional `--token` are passed into datapack ingest (the outer recipe sink was unused after the demo-data rewrite).
- If nothing is configured, datapack ingest falls back to `http://localhost:8080` with no token. OAuth-without-server and `DATAHUB_SKIP_CONFIG` still raise instead of writing unauthenticated to localhost.
- Fixes scheduled Quickstart Test `ingest-sample-data` after bringing up older servers with the latest CLI. [PFP-6132](https://linear.app/acryl-data/issue/PFP-6132/ingest-sample-data-should-not-require-datahubenv)

## Test plan
- [x] `./gradlew :metadata-ingestion:lint`
- [x] `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/cli/datapack/test_loader.py`
- [x] `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/test_demo_data_source.py`
- [x] `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/cli/docker/test_docker_cli.py`
- [ ] After the next CLI publish, scheduled Quickstart Test `v1.1.0` / `v1.2.0` `ingest-sample-data` steps succeed without `datahub init`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`datahub docker ingest-sample-data` no longer requires `datahub init` or `~/.datahubenv`; it now targets local GMS at `http://localhost:8080` when no client configuration exists, while preserving optional token support. This fixes the Quickstart failure described in [PFP-6132](https://linear.app/acryl-data/issue/PFP-6132) without masking OAuth or `DATAHUB_SKIP_CONFIG` errors.

**Details**

- The demo-data source passes the server and token directly to datapack ingestion instead of relying on the outer recipe sink.
- Tests cover localhost fallback, token handling, and configuration safeguards.

<sup>Written for commit 035d3785e420818fa5a8476d0b1c846d93047687. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

