### PR TITLE
test(ui/lineage): Add more playwright test coverage

### DIFF
--- a/datahub-web-react/src/app/lineageV3/LineageEntityNode/Columns.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageEntityNode/Columns.tsx
@@ -207,12 +207,12 @@ function Columns(props: Props) {
     return (
         <MainColumnsWrapper isGhost={isGhost}>
             {showAllColumns && (
-                <SearchBarWrapper>
+                <SearchBarWrapper data-testid="column-search">
                     <ColumnSearch searchText={filterText} setSearchText={setFilterText} />
                 </SearchBarWrapper>
             )}
             {((showAllColumns && !!paginatedColumns.length) || !!highlightedColumns.length) && (
-                <OnlyColumnsWrapper onMouseLeave={handleMouseLeave}>
+                <OnlyColumnsWrapper data-testid="columns-list" onMouseLeave={handleMouseLeave}>
                     {showAllColumns &&
                         paginatedColumns.map((col) => <Column key={col.fieldPath} {...col} {...columnProps} />)}
                     {showAllColumns && !!paginatedColumns.length && !!highlightedColumns.length && (
@@ -224,7 +224,7 @@ function Columns(props: Props) {
                 </OnlyColumnsWrapper>
             )}
             {hasColumnPagination && (
-                <ColumnPaginationWrapper onClick={(e) => e.stopPropagation()}>
+                <ColumnPaginationWrapper data-testid="column-pagination" onClick={(e) => e.stopPropagation()}>
                     <ColumnPagination
                         className="nodrag"
                         currentPage={pageIndex + 1}

--- a/datahub-web-react/src/app/lineageV3/LineageSidebar.tsx
+++ b/datahub-web-react/src/app/lineageV3/LineageSidebar.tsx
@@ -66,7 +66,7 @@ export default function LineageSidebar() {
             }}
         >
             {createPortal(
-                <SidebarWrapper $distanceFromTop={0}>
+                <SidebarWrapper $distanceFromTop={0} data-testid="lineage-sidebar">
                     <CompactContext.Provider key={selectedEntity.urn} value>
                         {entityRegistry.renderProfile(selectedEntity.type, selectedEntity.urn)}
                     </CompactContext.Provider>

--- a/datahub-web-react/src/app/lineageV3/controls/LineageControls.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/LineageControls.tsx
@@ -118,6 +118,7 @@ export default function LineageControls() {
                     <StyledDivider />
                     <StyledPanelButton
                         $showText={isExpanded}
+                        data-testid="lineage-filters-button"
                         onClick={() =>
                             visiblePanel === 'filters' ? setVisiblePanel(null) : setVisiblePanel('filters')
                         }

--- a/datahub-web-react/src/app/lineageV3/controls/LineageSearchFilters.tsx
+++ b/datahub-web-react/src/app/lineageV3/controls/LineageSearchFilters.tsx
@@ -63,7 +63,7 @@ export default function LineageSearchFilters() {
         [rootUrn, rootType, nodes, nodeVersion],
     );
     return (
-        <ControlPanel>
+        <ControlPanel data-testid="lineage-filters-panel">
             <ControlPanelTitle>{t('controls.filters.title')}</ControlPanelTitle>
             <ControlPanelSubtext>{t('controls.filters.description')}</ControlPanelSubtext>
             {rootType === EntityType.DataProduct && (
@@ -77,6 +77,7 @@ export default function LineageSearchFilters() {
                     <Switch
                         label=""
                         labelStyle={{ display: 'none' }}
+                        data-testid="lineage-filter-output-ports-only"
                         isChecked={outputPortsOnly}
                         onChange={() => setOutputPortsOnly(!outputPortsOnly)}
                     />
@@ -94,6 +95,7 @@ export default function LineageSearchFilters() {
                         label=""
                         labelStyle={{ display: 'none' }}
                         isDisabled={!hasTransformations}
+                        data-testid="lineage-filter-hide-transformations"
                         isChecked={hideTransformations}
                         onChange={() => setHideTransformations(!hideTransformations)}
                     />
@@ -109,6 +111,7 @@ export default function LineageSearchFilters() {
                 <Switch
                     label=""
                     labelStyle={{ display: 'none' }}
+                    data-testid="lineage-filter-hide-process-instances"
                     isChecked={!showDataProcessInstances}
                     onChange={() => setShowDataProcessInstances(!showDataProcessInstances)}
                 />
@@ -127,6 +130,7 @@ export default function LineageSearchFilters() {
                         label=""
                         labelStyle={{ display: 'none' }}
                         isDisabled={mustShowGhostEntities}
+                        data-testid="lineage-filter-show-ghost-entities"
                         isChecked={showGhostEntities}
                         onChange={() => setShowGhostEntities(!showGhostEntities)}
                     />

--- a/e2e-test/ui/playwright/pages/lineage-base.page.ts
+++ b/e2e-test/ui/playwright/pages/lineage-base.page.ts
@@ -14,6 +14,11 @@
  *   - Column edge:   [data-testid="rf__edge-{urn1}::{col1}-{urn2}::{col2}"]
  *   - Filter node:   [data-testid="rf__node-lf:{dir}:{urn}"]  dir = u | d
  *   - Column:        within lineage-node, [data-testid="column-{name}"]
+ *   - Column search: within lineage-node, [data-testid="column-search"]
+ *   - Column pages:  within lineage-node, [data-testid="column-pagination"]
+ *   - Filters panel: [data-testid="lineage-filters-panel"], toggles
+ *                    [data-testid="lineage-filter-{name}"]
+ *   - Node sidebar:  [data-testid="lineage-sidebar"]
  */
 
 import * as path from 'path';
@@ -29,6 +34,13 @@ import type { DataHubLogger } from '../utils/logger';
  * out rather than declared settled.
  */
 const VIEWPORT_SETTLE_MS = 2200;
+
+/** Toggles in the graph's filters panel, keyed by the suffix of their test id. */
+export type LineageFilterToggle =
+  | 'hide-transformations'
+  | 'hide-process-instances'
+  | 'show-ghost-entities'
+  | 'output-ports-only';
 
 export class LineageBasePage extends BasePage {
   // ── Static selector properties ───────────────────────────────────────────────
@@ -55,6 +67,8 @@ export class LineageBasePage extends BasePage {
   readonly lineageTabUpstreamOption: Locator;
   readonly columnDropdownVirtualList: Locator;
   readonly resultTextLink: Locator;
+  readonly lineageFiltersPanel: Locator;
+  readonly lineageSidebar: Locator;
 
   constructor(page: Page, logger?: DataHubLogger, logDir?: string) {
     super(page, logger, logDir);
@@ -86,6 +100,8 @@ export class LineageBasePage extends BasePage {
     this.columnDropdownVirtualList = page.locator('.rc-virtual-list');
     // eslint-disable-next-line playwright/no-raw-locators -- CSS class substring match for generated class name; no data-testid on ResultText
     this.resultTextLink = page.locator('.ant-list-items [class*="ResultText"]').first();
+    this.lineageFiltersPanel = page.getByTestId('lineage-filters-panel');
+    this.lineageSidebar = page.getByTestId('lineage-sidebar');
   }
 
   // ── Navigation ──────────────────────────────────────────────────────────────
@@ -104,6 +120,12 @@ export class LineageBasePage extends BasePage {
     await this.navigate(
       `/${entityType}/${urn}/Lineage?start_time_millis=${startTimeMillis}&end_time_millis=${endTimeMillis}`,
     );
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  /** Open a schema field's own lineage graph, e.g. from a column's "view lineage" action. */
+  async goToSchemaFieldLineage(fieldUrn: string): Promise<void> {
+    await this.navigate(`/schemaField/${fieldUrn}/Lineage`);
     await this.page.waitForLoadState('domcontentloaded');
   }
 
@@ -510,5 +532,102 @@ export class LineageBasePage extends BasePage {
   async clickUpstreamOption(): Promise<void> {
     await this.lineageTabDirectionSelect.click();
     await this.lineageTabUpstreamOption.last().click();
+  }
+
+  // ── Filters panel ───────────────────────────────────────────────────────────
+
+  /** Open the graph's filters panel, if it is not already open. */
+  async openFilterPanel(): Promise<void> {
+    if (!(await this.lineageFiltersPanel.isVisible())) {
+      await this.page.getByTestId('lineage-filters-button').click();
+    }
+    await expect(this.lineageFiltersPanel).toBeVisible({ timeout: 10000 });
+  }
+
+  getFilterToggle(filter: LineageFilterToggle): Locator {
+    return this.lineageFiltersPanel.getByTestId(`lineage-filter-${filter}`);
+  }
+
+  /**
+   * Set a filter toggle, opening the panel first. The toggle's `<input>` is transparent and sits
+   * under the slider that paints it, so dispatch the click rather than fighting actionability.
+   */
+  async setFilter(filter: LineageFilterToggle, enabled: boolean): Promise<void> {
+    await this.openFilterPanel();
+    const toggle = this.getFilterToggle(filter);
+    if ((await toggle.isChecked()) !== enabled) {
+      await toggle.dispatchEvent('click');
+    }
+    await expect(toggle).toBeChecked({ checked: enabled });
+  }
+
+  // ── Node selection and sidebar ──────────────────────────────────────────────
+
+  /** Click a node to select it, which opens the lineage sidebar for that entity. */
+  async clickNode(nodeUrn: string): Promise<void> {
+    await this.getReactFlowNode(nodeUrn).dispatchEvent('click');
+  }
+
+  /** Assert the lineage sidebar is open and showing the given entity. */
+  async checkSidebarShows(entityName: string): Promise<void> {
+    await expect(this.lineageSidebar).toBeVisible({ timeout: 15000 });
+    await expect(this.lineageSidebar.getByText(entityName).first()).toBeVisible({ timeout: 15000 });
+  }
+
+  // ── Column search and pagination within a node ──────────────────────────────
+
+  getColumnSearchInput(nodeUrn: string): Locator {
+    return this.page
+      .getByTestId(`lineage-node-${nodeUrn}`)
+      .getByTestId('column-search')
+      .getByTestId('search-bar-input');
+  }
+
+  async searchColumns(nodeUrn: string, query: string): Promise<void> {
+    const input = this.getColumnSearchInput(nodeUrn);
+    await input.click();
+    await input.fill(query);
+  }
+
+  async clearColumnSearch(nodeUrn: string): Promise<void> {
+    await this.getColumnSearchInput(nodeUrn).fill('');
+  }
+
+  getColumnPagination(nodeUrn: string): Locator {
+    return this.page.getByTestId(`lineage-node-${nodeUrn}`).getByTestId('column-pagination');
+  }
+
+  async goToColumnPage(nodeUrn: string, pageNumber: number): Promise<void> {
+    // antd renders each page button as li[title="<n>"]; title is the exact page number.
+    // eslint-disable-next-line playwright/no-raw-locators -- antd pagination item keyed by title attribute
+    await this.getColumnPagination(nodeUrn).locator(`li[title="${pageNumber}"]`).click();
+  }
+
+  /** The columns currently rendered on a node, in the order the node draws them. */
+  async getShownColumnNames(nodeUrn: string): Promise<string[]> {
+    const list = this.page.getByTestId(`lineage-node-${nodeUrn}`).getByTestId('columns-list');
+    // Each column's test id carries its own name, so match by prefix; the hover/selection
+    // readouts a column renders beside itself share that prefix and are not columns.
+    // eslint-disable-next-line playwright/no-raw-locators -- prefix match on generated per-column test ids
+    const testIds = await list
+      .locator('[data-testid^="column-"]:not([data-testid^="column-lineage-control-"])')
+      .evaluateAll((els) => els.map((el) => el.getAttribute('data-testid') ?? ''));
+    return testIds.map((id) => id.slice('column-'.length));
+  }
+
+  // ── Edge styling ────────────────────────────────────────────────────────────
+
+  /**
+   * Manually added edges are drawn dashed (`stroke-dasharray`), every other edge solid. The dash
+   * pattern itself is a style choice; assert only that the edge is dashed or is not.
+   */
+  async checkEdgeIsManual(node1Urn: string, node2Urn: string, isManual: boolean): Promise<void> {
+    // eslint-disable-next-line playwright/no-raw-locators -- ReactFlow edge path has no test id of its own
+    const path = this.page.getByTestId(`rf__edge-${node1Urn}-:-${node2Urn}`).locator('path.react-flow__edge-path');
+    if (isManual) {
+      await expect(path).not.toHaveCSS('stroke-dasharray', 'none');
+    } else {
+      await expect(path).toHaveCSS('stroke-dasharray', 'none');
+    }
   }
 }

--- a/e2e-test/ui/playwright/pages/lineage-base.page.ts
+++ b/e2e-test/ui/playwright/pages/lineage-base.page.ts
@@ -610,7 +610,9 @@ export class LineageBasePage extends BasePage {
     // readouts a column renders beside itself share that prefix and are not columns.
     // eslint-disable-next-line playwright/no-raw-locators -- prefix match on generated per-column test ids
     const testIds = await list
-      .locator('[data-testid^="column-"]:not([data-testid^="column-lineage-control-"])')
+      .locator(
+        '[data-testid^="column-"]:not([data-testid^="column-lineage-control-"]):not([data-testid^="column-lineage-count-"])',
+      )
       .evaluateAll((els) => els.map((el) => el.getAttribute('data-testid') ?? ''));
     return testIds.map((id) => id.slice('column-'.length));
   }

--- a/e2e-test/ui/playwright/tests/lineage-controls/constants.ts
+++ b/e2e-test/ui/playwright/tests/lineage-controls/constants.ts
@@ -1,0 +1,33 @@
+/** URNs seeded by fixtures/data.json, shared across the lineage-controls specs. */
+
+const PREFIX = 'playwright_lineage_controls';
+
+const dataset = (platform: string, name: string) =>
+  `urn:li:dataset:(urn:li:dataPlatform:${platform},${PREFIX}.${name},PROD)`;
+
+export const schemaField = (datasetUrn: string, column: string) => `urn:li:schemaField:(${datasetUrn},${column})`;
+
+// raw ──metric──▶ [model (dbt)] ──metric──▶ mart ──▶ chart
+export const RAW_URN = dataset('snowflake', 'raw');
+export const MODEL_DBT_URN = dataset('dbt', 'model');
+export const MART_URN = dataset('snowflake', 'mart');
+export const CHART_URN = `urn:li:chart:(looker,${PREFIX}.chart)`;
+
+// ghost_src ──value──▶ ghost_dst, which is soft deleted
+export const GHOST_SRC_URN = dataset('snowflake', 'ghost_src');
+export const GHOST_DST_URN = dataset('snowflake', 'ghost_dst');
+
+// wide_upstream ──col_01──▶ wide, which has 25 columns
+export const WIDE_URN = dataset('snowflake', 'wide');
+export const WIDE_UPSTREAM_URN = dataset('snowflake', 'wide_upstream');
+
+// sf_a ──breed──▶ sf_b ──breed──▶ sf_c
+export const SF_A_URN = dataset('snowflake', 'sf_a');
+export const SF_B_URN = dataset('snowflake', 'sf_b');
+export const SF_C_URN = dataset('snowflake', 'sf_c');
+
+export const BASE_FEATURE_FLAGS = {
+  themeV2Enabled: true,
+  themeV2Default: true,
+  showNavBarRedesign: true,
+};

--- a/e2e-test/ui/playwright/tests/lineage-controls/fixtures/data.json
+++ b/e2e-test/ui/playwright/tests/lineage-controls/fixtures/data.json
@@ -1,0 +1,1030 @@
+[
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.raw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "json": {
+        "name": "raw",
+        "description": "Upstream of the dbt transformation chain"
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.raw,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+      "json": {
+        "schemaName": "playwright_lineage_controls.raw",
+        "platform": "urn:li:dataPlatform:snowflake",
+        "version": 0,
+        "hash": "",
+        "platformSchema": {
+          "com.linkedin.schema.OtherSchema": {
+            "rawSchema": ""
+          }
+        },
+        "fields": [
+          {
+            "fieldPath": "id",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "metric",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,playwright_lineage_controls.model,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "json": {
+        "name": "model",
+        "description": "dbt model drawn as a transformation node"
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,playwright_lineage_controls.model,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+      "json": {
+        "schemaName": "playwright_lineage_controls.model",
+        "platform": "urn:li:dataPlatform:dbt",
+        "version": 0,
+        "hash": "",
+        "platformSchema": {
+          "com.linkedin.schema.OtherSchema": {
+            "rawSchema": ""
+          }
+        },
+        "fields": [
+          {
+            "fieldPath": "id",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "metric",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.mart,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "json": {
+        "name": "mart",
+        "description": "Downstream of the dbt transformation chain"
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.mart,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+      "json": {
+        "schemaName": "playwright_lineage_controls.mart",
+        "platform": "urn:li:dataPlatform:snowflake",
+        "version": 0,
+        "hash": "",
+        "platformSchema": {
+          "com.linkedin.schema.OtherSchema": {
+            "rawSchema": ""
+          }
+        },
+        "fields": [
+          {
+            "fieldPath": "id",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "metric",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:dbt,playwright_lineage_controls.model,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+      "json": {
+        "upstreams": [
+          {
+            "auditStamp": {
+              "time": 0,
+              "actor": "urn:li:corpuser:datahub"
+            },
+            "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.raw,PROD)",
+            "type": "TRANSFORMED"
+          }
+        ],
+        "fineGrainedLineages": [
+          {
+            "upstreamType": "FIELD_SET",
+            "downstreamType": "FIELD",
+            "upstreams": [
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.raw,PROD),metric)"
+            ],
+            "downstreams": [
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,playwright_lineage_controls.model,PROD),metric)"
+            ],
+            "confidenceScore": 1.0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.mart,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+      "json": {
+        "upstreams": [
+          {
+            "auditStamp": {
+              "time": 0,
+              "actor": "urn:li:corpuser:datahub"
+            },
+            "dataset": "urn:li:dataset:(urn:li:dataPlatform:dbt,playwright_lineage_controls.model,PROD)",
+            "type": "TRANSFORMED"
+          }
+        ],
+        "fineGrainedLineages": [
+          {
+            "upstreamType": "FIELD_SET",
+            "downstreamType": "FIELD",
+            "upstreams": [
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:dbt,playwright_lineage_controls.model,PROD),metric)"
+            ],
+            "downstreams": [
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.mart,PROD),metric)"
+            ],
+            "confidenceScore": 1.0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "chart",
+    "entityUrn": "urn:li:chart:(looker,playwright_lineage_controls.chart)",
+    "changeType": "UPSERT",
+    "aspectName": "chartInfo",
+    "aspect": {
+      "json": {
+        "title": "Lineage Controls Chart",
+        "description": "Chart downstream of the dbt transformation chain",
+        "lastModified": {
+          "created": {
+            "time": 0,
+            "actor": "urn:li:corpuser:datahub"
+          },
+          "lastModified": {
+            "time": 0,
+            "actor": "urn:li:corpuser:datahub"
+          }
+        },
+        "inputEdges": [
+          {
+            "destinationUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.mart,PROD)"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.ghost_src,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "json": {
+        "name": "ghost_src",
+        "description": "Upstream of a soft-deleted table"
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.ghost_src,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+      "json": {
+        "schemaName": "playwright_lineage_controls.ghost_src",
+        "platform": "urn:li:dataPlatform:snowflake",
+        "version": 0,
+        "hash": "",
+        "platformSchema": {
+          "com.linkedin.schema.OtherSchema": {
+            "rawSchema": ""
+          }
+        },
+        "fields": [
+          {
+            "fieldPath": "id",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "value",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.ghost_dst,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "json": {
+        "name": "ghost_dst",
+        "description": "Soft-deleted downstream table"
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.ghost_dst,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+      "json": {
+        "schemaName": "playwright_lineage_controls.ghost_dst",
+        "platform": "urn:li:dataPlatform:snowflake",
+        "version": 0,
+        "hash": "",
+        "platformSchema": {
+          "com.linkedin.schema.OtherSchema": {
+            "rawSchema": ""
+          }
+        },
+        "fields": [
+          {
+            "fieldPath": "id",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "value",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.ghost_dst,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+      "json": {
+        "upstreams": [
+          {
+            "auditStamp": {
+              "time": 0,
+              "actor": "urn:li:corpuser:datahub"
+            },
+            "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.ghost_src,PROD)",
+            "type": "TRANSFORMED"
+          }
+        ],
+        "fineGrainedLineages": [
+          {
+            "upstreamType": "FIELD_SET",
+            "downstreamType": "FIELD",
+            "upstreams": [
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.ghost_src,PROD),value)"
+            ],
+            "downstreams": [
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.ghost_dst,PROD),value)"
+            ],
+            "confidenceScore": 1.0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.ghost_dst,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+      "json": {
+        "removed": true
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.wide,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "json": {
+        "name": "wide",
+        "description": "25 columns, to paginate and search within a node"
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.wide,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+      "json": {
+        "schemaName": "playwright_lineage_controls.wide",
+        "platform": "urn:li:dataPlatform:snowflake",
+        "version": 0,
+        "hash": "",
+        "platformSchema": {
+          "com.linkedin.schema.OtherSchema": {
+            "rawSchema": ""
+          }
+        },
+        "fields": [
+          {
+            "fieldPath": "col_01",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_02",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_03",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_04",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_05",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_06",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_07",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_08",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_09",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_10",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_11",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_12",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_13",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_14",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_15",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_16",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_17",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_18",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_19",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_20",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_21",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_22",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_23",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_24",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "col_25",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.wide_upstream,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "json": {
+        "name": "wide_upstream",
+        "description": "Upstream of the wide table"
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.wide_upstream,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+      "json": {
+        "schemaName": "playwright_lineage_controls.wide_upstream",
+        "platform": "urn:li:dataPlatform:snowflake",
+        "version": 0,
+        "hash": "",
+        "platformSchema": {
+          "com.linkedin.schema.OtherSchema": {
+            "rawSchema": ""
+          }
+        },
+        "fields": [
+          {
+            "fieldPath": "col_01",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.wide,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+      "json": {
+        "upstreams": [
+          {
+            "auditStamp": {
+              "time": 0,
+              "actor": "urn:li:corpuser:datahub"
+            },
+            "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.wide_upstream,PROD)",
+            "type": "TRANSFORMED"
+          }
+        ],
+        "fineGrainedLineages": [
+          {
+            "upstreamType": "FIELD_SET",
+            "downstreamType": "FIELD",
+            "upstreams": [
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.wide_upstream,PROD),col_01)"
+            ],
+            "downstreams": [
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.wide,PROD),col_01)"
+            ],
+            "confidenceScore": 1.0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_a,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "json": {
+        "name": "sf_a",
+        "description": "First table in the schema field lineage chain"
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_a,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+      "json": {
+        "schemaName": "playwright_lineage_controls.sf_a",
+        "platform": "urn:li:dataPlatform:snowflake",
+        "version": 0,
+        "hash": "",
+        "platformSchema": {
+          "com.linkedin.schema.OtherSchema": {
+            "rawSchema": ""
+          }
+        },
+        "fields": [
+          {
+            "fieldPath": "id",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "breed",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_b,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "json": {
+        "name": "sf_b",
+        "description": "Second table in the schema field lineage chain"
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_b,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+      "json": {
+        "schemaName": "playwright_lineage_controls.sf_b",
+        "platform": "urn:li:dataPlatform:snowflake",
+        "version": 0,
+        "hash": "",
+        "platformSchema": {
+          "com.linkedin.schema.OtherSchema": {
+            "rawSchema": ""
+          }
+        },
+        "fields": [
+          {
+            "fieldPath": "id",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "breed",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_c,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+      "json": {
+        "name": "sf_c",
+        "description": "Third table in the schema field lineage chain"
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_c,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+      "json": {
+        "schemaName": "playwright_lineage_controls.sf_c",
+        "platform": "urn:li:dataPlatform:snowflake",
+        "version": 0,
+        "hash": "",
+        "platformSchema": {
+          "com.linkedin.schema.OtherSchema": {
+            "rawSchema": ""
+          }
+        },
+        "fields": [
+          {
+            "fieldPath": "id",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          },
+          {
+            "fieldPath": "breed",
+            "nullable": true,
+            "type": {
+              "type": {
+                "com.linkedin.schema.StringType": {}
+              }
+            },
+            "nativeDataType": "varchar",
+            "recursive": false
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_b,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+      "json": {
+        "upstreams": [
+          {
+            "auditStamp": {
+              "time": 0,
+              "actor": "urn:li:corpuser:datahub"
+            },
+            "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_a,PROD)",
+            "type": "TRANSFORMED"
+          }
+        ],
+        "fineGrainedLineages": [
+          {
+            "upstreamType": "FIELD_SET",
+            "downstreamType": "FIELD",
+            "upstreams": [
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_a,PROD),breed)"
+            ],
+            "downstreams": [
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_b,PROD),breed)"
+            ],
+            "confidenceScore": 1.0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_c,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "upstreamLineage",
+    "aspect": {
+      "json": {
+        "upstreams": [
+          {
+            "auditStamp": {
+              "time": 0,
+              "actor": "urn:li:corpuser:datahub"
+            },
+            "dataset": "urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_b,PROD)",
+            "type": "TRANSFORMED"
+          }
+        ],
+        "fineGrainedLineages": [
+          {
+            "upstreamType": "FIELD_SET",
+            "downstreamType": "FIELD",
+            "upstreams": [
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_b,PROD),breed)"
+            ],
+            "downstreams": [
+              "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:snowflake,playwright_lineage_controls.sf_c,PROD),breed)"
+            ],
+            "confidenceScore": 1.0
+          }
+        ]
+      }
+    }
+  }
+]

--- a/e2e-test/ui/playwright/tests/lineage-controls/lineage-filters.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-controls/lineage-filters.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * The graph's filters panel — "hide transformations" and "show hidden edges" (ghost entities).
+ *
+ * DATA SEEDING: static datasets from fixtures/data.json (auto-seeded via test.use below).
+ *
+ * Two of the seeded chains are used here:
+ *
+ *   transformations:  raw ──metric──▶ [model (dbt)] ──metric──▶ mart
+ *   ghost:            ghost_src ──value──▶ ghost_dst (soft deleted, so drawn as a ghost)
+ *
+ * Hiding transformations takes the dbt model off the graph without taking its column lineage
+ * with it: the arrow that ran raw.metric ──▶ model.metric ──▶ mart.metric is redrawn as a single
+ * hop straight from raw.metric to mart.metric. Ghost entities are the same story for
+ * soft-deleted nodes, which are off the graph until the toggle puts them back.
+ */
+
+import { test, expect } from '../../fixtures/base-test';
+import { LineageV3Page } from '../../pages/lineage-v3.page';
+import { TIMEOUTS } from '../../utils/constants';
+import { BASE_FEATURE_FLAGS, GHOST_DST_URN, GHOST_SRC_URN, MART_URN, MODEL_DBT_URN, RAW_URN } from './constants';
+
+test.use({ featureName: 'lineage-controls' });
+
+test.describe('lineage graph filters', () => {
+  let lineagePage: LineageV3Page;
+
+  test.beforeEach(async ({ page, logger, logDir, apiMock }) => {
+    lineagePage = new LineageV3Page(page, logger, logDir);
+    await apiMock.setFeatureFlags(BASE_FEATURE_FLAGS);
+  });
+
+  /** Open a dataset's lineage graph, wait for it to settle, and expand its columns. */
+  async function openLineageAndExpandColumns(homeUrn: string): Promise<void> {
+    await lineagePage.navigateToDatasetLineage(homeUrn);
+    await lineagePage.waitForGraphToRender();
+    // The minimap floats over the bottom-right of the canvas; after fitView a column can land
+    // under it, which intercepts pointer events and blocks hovers. Let hovers pass through it.
+    await lineagePage.page.addStyleTag({ content: '.react-flow__minimap { pointer-events: none !important; }' });
+    await lineagePage.expandContractColumns(homeUrn);
+    await lineagePage.waitForViewportToSettle();
+  }
+
+  test.describe('hide transformations', () => {
+    test('takes the dbt model off the graph and puts it back', async () => {
+      await lineagePage.navigateToDatasetLineage(RAW_URN);
+      await lineagePage.waitForGraphToRender();
+      await lineagePage.checkNodeExists(MODEL_DBT_URN);
+      await lineagePage.checkNodeExists(MART_URN);
+
+      await lineagePage.setFilter('hide-transformations', true);
+      await lineagePage.checkNodeNotExists(MODEL_DBT_URN);
+      // Hiding the transformation collapses the chain rather than truncating it: what the model
+      // fed still has to be reachable from what fed the model.
+      await lineagePage.checkNodeExists(MART_URN);
+      await lineagePage.checkEdgeExists(RAW_URN, MART_URN);
+
+      await lineagePage.setFilter('hide-transformations', false);
+      await lineagePage.checkNodeExists(MODEL_DBT_URN);
+      await lineagePage.checkEdgeExists(RAW_URN, MODEL_DBT_URN);
+      await lineagePage.checkEdgeExists(MODEL_DBT_URN, MART_URN);
+    });
+
+    test('keeps drawing column lineage through the hidden transformation', async () => {
+      await openLineageAndExpandColumns(RAW_URN);
+
+      // With the model shown, the column path is drawn in two hops, through it
+      await lineagePage.hoverColumn(RAW_URN, 'metric');
+      await expect(lineagePage.getColumnEdge(RAW_URN, 'metric', MODEL_DBT_URN, 'metric')).toBeAttached({
+        timeout: TIMEOUTS.MEDIUM,
+      });
+      await expect(lineagePage.getColumnEdge(MODEL_DBT_URN, 'metric', MART_URN, 'metric')).toBeAttached({
+        timeout: TIMEOUTS.MEDIUM,
+      });
+
+      await lineagePage.setFilter('hide-transformations', true);
+      await lineagePage.checkNodeNotExists(MODEL_DBT_URN);
+
+      // The readout only lives as long as the hover, and toggling a filter re-lays out the graph,
+      // which can slide the column out from under the cursor: re-hover and retry.
+      const collapsedEdge = lineagePage.getColumnEdge(RAW_URN, 'metric', MART_URN, 'metric');
+      await expect(async () => {
+        await lineagePage.hoverColumn(RAW_URN, 'metric');
+        await expect(collapsedEdge).toBeAttached({ timeout: TIMEOUTS.SHORT });
+      }).toPass({ timeout: TIMEOUTS.EXTRA_LONG });
+      await lineagePage.checkEdgeHasArrowMarker(collapsedEdge);
+    });
+  });
+
+  test.describe('show hidden edges', () => {
+    test('keeps a soft-deleted downstream off the graph until the toggle puts it back', async () => {
+      await lineagePage.navigateToDatasetLineage(GHOST_SRC_URN);
+      await lineagePage.waitForGraphToRender();
+      await lineagePage.checkNodeExists(GHOST_SRC_URN);
+      await lineagePage.checkNodeNotExists(GHOST_DST_URN);
+
+      await lineagePage.setFilter('show-ghost-entities', true);
+      await lineagePage.checkNodeExists(GHOST_DST_URN);
+      await lineagePage.checkEdgeExists(GHOST_SRC_URN, GHOST_DST_URN);
+
+      await lineagePage.setFilter('show-ghost-entities', false);
+      await lineagePage.checkNodeNotExists(GHOST_DST_URN);
+    });
+
+    test('draws column lineage into a soft-deleted downstream once it is shown', async () => {
+      await lineagePage.navigateToDatasetLineage(GHOST_SRC_URN);
+      await lineagePage.waitForGraphToRender();
+      await lineagePage.setFilter('show-ghost-entities', true);
+      await lineagePage.checkNodeExists(GHOST_DST_URN);
+
+      await lineagePage.page.addStyleTag({ content: '.react-flow__minimap { pointer-events: none !important; }' });
+      await lineagePage.expandContractColumns(GHOST_SRC_URN);
+      await lineagePage.waitForViewportToSettle();
+
+      const ghostEdge = lineagePage.getColumnEdge(GHOST_SRC_URN, 'value', GHOST_DST_URN, 'value');
+      await expect(async () => {
+        await lineagePage.hoverColumn(GHOST_SRC_URN, 'value');
+        await expect(ghostEdge).toBeAttached({ timeout: TIMEOUTS.SHORT });
+      }).toPass({ timeout: TIMEOUTS.EXTRA_LONG });
+    });
+  });
+});

--- a/e2e-test/ui/playwright/tests/lineage-controls/lineage-node-columns.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-controls/lineage-node-columns.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Searching and paginating the columns drawn inside a lineage node.
+ *
+ * DATA SEEDING: static datasets from fixtures/data.json (auto-seeded via test.use below).
+ *
+ *   wide_upstream ──col_01──▶ wide, which has 25 columns: col_01 … col_25
+ *
+ * A node draws NUM_COLUMNS_PER_PAGE (10) columns at a time in schema order, so the wide table
+ * takes three pages. The search box filters the whole column list, not just the page on screen,
+ * and the pagination follows what is left.
+ */
+
+import { test, expect } from '../../fixtures/base-test';
+import { LineageV3Page } from '../../pages/lineage-v3.page';
+import { TIMEOUTS } from '../../utils/constants';
+import { BASE_FEATURE_FLAGS, WIDE_URN } from './constants';
+
+test.use({ featureName: 'lineage-controls' });
+
+const PAGE_1_COLUMNS = [
+  'col_01',
+  'col_02',
+  'col_03',
+  'col_04',
+  'col_05',
+  'col_06',
+  'col_07',
+  'col_08',
+  'col_09',
+  'col_10',
+];
+const PAGE_3_COLUMNS = ['col_21', 'col_22', 'col_23', 'col_24', 'col_25'];
+
+test.describe('column search and pagination within a lineage node', () => {
+  let lineagePage: LineageV3Page;
+
+  test.beforeEach(async ({ page, logger, logDir, apiMock }) => {
+    lineagePage = new LineageV3Page(page, logger, logDir);
+    await apiMock.setFeatureFlags(BASE_FEATURE_FLAGS);
+
+    await lineagePage.navigateToDatasetLineage(WIDE_URN);
+    await lineagePage.waitForGraphToRender();
+    // The minimap floats over the bottom-right of the canvas; an expanded node's pagination can
+    // land under it, which intercepts the click. Let clicks pass through it.
+    await lineagePage.page.addStyleTag({ content: '.react-flow__minimap { pointer-events: none !important; }' });
+    await lineagePage.expandContractColumns(WIDE_URN);
+    await expect(lineagePage.getColumnSearchInput(WIDE_URN)).toBeVisible({ timeout: TIMEOUTS.MEDIUM });
+    await lineagePage.waitForViewportToSettle();
+  });
+
+  test('pages through the columns ten at a time', async () => {
+    expect(await lineagePage.getShownColumnNames(WIDE_URN)).toEqual(PAGE_1_COLUMNS);
+    // 25 columns over 10 per page: three page buttons
+    // eslint-disable-next-line playwright/no-raw-locators -- antd pagination items have no test id of their own
+    await expect(lineagePage.getColumnPagination(WIDE_URN).locator('li.ant-pagination-item')).toHaveCount(3);
+
+    await lineagePage.goToColumnPage(WIDE_URN, 3);
+    await expect
+      .poll(() => lineagePage.getShownColumnNames(WIDE_URN), { timeout: TIMEOUTS.MEDIUM })
+      .toEqual(PAGE_3_COLUMNS);
+
+    await lineagePage.goToColumnPage(WIDE_URN, 1);
+    await expect
+      .poll(() => lineagePage.getShownColumnNames(WIDE_URN), { timeout: TIMEOUTS.MEDIUM })
+      .toEqual(PAGE_1_COLUMNS);
+  });
+
+  test('searches across every column, not just the page on screen', async () => {
+    // col_23 is on the last page, so a search that finds it proves the filter runs over the
+    // whole column list rather than the ten columns currently drawn.
+    await lineagePage.searchColumns(WIDE_URN, 'col_23');
+    await expect
+      .poll(() => lineagePage.getShownColumnNames(WIDE_URN), { timeout: TIMEOUTS.MEDIUM })
+      .toEqual(['col_23']);
+    // One match fits on a single page, so the pagination goes away
+    await expect(lineagePage.getColumnPagination(WIDE_URN)).toHaveCount(0);
+
+    // A prefix matches a set, still drawn in schema order
+    await lineagePage.searchColumns(WIDE_URN, 'col_2');
+    await expect
+      .poll(() => lineagePage.getShownColumnNames(WIDE_URN), { timeout: TIMEOUTS.MEDIUM })
+      .toEqual(['col_20', 'col_21', 'col_22', 'col_23', 'col_24', 'col_25']);
+
+    // Clearing the search restores the full, paginated list
+    await lineagePage.clearColumnSearch(WIDE_URN);
+    await expect
+      .poll(() => lineagePage.getShownColumnNames(WIDE_URN), { timeout: TIMEOUTS.MEDIUM })
+      .toEqual(PAGE_1_COLUMNS);
+    await expect(lineagePage.getColumnPagination(WIDE_URN)).toBeVisible();
+  });
+});

--- a/e2e-test/ui/playwright/tests/lineage-controls/lineage-node-columns.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-controls/lineage-node-columns.spec.ts
@@ -49,7 +49,9 @@ test.describe('column search and pagination within a lineage node', () => {
   });
 
   test('pages through the columns ten at a time', async () => {
-    expect(await lineagePage.getShownColumnNames(WIDE_URN)).toEqual(PAGE_1_COLUMNS);
+    await expect
+      .poll(() => lineagePage.getShownColumnNames(WIDE_URN), { timeout: TIMEOUTS.MEDIUM })
+      .toEqual(PAGE_1_COLUMNS);
     // 25 columns over 10 per page: three page buttons
     // eslint-disable-next-line playwright/no-raw-locators -- antd pagination items have no test id of their own
     await expect(lineagePage.getColumnPagination(WIDE_URN).locator('li.ant-pagination-item')).toHaveCount(3);

--- a/e2e-test/ui/playwright/tests/lineage-controls/lineage-sidebar.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-controls/lineage-sidebar.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * The lineage sidebar — clicking a node on the graph selects it and opens its entity profile in
+ * a sidebar beside the canvas.
+ *
+ * DATA SEEDING: static datasets from fixtures/data.json (auto-seeded via test.use below).
+ *
+ *   raw ──▶ [model (dbt)] ──▶ mart ──▶ chart
+ *
+ * The graph is opened on `mart` so that all three kinds of node are one hop away: a warehouse
+ * dataset, a dbt model (drawn as a transformation node) and a Looker chart. Each has to be able
+ * to fill the sidebar, and selecting a new node has to replace what the last one put there.
+ */
+
+import { test, expect } from '../../fixtures/base-test';
+import { LineageV3Page } from '../../pages/lineage-v3.page';
+import { BASE_FEATURE_FLAGS, CHART_URN, MART_URN, MODEL_DBT_URN } from './constants';
+
+test.use({ featureName: 'lineage-controls' });
+
+test.describe('lineage sidebar', () => {
+  let lineagePage: LineageV3Page;
+
+  test.beforeEach(async ({ page, logger, logDir, apiMock }) => {
+    lineagePage = new LineageV3Page(page, logger, logDir);
+    await apiMock.setFeatureFlags(BASE_FEATURE_FLAGS);
+
+    await lineagePage.navigateToDatasetLineage(MART_URN);
+    await lineagePage.waitForGraphToRender();
+    await lineagePage.checkNodeExists(MODEL_DBT_URN);
+    await lineagePage.checkNodeExists(CHART_URN);
+    await lineagePage.waitForViewportToSettle();
+  });
+
+  test('opens for a dataset, a dbt model and a chart, one at a time', async () => {
+    await expect(lineagePage.lineageSidebar).toHaveCount(0);
+
+    await lineagePage.clickNode(MART_URN);
+    await lineagePage.checkSidebarShows('mart');
+
+    await lineagePage.clickNode(MODEL_DBT_URN);
+    await lineagePage.checkSidebarShows('model');
+
+    await lineagePage.clickNode(CHART_URN);
+    await lineagePage.checkSidebarShows('Lineage Controls Chart');
+
+    // One node is selected at a time, so one sidebar is open at a time
+    await expect(lineagePage.lineageSidebar).toHaveCount(1);
+  });
+});

--- a/e2e-test/ui/playwright/tests/lineage-controls/schema-field-lineage.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-controls/schema-field-lineage.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * A schema field's own lineage graph — the view reached from a column, at
+ * /schemaField/{urn}/Lineage, where every node is a column rather than a table.
+ *
+ * DATA SEEDING: static datasets from fixtures/data.json (auto-seeded via test.use below).
+ *
+ *   sf_a ──breed──▶ sf_b ──breed──▶ sf_c
+ *
+ * Opened on sf_a.breed, the graph draws one hop by default: sf_b.breed. Expanding that node has
+ * to reach sf_c.breed, exactly as expanding a table node does on the table graph.
+ */
+
+import { test } from '../../fixtures/base-test';
+import { LineageV3Page } from '../../pages/lineage-v3.page';
+import { BASE_FEATURE_FLAGS, SF_A_URN, SF_B_URN, SF_C_URN, schemaField } from './constants';
+
+test.use({ featureName: 'lineage-controls' });
+
+const A_BREED = schemaField(SF_A_URN, 'breed');
+const B_BREED = schemaField(SF_B_URN, 'breed');
+const C_BREED = schemaField(SF_C_URN, 'breed');
+
+test.describe('schema field lineage graph', () => {
+  let lineagePage: LineageV3Page;
+
+  test.beforeEach(async ({ page, logger, logDir, apiMock }) => {
+    lineagePage = new LineageV3Page(page, logger, logDir);
+    await apiMock.setFeatureFlags(BASE_FEATURE_FLAGS);
+  });
+
+  test('draws the field graph and expands it a hop at a time', async () => {
+    await lineagePage.goToSchemaFieldLineage(A_BREED);
+    await lineagePage.waitForGraphToRender();
+
+    await lineagePage.checkNodeExists(A_BREED);
+    await lineagePage.checkNodeExists(B_BREED);
+    await lineagePage.checkEdgeExists(A_BREED, B_BREED);
+    // Only one hop is drawn to begin with
+    await lineagePage.checkNodeNotExists(C_BREED);
+
+    await lineagePage.expandOne(B_BREED);
+    await lineagePage.checkNodeExists(C_BREED);
+    await lineagePage.checkEdgeExists(B_BREED, C_BREED);
+
+    await lineagePage.contract(B_BREED);
+    await lineagePage.checkNodeNotExists(C_BREED);
+  });
+});

--- a/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
+++ b/e2e-test/ui/playwright/tests/lineage-v3/v3-lineage-graph.spec.ts
@@ -555,6 +555,17 @@ test.describe('lineage v3 — lineage graph', () => {
     await lineagePage.checkEdgeExists(NODE7_DATAJOB_URN, NODE8_DATASET_URN);
   });
 
+  test('draws manually added edges dashed, and ingested ones solid', async () => {
+    // node5's upstream edge from node1 is seeded with `properties.source = UI`, which is what
+    // marks a lineage edge as manually added; node1 -> node2 is an ordinary ingested edge.
+    await lineagePage.goToLineageGraph(DATASET_ENTITY_TYPE, NODE1_DATASET_URN);
+    await lineagePage.checkEdgeExists(NODE1_DATASET_URN, NODE5_DATASET_MANUAL_URN);
+    await lineagePage.checkEdgeExists(NODE1_DATASET_URN, NODE2_DATASET_URN);
+
+    await lineagePage.checkEdgeIsManual(NODE1_DATASET_URN, NODE5_DATASET_MANUAL_URN, true);
+    await lineagePage.checkEdgeIsManual(NODE1_DATASET_URN, NODE2_DATASET_URN, false);
+  });
+
   test('should allow to expand and filter children', async ({ apiMock }) => {
     // The dedicated filter-node UI asserted below only renders when showLineageFilterNodes is on.
     await apiMock.setFeatureFlags({ ...BASE_FEATURE_FLAGS, showLineageFilterNodes: true });


### PR DESCRIPTION
Adds data-testids and tests for paginating columns; CLL; schema field lineage

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Playwright coverage for lineage graph controls and interactions, with `data-testid` hooks on the affected components so the tests can target them. No user-facing behavior changes.

**New Features**
- Covers column search and pagination, filter toggles, the entity sidebar, schema field lineage graphs, and manual vs. ingested edge styling.
- Adds seeded fixture data for the new specs under `e2e-test/ui/playwright/tests/lineage-controls/`.

<sup>Written for commit b839e5170d391a5bd1263802f060fd1ac891d603. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

