### PR TITLE
fix(auth): let Edit Domain alone authorize domain changes

### DIFF
--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/DomainWriteAuthorizationValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/DomainWriteAuthorizationValidator.java
@@ -33,9 +33,11 @@ import lombok.experimental.Accessors;
 /**
  * Authorizes {@code domains} writes for domain-separated writers.
  *
- * <p>CREATE / UPSERT establishing domains still match Create/Edit against proposed domains. {@code
- * PATCH} always uses Edit Entity and requires the actor to be allowed for both before and after
- * domains when before membership exists (after-only when establishing first domains).
+ * <p>CREATE / UPSERT establishing domains still match Create/Edit Entity against proposed domains.
+ * Updates on existing entities (including {@code PATCH}) accept {@code EDIT_ENTITY} <em>or</em>
+ * {@code EDIT_DOMAINS_PRIVILEGE}; domain resource filters still apply. {@code PATCH} requires the
+ * actor to be allowed for both before and after domains when before membership exists (after-only
+ * when establishing first domains).
  *
  * <p>In-transaction {@code validatePreCommit} re-checks when a user session is present (sync):
  * before+after Edit when domains already exist, otherwise Create/Edit establish against proposed
@@ -106,7 +108,7 @@ public class DomainWriteAuthorizationValidator extends AbstractAspectAuthorizati
                   item,
                   "Unauthorized to edit domains on entity "
                       + urn
-                      + " (domain-scoped Edit Entity policy does not allow before and/or after domains)"));
+                      + " (requires EDIT_DOMAINS_PRIVILEGE or EDIT_ENTITY for current and proposed domains)"));
         }
         continue;
       }
@@ -131,9 +133,7 @@ public class DomainWriteAuthorizationValidator extends AbstractAspectAuthorizati
                     + (exists ? "edit" : "create")
                     + " domains on entity "
                     + urn
-                    + (useProposed
-                        ? " (proposed domain does not match domain-scoped write policy)"
-                        : "")));
+                    + domainsAuthHint(exists, useProposed)));
       }
     }
     return failures;
@@ -178,7 +178,7 @@ public class DomainWriteAuthorizationValidator extends AbstractAspectAuthorizati
                   item,
                   "Unauthorized to edit domains on entity "
                       + urn
-                      + " (domain-scoped Edit Entity policy does not allow before and/or after domains)"));
+                      + " (requires EDIT_DOMAINS_PRIVILEGE or EDIT_ENTITY for current and proposed domains)"));
         }
         continue;
       }
@@ -198,7 +198,7 @@ public class DomainWriteAuthorizationValidator extends AbstractAspectAuthorizati
                     + (exists ? "edit" : "create")
                     + " domains on entity "
                     + urn
-                    + " (proposed domain does not match domain-scoped write policy)"));
+                    + domainsAuthHint(exists, true)));
       }
     }
     return failures.stream();
@@ -217,5 +217,21 @@ public class DomainWriteAuthorizationValidator extends AbstractAspectAuthorizati
       return true;
     }
     return opContext.isSystemAuth();
+  }
+
+  /**
+   * Privilege hint for ingest-time domain auth failures. Create still requires Create/Edit Entity;
+   * updates accept Edit Domain or Edit Entity. Domain-scoped policies are mentioned only when the
+   * check evaluated proposed domains.
+   */
+  static String domainsAuthHint(boolean entityExists, boolean usedProposedDomains) {
+    String privileges =
+        entityExists
+            ? "requires EDIT_DOMAINS_PRIVILEGE or EDIT_ENTITY"
+            : "requires CREATE_ENTITY or EDIT_ENTITY";
+    if (usedProposedDomains) {
+      return " (" + privileges + "; proposed domain must match any domain-scoped write policy)";
+    }
+    return " (" + privileges + ")";
   }
 }

--- a/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/DomainWriteAuthorizationValidator.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/aspect/validation/DomainWriteAuthorizationValidator.java
@@ -35,9 +35,10 @@ import lombok.experimental.Accessors;
  *
  * <p>CREATE / UPSERT establishing domains still match Create/Edit Entity against proposed domains.
  * Updates on existing entities (including {@code PATCH}) accept {@code EDIT_ENTITY} <em>or</em>
- * {@code EDIT_DOMAINS_PRIVILEGE}; domain resource filters still apply. {@code PATCH} requires the
- * actor to be allowed for both before and after domains when before membership exists (after-only
- * when establishing first domains).
+ * {@code EDIT_DOMAINS_PRIVILEGE}; domain resource filters still apply. {@code PATCH} on a missing
+ * entity is authorized as Create/Edit Entity only. On an existing entity, PATCH requires the actor
+ * to be allowed for both before and after domains when before membership exists (after-only when
+ * establishing first domains).
  *
  * <p>In-transaction {@code validatePreCommit} re-checks when a user session is present (sync):
  * before+after Edit when domains already exist, otherwise Create/Edit establish against proposed
@@ -99,6 +100,22 @@ public class DomainWriteAuthorizationValidator extends AbstractAspectAuthorizati
                   "Unauthorized to edit domains via PATCH on entity "
                       + urn
                       + " (could not resolve proposed domains from patch)"));
+          continue;
+        }
+        ApiOperation patchOperation =
+            DomainWriteAuthorizationUtils.resolveApiOperation(ChangeType.PATCH, exists);
+        if (ApiOperation.CREATE.equals(patchOperation)) {
+          boolean allowed =
+              DomainWriteAuthorizationUtils.isAuthorizedEntityWrite(
+                  session, urn, ApiOperation.CREATE, true, afterDomains);
+          if (!allowed) {
+            failures.add(
+                authFailure(
+                    item,
+                    "Unauthorized to create domains on entity "
+                        + urn
+                        + domainsAuthHint(false, true)));
+          }
           continue;
         }
         if (!DomainWriteAuthorizationUtils.isAuthorizedDomainsEdit(

--- a/metadata-io/src/main/java/com/linkedin/metadata/authorization/DomainWriteAuthorizationUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/authorization/DomainWriteAuthorizationUtils.java
@@ -39,14 +39,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * Helpers for domain-separated writers: privilege selection by entity existence, proposed-domain
- * resolution (including PATCH apply), and authorizing writes against domain-scoped Create/Edit
- * policies (including before/after Edit reconciliation for {@code domains} PATCH).
+ * resolution (including PATCH apply), and authorizing {@code domains} writes against domain-scoped
+ * Create/Edit Entity policies or the aspect-specific Edit Domain privilege (including before/after
+ * reconciliation for {@code domains} PATCH).
  */
 @Slf4j
 public final class DomainWriteAuthorizationUtils {
@@ -222,7 +224,31 @@ public final class DomainWriteAuthorizationUtils {
   }
 
   /**
-   * Authorize domain-scoped {@code EDIT_ENTITY} for a domains write given before/after membership.
+   * Privileges that can authorize a {@code domains} aspect write.
+   *
+   * <p>{@link ApiOperation#UPDATE} (set / clear / move on an existing entity) accepts {@code
+   * EDIT_ENTITY} <em>or</em> {@code EDIT_DOMAINS_PRIVILEGE}. Domain resource filters still apply to
+   * whichever privilege matches. {@link ApiOperation#CREATE} stays Create/Edit Entity only so Edit
+   * Domain cannot create entities.
+   */
+  @Nonnull
+  public static Disjunctive<Conjunctive<PoliciesConfig.Privilege>> lookupDomainsAspectPrivileges(
+      @Nonnull ApiOperation apiOperation, @Nonnull String entityType) {
+    Disjunctive<Conjunctive<PoliciesConfig.Privilege>> entityPrivileges =
+        AuthUtil.lookupAPIPrivilege(ENTITY, apiOperation, entityType);
+    if (apiOperation != UPDATE) {
+      return entityPrivileges;
+    }
+    return new Disjunctive<>(
+        Stream.concat(
+                entityPrivileges.stream(),
+                Stream.of(Conjunctive.of(PoliciesConfig.EDIT_ENTITY_DOMAINS_PRIVILEGE)))
+            .collect(Collectors.toList()));
+  }
+
+  /**
+   * Authorize a domains write given before/after membership. Update-path checks accept Edit Domain
+   * or Edit Entity; domain-scoped policies must still match the seeded domain field.
    *
    * <ul>
    *   <li>No before domains: match against after only (first-domains pattern).
@@ -444,8 +470,11 @@ public final class DomainWriteAuthorizationUtils {
   }
 
   /**
-   * Authorize a write against the entity resource, optionally seeding the session resource-spec
-   * cache with proposed domains (plus ancestors) so domain-scoped policies can match.
+   * Authorize a {@code domains} write against the entity resource, optionally seeding the session
+   * resource-spec cache with proposed domains (plus ancestors) so domain-scoped policies can match.
+   *
+   * <p>On {@link ApiOperation#UPDATE}, {@code EDIT_DOMAINS_PRIVILEGE} is sufficient; Create still
+   * requires Create/Edit Entity.
    */
   public static boolean isAuthorizedEntityWrite(
       @Nonnull AuthorizationSession session,
@@ -463,7 +492,7 @@ public final class DomainWriteAuthorizationUtils {
     return AuthUtil.isAuthorized(
         session,
         AuthUtil.buildDisjunctivePrivilegeGroup(
-            AuthUtil.lookupAPIPrivilege(ENTITY, apiOperation, urn.getEntityType())),
+            lookupDomainsAspectPrivileges(apiOperation, urn.getEntityType())),
         resourceSpec);
   }
 

--- a/metadata-io/src/main/java/com/linkedin/metadata/authorization/DomainWriteAuthorizationUtils.java
+++ b/metadata-io/src/main/java/com/linkedin/metadata/authorization/DomainWriteAuthorizationUtils.java
@@ -205,8 +205,8 @@ public final class DomainWriteAuthorizationUtils {
       case CREATE:
         return UPDATE;
       case PATCH:
-        // PATCH never uses CREATE_ENTITY — always Edit Entity.
-        return UPDATE;
+        // PATCH on a missing entity is a create; Edit Domain must not suffice.
+        return entityExists ? UPDATE : CREATE;
       case UPSERT:
       case UPDATE:
       case RESTATE:

--- a/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/DomainWriteAuthorizationValidatorTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/aspect/validation/DomainWriteAuthorizationValidatorTest.java
@@ -240,6 +240,71 @@ public class DomainWriteAuthorizationValidatorTest {
   }
 
   @Test
+  public void testPatchOnMissingEntityUsesCreatePrivilege() {
+    TestMCP patchItem =
+        TestMCP.builder()
+            .urn(DATASET_URN)
+            .entitySpec(entitySpec)
+            .aspectSpec(domainsAspectSpec)
+            .changeType(ChangeType.PATCH)
+            .build();
+    Domains after = new Domains().setDomains(new UrnArray(List.of(DOMAIN_X)));
+    when(aspectRetriever.entityExists(any(), eq(Set.of(DATASET_URN))))
+        .thenReturn(Map.of(DATASET_URN, false));
+    when(aspectRetriever.getLatestAspectObjects(any(), eq(Set.of(DATASET_URN)), any()))
+        .thenReturn(Map.of(DATASET_URN, Map.of()));
+    domainWriteUtilsMock
+        .when(
+            () ->
+                DomainWriteAuthorizationUtils.resolveAndAccumulateProposedDomains(
+                    eq(patchItem), eq(aspectRetriever), any(), any()))
+        .thenReturn(after);
+    domainWriteUtilsMock
+        .when(
+            () ->
+                DomainWriteAuthorizationUtils.isAuthorizedEntityWrite(
+                    eq(session), eq(DATASET_URN), eq(ApiOperation.CREATE), eq(true), eq(after)))
+        .thenReturn(true);
+
+    assertEquals(validate(patchItem).count(), 0);
+    domainWriteUtilsMock.verify(
+        () ->
+            DomainWriteAuthorizationUtils.isAuthorizedEntityWrite(
+                eq(session), eq(DATASET_URN), eq(ApiOperation.CREATE), eq(true), eq(after)));
+    domainWriteUtilsMock.verify(
+        () -> DomainWriteAuthorizationUtils.isAuthorizedDomainsEdit(any(), any(), any(), any()),
+        Mockito.never());
+  }
+
+  @Test
+  public void testPatchOnMissingEntityDeniesWhenCreateUnauthorized() {
+    TestMCP patchItem =
+        TestMCP.builder()
+            .urn(DATASET_URN)
+            .entitySpec(entitySpec)
+            .aspectSpec(domainsAspectSpec)
+            .changeType(ChangeType.PATCH)
+            .build();
+    Domains after = new Domains().setDomains(new UrnArray(List.of(DOMAIN_X)));
+    when(aspectRetriever.entityExists(any(), eq(Set.of(DATASET_URN))))
+        .thenReturn(Map.of(DATASET_URN, false));
+    when(aspectRetriever.getLatestAspectObjects(any(), eq(Set.of(DATASET_URN)), any()))
+        .thenReturn(Map.of(DATASET_URN, Map.of()));
+    domainWriteUtilsMock
+        .when(
+            () ->
+                DomainWriteAuthorizationUtils.resolveAndAccumulateProposedDomains(
+                    eq(patchItem), eq(aspectRetriever), any(), any()))
+        .thenReturn(after);
+    stubWriteAuth(false);
+
+    assertEquals(validate(patchItem).count(), 1);
+    domainWriteUtilsMock.verify(
+        () -> DomainWriteAuthorizationUtils.isAuthorizedDomainsEdit(any(), any(), any(), any()),
+        Mockito.never());
+  }
+
+  @Test
   public void testPatchUsesBeforeAfterEditHelper() {
     TestMCP patchItem =
         TestMCP.builder()
@@ -326,8 +391,12 @@ public class DomainWriteAuthorizationValidatorTest {
     domainWriteUtilsMock
         .when(
             () ->
-                DomainWriteAuthorizationUtils.isAuthorizedDomainsEdit(
-                    eq(session), eq(DATASET_URN), eq(upsertDomains), eq(patchDomains)))
+                DomainWriteAuthorizationUtils.isAuthorizedEntityWrite(
+                    eq(session),
+                    eq(DATASET_URN),
+                    eq(ApiOperation.CREATE),
+                    eq(true),
+                    eq(patchDomains)))
         .thenReturn(true);
 
     assertEquals(
@@ -338,8 +407,11 @@ public class DomainWriteAuthorizationValidatorTest {
         0);
     domainWriteUtilsMock.verify(
         () ->
-            DomainWriteAuthorizationUtils.isAuthorizedDomainsEdit(
-                eq(session), eq(DATASET_URN), eq(upsertDomains), eq(patchDomains)));
+            DomainWriteAuthorizationUtils.isAuthorizedEntityWrite(
+                eq(session), eq(DATASET_URN), eq(ApiOperation.CREATE), eq(true), eq(patchDomains)));
+    domainWriteUtilsMock.verify(
+        () -> DomainWriteAuthorizationUtils.isAuthorizedDomainsEdit(any(), any(), any(), any()),
+        Mockito.never());
   }
 
   @Test

--- a/metadata-io/src/test/java/com/linkedin/metadata/authorization/DomainWriteAuthorizationUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/authorization/DomainWriteAuthorizationUtilsTest.java
@@ -113,10 +113,14 @@ public class DomainWriteAuthorizationUtilsTest {
   }
 
   @Test
-  public void testResolveApiOperation_patchAlwaysUpdate() {
+  public void testResolveApiOperation_patchMissingEntityUsesCreate() {
     assertEquals(
         DomainWriteAuthorizationUtils.resolveApiOperation(ChangeType.PATCH, false),
-        ApiOperation.UPDATE);
+        ApiOperation.CREATE);
+  }
+
+  @Test
+  public void testResolveApiOperation_patchExistingUsesUpdate() {
     assertEquals(
         DomainWriteAuthorizationUtils.resolveApiOperation(ChangeType.PATCH, true),
         ApiOperation.UPDATE);

--- a/metadata-io/src/test/java/com/linkedin/metadata/authorization/DomainWriteAuthorizationUtilsTest.java
+++ b/metadata-io/src/test/java/com/linkedin/metadata/authorization/DomainWriteAuthorizationUtilsTest.java
@@ -12,6 +12,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import com.datahub.authorization.AuthorizationResult;
 import com.datahub.authorization.AuthorizationSession;
 import com.datahub.authorization.EntityFieldType;
 import com.datahub.authorization.FieldResolver;
@@ -136,6 +137,52 @@ public class DomainWriteAuthorizationUtilsTest {
     Domains before = new Domains().setDomains(new UrnArray(List.of(DOMAIN_X)));
     assertFalse(
         DomainWriteAuthorizationUtils.isAuthorizedDomainsEdit(session, DATASET_URN, before, null));
+  }
+
+  @Test
+  public void testLookupDomainsAspectPrivileges_updateIncludesEditDomain() {
+    Disjunctive<Conjunctive<PoliciesConfig.Privilege>> privileges =
+        DomainWriteAuthorizationUtils.lookupDomainsAspectPrivileges(ApiOperation.UPDATE, "dataset");
+    assertTrue(containsPrivilege(privileges, PoliciesConfig.EDIT_ENTITY_PRIVILEGE));
+    assertTrue(containsPrivilege(privileges, PoliciesConfig.EDIT_ENTITY_DOMAINS_PRIVILEGE));
+  }
+
+  @Test
+  public void testLookupDomainsAspectPrivileges_createOmitsEditDomain() {
+    Disjunctive<Conjunctive<PoliciesConfig.Privilege>> privileges =
+        DomainWriteAuthorizationUtils.lookupDomainsAspectPrivileges(ApiOperation.CREATE, "dataset");
+    assertFalse(containsPrivilege(privileges, PoliciesConfig.EDIT_ENTITY_DOMAINS_PRIVILEGE));
+    assertTrue(containsPrivilege(privileges, PoliciesConfig.EDIT_ENTITY_PRIVILEGE));
+  }
+
+  @Test
+  public void testIsAuthorizedEntityWrite_updateAllowsEditDomainAlone() {
+    AuthorizationSession session =
+        sessionAllowing(PoliciesConfig.EDIT_ENTITY_DOMAINS_PRIVILEGE.getType());
+    Domains proposed = new Domains().setDomains(new UrnArray(List.of(DOMAIN_X)));
+    assertTrue(
+        DomainWriteAuthorizationUtils.isAuthorizedEntityWrite(
+            session, DATASET_URN, ApiOperation.UPDATE, true, proposed));
+  }
+
+  @Test
+  public void testIsAuthorizedEntityWrite_createRejectsEditDomainAlone() {
+    AuthorizationSession session =
+        sessionAllowing(PoliciesConfig.EDIT_ENTITY_DOMAINS_PRIVILEGE.getType());
+    Domains proposed = new Domains().setDomains(new UrnArray(List.of(DOMAIN_X)));
+    assertFalse(
+        DomainWriteAuthorizationUtils.isAuthorizedEntityWrite(
+            session, DATASET_URN, ApiOperation.CREATE, true, proposed));
+  }
+
+  @Test
+  public void testIsAuthorizedDomainsEdit_clearAllowedWithEditDomain() {
+    AuthorizationSession session =
+        sessionAllowing(PoliciesConfig.EDIT_ENTITY_DOMAINS_PRIVILEGE.getType());
+    Domains before = new Domains().setDomains(new UrnArray(List.of(DOMAIN_X)));
+    assertTrue(
+        DomainWriteAuthorizationUtils.isAuthorizedDomainsEdit(
+            session, DATASET_URN, before, new Domains().setDomains(new UrnArray())));
   }
 
   @Test
@@ -374,6 +421,27 @@ public class DomainWriteAuthorizationUtilsTest {
         return new AspectTemplateEngine(aspectTemplateMap);
       }
     };
+  }
+
+  private static boolean containsPrivilege(
+      Disjunctive<Conjunctive<PoliciesConfig.Privilege>> privileges,
+      PoliciesConfig.Privilege privilege) {
+    return privileges.stream().anyMatch(conjunct -> conjunct.contains(privilege));
+  }
+
+  private static AuthorizationSession sessionAllowing(String privilegeType) {
+    AuthorizationSession session = mock(AuthorizationSession.class);
+    when(session.authorize(any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              String privilege = invocation.getArgument(0);
+              boolean allowed = privilegeType.equals(privilege);
+              return new AuthorizationResult(
+                  null,
+                  allowed ? AuthorizationResult.Type.ALLOW : AuthorizationResult.Type.DENY,
+                  null);
+            });
+    return session;
   }
 
   @Nonnull


### PR DESCRIPTION
## Summary
- Fixes PM-318: GraphQL already allows setting or clearing an entity's domain with **Edit Domain** *or* **Edit Entity**. Ingest-time authorization only accepted Create/Edit Entity, so a policy that grants Edit Domain without Edit Entity was denied after the GraphQL check passed.
- Domain writes on existing entities now accept `EDIT_DOMAINS_PRIVILEGE` or `EDIT_ENTITY`. Domain resource filters still apply to whichever privilege matches.
- Creating a new entity still requires Create/Edit Entity, so domain-scoped ingestion isolation is unchanged. Auth failure messages name the privilege that was required instead of always implying a domain-scoped policy mismatch.

## Test plan
- [x] `./gradlew :metadata-io:spotlessCheck`
- [x] `./gradlew :metadata-io:test --tests com.linkedin.metadata.authorization.DomainWriteAuthorizationUtilsTest --tests com.linkedin.metadata.aspect.validation.DomainWriteAuthorizationValidatorTest`
- [ ] Set a domain on an existing entity as a user with Edit Domain only (no Edit Entity)
- [ ] Clear a domain as the same user (unscoped Edit Domain policy)
- [ ] Confirm a domain-scoped Create/Edit Entity writer still cannot assign a domain outside that policy