### PR TITLE
fix(cli): use quickstart GMS default for datapack load and dry-run

### DIFF
--- a/metadata-ingestion/src/datahub/cli/datapack/loader.py
+++ b/metadata-ingestion/src/datahub/cli/datapack/loader.py
@@ -853,7 +853,7 @@ def load_pack_into_datahub(
     Returns:
         The run_id used for this load.
     """
-    client_config = load_client_config()
+    client_config = _resolve_datapack_client_config()
     run_id = _generate_run_id(pack.name)
 
     if dry_run:
@@ -861,6 +861,7 @@ def load_pack_into_datahub(
             click.echo(f"\n--- File {i + 1}/{len(file_entries)}: {entry.path.name} ---")
             click.echo(f"Dry run - would load {entry.path}")
         click.echo(f"\nDry run complete for {len(file_entries)} files.")
+        click.echo(f"Would ingest to {client_config.server}.")
         return run_id
 
     ingest_datapack_file_entries(

--- a/metadata-ingestion/src/datahub/cli/datapack/loader.py
+++ b/metadata-ingestion/src/datahub/cli/datapack/loader.py
@@ -377,7 +377,7 @@ def check_version_compatibility(
         return
 
     try:
-        client_config = load_client_config()
+        client_config = _resolve_datapack_client_config()
         from datahub.ingestion.graph.client import DataHubGraph
 
         graph = DataHubGraph(client_config)

--- a/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
+++ b/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
@@ -1188,6 +1188,37 @@ class TestCheckVersionCompatibility:
         ):
             check_version_compatibility(pack, force=True)  # Should not raise
 
+    def test_missing_config_uses_quickstart_fallback(self) -> None:
+        from datahub.cli.config_utils import MissingConfigError
+        from datahub.cli.datapack.loader import check_version_compatibility
+
+        pack = DataPackInfo(
+            name="t", description="t", url="https://x.com", min_server_version="0.14.0"
+        )
+        mock_graph = MagicMock()
+        mock_graph.server_config.is_datahub_cloud = False
+        mock_graph.server_config.is_version_at_least.return_value = True
+
+        with (
+            patch(
+                "datahub.cli.datapack.loader.build_auth_config_from_env",
+                return_value=None,
+            ),
+            patch("datahub.cli.datapack.loader.get_skip_config", return_value=False),
+            patch(
+                "datahub.cli.datapack.loader.load_client_config",
+                side_effect=MissingConfigError("No ~/.datahubenv file found"),
+            ),
+            patch(
+                "datahub.ingestion.graph.client.DataHubGraph", return_value=mock_graph
+            ) as mock_graph_cls,
+        ):
+            check_version_compatibility(pack)
+
+        client_config = mock_graph_cls.call_args.args[0]
+        assert client_config.server == "http://localhost:8080"
+        assert client_config.token is None
+
 
 class TestReferentialIntegrity:
     def test_detects_dangling_references(

--- a/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
+++ b/metadata-ingestion/tests/unit/cli/datapack/test_loader.py
@@ -532,6 +532,41 @@ class TestLoadPackIntoDatahub:
         output = capsys.readouterr().out
         assert "Dry run" in output
         assert "data.json" in output
+        assert "Would ingest to http://localhost:8080." in output
+
+    @patch("datahub.cli.datapack.loader.build_auth_config_from_env", return_value=None)
+    @patch("datahub.cli.datapack.loader.get_skip_config", return_value=False)
+    @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
+    @patch("datahub.cli.datapack.loader._generate_run_id", return_value="generated-run")
+    @patch("datahub.cli.datapack.loader.load_client_config")
+    def test_dry_run_defaults_localhost_when_client_config_missing(
+        self,
+        mock_load_config: MagicMock,
+        mock_run_id: MagicMock,
+        mock_ingest: MagicMock,
+        mock_skip: MagicMock,
+        mock_auth: MagicMock,
+        tmp_path: pathlib.Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from datahub.cli.config_utils import MissingConfigError
+
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        pack = DataPackInfo(
+            name="bootstrap",
+            description="test",
+            url="https://example.com/bootstrap.json",
+            trust=TrustTier.VERIFIED,
+        )
+        mock_load_config.side_effect = MissingConfigError("No ~/.datahubenv file found")
+
+        run_id = load_pack_into_datahub(pack, [IndexFileEntry(data_file)], dry_run=True)
+
+        assert run_id == "generated-run"
+        mock_ingest.assert_not_called()
+        output = capsys.readouterr().out
+        assert "Would ingest to http://localhost:8080." in output
 
     @patch("datahub.cli.datapack.loader.save_load_record")
     @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
@@ -571,6 +606,42 @@ class TestLoadPackIntoDatahub:
         )
         mock_save.assert_called_once_with(pack, "generated-run")
         assert "loaded successfully" in capsys.readouterr().out
+
+    @patch("datahub.cli.datapack.loader.build_auth_config_from_env", return_value=None)
+    @patch("datahub.cli.datapack.loader.get_skip_config", return_value=False)
+    @patch("datahub.cli.datapack.loader.save_load_record")
+    @patch("datahub.cli.datapack.loader.ingest_datapack_file_entries")
+    @patch("datahub.cli.datapack.loader._generate_run_id", return_value="generated-run")
+    @patch("datahub.cli.datapack.loader.load_client_config")
+    def test_load_pack_defaults_localhost_when_client_config_missing(
+        self,
+        mock_load_config: MagicMock,
+        mock_run_id: MagicMock,
+        mock_ingest: MagicMock,
+        mock_save: MagicMock,
+        mock_skip: MagicMock,
+        mock_auth: MagicMock,
+        tmp_path: pathlib.Path,
+    ) -> None:
+        from datahub.cli.config_utils import MissingConfigError
+
+        data_file = tmp_path / "data.json"
+        data_file.write_text("[]")
+        pack = DataPackInfo(
+            name="bootstrap",
+            description="test",
+            url="https://example.com/bootstrap.json",
+            trust=TrustTier.VERIFIED,
+        )
+        mock_load_config.side_effect = MissingConfigError("No ~/.datahubenv file found")
+        entries = [IndexFileEntry(data_file)]
+
+        run_id = load_pack_into_datahub(pack, entries)
+
+        assert run_id == "generated-run"
+        client_config = mock_ingest.call_args.kwargs["client_config"]
+        assert client_config.server == "http://localhost:8080"
+        assert client_config.token is None
 
 
 class TestIsCached:


### PR DESCRIPTION
## Summary
- `datahub datapack load` (including `--dry-run`) now uses the same client-config resolver as ingest-sample-data / demo-data: `DATAHUB_GMS_URL`, then `~/.datahubenv`, then `http://localhost:8080`.
- Dry-run no longer fails with "No ~/.datahubenv file found"; it prints the server it would ingest to.

## Test plan
- [x] `./gradlew :metadata-ingestion:testSingle -PtestFile=tests/unit/cli/datapack/test_loader.py`
- [ ] With no `~/.datahubenv` and no `DATAHUB_GMS_URL`: `datahub datapack load showcase-ecommerce --dry-run` succeeds and prints `Would ingest to http://localhost:8080.`
- [ ] Same setup with a running quickstart: `datahub datapack load showcase-ecommerce` loads without `datahub init`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `datahub datapack load` (including `--dry-run` and the pre-ingest version check) resolve the GMS client config with the same fallback order as ingest-sample-data: `DATAHUB_GMS_URL`, then `~/.datahubenv`, then `http://localhost:8080`. Previously, both dry-run and version checks failed with "No ~/.datahubenv file found" when no config file existed.

**Behavior**
- Dry-run output now includes `Would ingest to http://localhost:8080.` when no config is present.
- Registry packs that set a `min_server_version` no longer require `datahub init` before loading.

<sup>Written for commit 291011d56b55fd2f7788ffbc6495082801ebb922. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

