### PR TITLE
refactor(ui): consolidate app/glossaryV2 with the Acryl fork

### DIFF
--- a/datahub-web-react/src/app/glossaryV2/BusinessGlossaryPage.tsx
+++ b/datahub-web-react/src/app/glossaryV2/BusinessGlossaryPage.tsx
@@ -35,6 +35,11 @@ const GlossaryWrapper = styled.div<{ $isShowNavBarRedesign?: boolean }>`
 const MainWrapper = styled.div<{ $isShowNavBarRedesign?: boolean }>`
     flex: 1;
     margin: ${(props) => (props.$isShowNavBarRedesign ? '0' : '0 16px 12px 12px')};
+    min-width: 0;
+    height: 100%;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
 `;
 
 const BusinessGlossaryPage = () => {

--- a/datahub-web-react/src/app/glossaryV2/GlossaryContentProvider.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryContentProvider.tsx
@@ -1,9 +1,10 @@
-import { Button } from '@components';
+import { Button, Tooltip } from '@components';
 import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components/macro';
 
+import { useUserContext } from '@app/context/useUserContext';
 import EmptyGlossarySection from '@app/glossaryV2/EmptyGlossarySection';
 import GlossaryEntitiesList from '@app/glossaryV2/GlossaryEntitiesList';
 import { BUSINESS_GLOSSARY_CREATE_TERM_GROUP_ID } from '@app/onboarding/config/BusinessGlossaryOnboardingConfig';
@@ -57,23 +58,31 @@ const GlossaryContentProvider = (props: Props) => {
         termsLoading,
         nodesLoading,
     } = props;
+    const { platformPrivileges } = useUserContext();
+    const showCreateGlossaryNode = platformPrivileges?.manageGlossaries;
 
     return (
         <MainContentWrapper data-testid="glossary-entities-list">
             <HeaderWrapper data-testid="glossaryPageV2">
                 <PageTitle title={t('page.title')} subTitle={t('page.subtitle')} />
-                <ButtonContainer>
-                    <Button
-                        data-testid="add-term-group-button-v2"
-                        id={BUSINESS_GLOSSARY_CREATE_TERM_GROUP_ID}
-                        size="md"
-                        icon={{ icon: Plus }}
-                        // can not be disabled on acryl-main due to ability to propose
-                        onClick={() => setIsCreateNodeModalVisible(true)}
-                    >
-                        {t('page.createGlossary')}
-                    </Button>
-                </ButtonContainer>
+                <Tooltip
+                    showArrow={false}
+                    title={showCreateGlossaryNode ? '' : t('page.contactAdmin')}
+                    placement="left"
+                >
+                    <ButtonContainer>
+                        <Button
+                            data-testid="add-term-group-button-v2"
+                            id={BUSINESS_GLOSSARY_CREATE_TERM_GROUP_ID}
+                            size="md"
+                            icon={{ icon: Plus }}
+                            disabled={!showCreateGlossaryNode}
+                            onClick={() => setIsCreateNodeModalVisible(true)}
+                        >
+                            {t('page.createGlossary')}
+                        </Button>
+                    </ButtonContainer>
+                </Tooltip>
             </HeaderWrapper>
             <ListWrapper>
                 {hasTermsOrNodes && <GlossaryEntitiesList nodes={nodes || []} terms={terms || []} />}

--- a/datahub-web-react/src/app/glossaryV2/GlossarySidebar.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossarySidebar.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Menu } from '@components';
+import { Avatar, Menu, Tooltip } from '@components';
 import { BookmarkSimple } from '@phosphor-icons/react/dist/csr/BookmarkSimple';
 import { BookmarksSimple } from '@phosphor-icons/react/dist/csr/BookmarksSimple';
 import { Plus } from '@phosphor-icons/react/dist/csr/Plus';
@@ -89,6 +89,7 @@ function GlossarySidebarInner() {
 
     const user = useUserContext();
     const canManageGlossaries = user?.platformPrivileges?.manageGlossaries;
+    const showCreateGlossary = canManageGlossaries;
 
     const entityRegistry = useEntityRegistry();
     const generateColor = useGenerateGlossaryColorFromPalette();
@@ -139,22 +140,39 @@ function GlossarySidebarInner() {
         [t],
     );
 
-    const headerActions = (
-        <Menu
-            open={isCreateMenuOpen}
-            onOpenChange={setIsCreateMenuOpen}
-            items={createMenuItems}
-            trigger={['click']}
-            placement="bottomRight"
-        >
-            <SidebarCreateButton
-                variant="filled"
-                color="primary"
-                isCircle
-                icon={{ icon: Plus }}
-                data-testid="create-glossary-button"
-            />
-        </Menu>
+    // Users who cannot create glossary entities get a disabled button plus a contact-admin
+    // tooltip rather than no button at all, so the action stays discoverable.
+    const headerActions = showCreateGlossary ? (
+        <Tooltip title={t('page.createGlossary')} placement="left" showArrow={false}>
+            <Menu
+                open={isCreateMenuOpen}
+                onOpenChange={setIsCreateMenuOpen}
+                items={createMenuItems}
+                trigger={['click']}
+                placement="bottomRight"
+            >
+                <SidebarCreateButton
+                    variant="filled"
+                    color="primary"
+                    isCircle
+                    icon={{ icon: Plus }}
+                    data-testid="create-glossary-button"
+                />
+            </Menu>
+        </Tooltip>
+    ) : (
+        <Tooltip title={t('page.contactAdmin')} placement="left" showArrow={false}>
+            <span style={{ display: 'inline-block' }}>
+                <SidebarCreateButton
+                    variant="filled"
+                    color="primary"
+                    isCircle
+                    icon={{ icon: Plus }}
+                    disabled
+                    data-testid="create-glossary-button"
+                />
+            </span>
+        </Tooltip>
     );
 
     const ownerOptions = useMemo(

--- a/datahub-web-react/src/app/glossaryV2/GlossaryTermPill.tsx
+++ b/datahub-web-react/src/app/glossaryV2/GlossaryTermPill.tsx
@@ -11,10 +11,10 @@ import PillRemoveIcon from '@app/sharedV2/icons/PillRemoveIcon';
  * `borderless` — inline-with-text usage (breadcrumbs, mentions, modal option rows). No chip body.
  * `highlighted` — chip is the active search match. Uses the hover border/background tokens.
  */
-export type GlossaryTermPillVariant = 'default' | 'borderless' | 'highlighted';
+type GlossaryTermPillVariant = 'default' | 'borderless' | 'highlighted';
 
 /** `md` is the canonical sidebar/modal size; `sm` is the compact size used in dense filter rows. */
-export type GlossaryTermPillSize = 'sm' | 'md';
+type GlossaryTermPillSize = 'sm' | 'md';
 
 const PillRoot = styled.span<{
     $variant: GlossaryTermPillVariant;

--- a/datahub-web-react/src/i18n/locales/de/governance.glossary.json
+++ b/datahub-web-react/src/i18n/locales/de/governance.glossary.json
@@ -9,6 +9,7 @@
     "empty.title": "Leeres Glossar",
     "list.error": "Glossar konnte nicht geladen werden! Ein unerwarteter Fehler ist aufgetreten.",
     "list.loading": "Glossar wird geladen...",
+    "page.contactAdmin": "Wende dich an deinen DataHub-Administrator, um das Glossar einzurichten.",
     "page.createGlossary": "Glossar erstellen",
     "page.subtitle": "Klassifiziere deine Daten-Assets und Spalten mithilfe von Datenwörterbüchern",
     "page.title": "Glossar",

--- a/datahub-web-react/src/i18n/locales/en/governance.glossary.json
+++ b/datahub-web-react/src/i18n/locales/en/governance.glossary.json
@@ -9,6 +9,7 @@
     "empty.title": "Empty Glossary",
     "list.error": "Failed to load glossary! An unexpected error occurred.",
     "list.loading": "Loading Glossary...",
+    "page.contactAdmin": "Reach out to your DataHub admin to set up Glossary.",
     "page.createGlossary": "Create Glossary",
     "page.subtitle": "Classify your data assets and columns using data dictionaries",
     "page.title": "Business Glossary",

--- a/datahub-web-react/src/i18n/locales/es/governance.glossary.json
+++ b/datahub-web-react/src/i18n/locales/es/governance.glossary.json
@@ -9,6 +9,7 @@
     "empty.title": "Glosario vacío",
     "list.error": "No se pudo cargar el glosario. Se produjo un error inesperado.",
     "list.loading": "Cargando glosario...",
+    "page.contactAdmin": "Póngase en contacto con su administrador de DataHub para configurar el Glosario.",
     "page.createGlossary": "Crear glosario",
     "page.subtitle": "Clasifique sus activos de datos y columnas mediante diccionarios de datos",
     "page.title": "Glosario de negocio",

--- a/datahub-web-react/src/i18n/locales/fi/governance.glossary.json
+++ b/datahub-web-react/src/i18n/locales/fi/governance.glossary.json
@@ -9,6 +9,7 @@
     "empty.title": "Tyhjä sanasto",
     "list.error": "Sanaston lataaminen epäonnistui! Tapahtui odottamaton virhe.",
     "list.loading": "Ladataan sanastoa...",
+    "page.contactAdmin": "Ota yhteyttä DataHub-pääkäyttäjääsi ottaaksesi sanaston käyttöön.",
     "page.createGlossary": "Luo sanasto",
     "page.subtitle": "Luokittele kohteesi ja sarakkeesi tietosanakirjojen avulla",
     "page.title": "Sanasto",

--- a/datahub-web-react/src/i18n/locales/fr/governance.glossary.json
+++ b/datahub-web-react/src/i18n/locales/fr/governance.glossary.json
@@ -9,6 +9,7 @@
     "empty.title": "Glossaire vide",
     "list.error": "Échec du chargement du glossaire! Une erreur inattendue s'est produite.",
     "list.loading": "Chargement du glossaire...",
+    "page.contactAdmin": "Contactez votre administrateur DataHub pour configurer le Glossaire.",
     "page.createGlossary": "Créer un glossaire",
     "page.subtitle": "Classer vos assets de données et vos colonnes à l'aide de dictionnaires de données",
     "page.title": "Glossaire",

--- a/datahub-web-react/src/i18n/locales/it/governance.glossary.json
+++ b/datahub-web-react/src/i18n/locales/it/governance.glossary.json
@@ -9,6 +9,7 @@
     "empty.title": "Glossario vuoto",
     "list.error": "Caricamento del glossario non riuscito. Si è verificato un errore imprevisto.",
     "list.loading": "Caricamento glossario in corso...",
+    "page.contactAdmin": "Contatta l'amministratore DataHub per configurare il glossario.",
     "page.createGlossary": "Crea glossario",
     "page.subtitle": "Classifica gli asset di dati e le colonne con dizionari dei dati",
     "page.title": "Glossario",

--- a/datahub-web-react/src/i18n/locales/ja/governance.glossary.json
+++ b/datahub-web-react/src/i18n/locales/ja/governance.glossary.json
@@ -7,6 +7,7 @@
     "empty.title": "空の用語集",
     "list.error": "用語集の読み込みに失敗しました!予期しないエラーが発生しました。",
     "list.loading": "用語集を読み込み中...",
+    "page.contactAdmin": "Glossaryを設定するには、DataHub管理者にお問い合わせください。",
     "page.createGlossary": "用語集を作成",
     "page.subtitle": "データ辞書を使ってAssetとColumnを分類します",
     "page.title": "業務用語集",

--- a/datahub-web-react/src/i18n/locales/nb/governance.glossary.json
+++ b/datahub-web-react/src/i18n/locales/nb/governance.glossary.json
@@ -9,6 +9,7 @@
     "empty.title": "Tom ordliste",
     "list.error": "Kunne ikke laste ordlisten! En uventet feil oppsto.",
     "list.loading": "Laster ordliste...",
+    "page.contactAdmin": "Ta kontakt med DataHub-administratoren din for å sette opp Ordliste.",
     "page.createGlossary": "Opprett ordliste",
     "page.subtitle": "Klassifiser dataressursene og kolonnene dine med dataordbøker",
     "page.title": "Ordliste",

--- a/datahub-web-react/src/i18n/locales/sv/governance.glossary.json
+++ b/datahub-web-react/src/i18n/locales/sv/governance.glossary.json
@@ -9,6 +9,7 @@
     "empty.title": "Tom ordlista",
     "list.error": "Kunde inte läsa in ordlistan! Ett oväntat fel uppstod.",
     "list.loading": "Läser in ordlistan...",
+    "page.contactAdmin": "Kontakta din DataHub-administratör för att konfigurera ordlistan.",
     "page.createGlossary": "Skapa ordlista",
     "page.subtitle": "Klassificera dina datatillgångar och kolumner med hjälp av dataordböcker",
     "page.title": "Ordlista",


### PR DESCRIPTION
Upstream the changes the fork made under app/glossaryV2 that are not tied to SaaS-only functionality, so the regular OSS -> SaaS merge has less to conflict over.

- BusinessGlossaryPage: harden the MainWrapper layout (flex column, min-width and min-height 0) so the content column sizes itself rather than relying on its child's height: 100%.
- GlossaryTermPill: drop `export` from GlossaryTermPillVariant and GlossaryTermPillSize - every consumer uses only the default export.
- GlossaryContentProvider, GlossarySidebar: gate glossary creation on manageGlossaries. Users without it now get a disabled button and a contact-admin tooltip instead of a modal whose own Create button is already disabled by the same privilege, so who may create is unchanged - only when they find out. Root-level creation resolves through GlossaryUtils.canManageChildrenEntities with a null parent node, which only MANAGE_GLOSSARIES satisfies.
- Add the page.contactAdmin key to the nine locales the fork translated.


<!--

Thank you for contributing to DataHub!

Before you submit your PR, please go through the checklist below:

- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [PR Title Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#pr-title-format))
- [ ] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable). If a new feature has been added a Usage Guide has been added for the same.
- [ ] For any breaking change/potential downtime/deprecation/big changes an entry has been made in [Updating DataHub](https://github.com/datahub-project/datahub/blob/master/docs/how/updating-datahub.md)


Allowed Types in PR Title: _feat_, _fix_, _refactor_, _docs_, _test_, _perf_, _style_, _build_, _ci_, _chore_


-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upstreams the Acryl fork's changes under the glossary V2 UI so the OSS-to-SaaS merge has less to reconcile. Users without `manageGlossaries` now see a disabled create button with a contact-admin tooltip instead of a modal whose own create action was already blocked.

- Hardens the main content wrapper layout so the column sizes itself instead of relying on its child's height.
- Drops `export` from the `GlossaryTermPill` variant and size types; all consumers use the default export.
- Adds the `page.contactAdmin` string to nine locales.
- Leaves `EmptyGlossarySection` ungated because it's shared with the glossary-node children tab, where `MANAGE_GLOSSARY_CHILDREN` is valid.

<sup>Written for commit 8db6e0e4995a84c216f00fb1f133c50646a0679f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

