### PR TITLE
fix(assertions): register a patch template for assertionRunSummary so the summary can be created

### DIFF
--- a/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/assertion/AssertionRunSummaryTemplate.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/aspect/patch/template/assertion/AssertionRunSummaryTemplate.java
@@ -1,0 +1,49 @@
+package com.linkedin.metadata.aspect.patch.template.assertion;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.linkedin.assertion.AssertionRunSummary;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.aspect.patch.template.Template;
+import javax.annotation.Nonnull;
+
+/**
+ * Patch template for the {@link AssertionRunSummary} aspect.
+ *
+ * <p>Registering a template is what allows the first PATCH for an assertion to be applied: without
+ * a default, {@code PatchItemImpl.applyTemplatePatch} has no base value and rejects the patch, so
+ * the summary could never be created.
+ */
+public class AssertionRunSummaryTemplate implements Template<AssertionRunSummary> {
+
+  @Override
+  public AssertionRunSummary getSubtype(RecordTemplate recordTemplate) throws ClassCastException {
+    if (recordTemplate instanceof AssertionRunSummary) {
+      return (AssertionRunSummary) recordTemplate;
+    }
+    throw new ClassCastException("Unable to cast RecordTemplate to AssertionRunSummary");
+  }
+
+  @Override
+  public Class<AssertionRunSummary> getTemplateType() {
+    return AssertionRunSummary.class;
+  }
+
+  @Nonnull
+  @Override
+  public AssertionRunSummary getDefault() {
+    // Every field is optional; the hook patches individual fields onto this empty base.
+    return new AssertionRunSummary();
+  }
+
+  @Nonnull
+  @Override
+  public JsonNode transformFields(JsonNode baseNode) {
+    return baseNode;
+  }
+
+  @Nonnull
+  @Override
+  public JsonNode rebaseFields(JsonNode patched) {
+    return patched;
+  }
+}

--- a/entity-registry/src/main/java/com/linkedin/metadata/models/registry/SnapshotEntityRegistry.java
+++ b/entity-registry/src/main/java/com/linkedin/metadata/models/registry/SnapshotEntityRegistry.java
@@ -7,6 +7,7 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.data.template.UnionTemplate;
 import com.linkedin.metadata.aspect.patch.template.AspectTemplateEngine;
 import com.linkedin.metadata.aspect.patch.template.Template;
+import com.linkedin.metadata.aspect.patch.template.assertion.AssertionRunSummaryTemplate;
 import com.linkedin.metadata.aspect.patch.template.chart.ChartInfoTemplate;
 import com.linkedin.metadata.aspect.patch.template.common.DocumentationTemplate;
 import com.linkedin.metadata.aspect.patch.template.common.DomainsTemplate;
@@ -136,6 +137,7 @@ public class SnapshotEntityRegistry implements EntityRegistry {
     aspectSpecTemplateMap.put(
         ML_MODEL_GROUP_EDITABLE_PROPERTIES_ASPECT_NAME,
         new EditableMLModelGroupPropertiesTemplate());
+    aspectSpecTemplateMap.put(ASSERTION_RUN_SUMMARY_ASPECT_NAME, new AssertionRunSummaryTemplate());
     return new AspectTemplateEngine(aspectSpecTemplateMap);
   }
 

--- a/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/AssertionRunSummaryTemplateTest.java
+++ b/entity-registry/src/test/java/com/linkedin/metadata/aspect/patch/template/AssertionRunSummaryTemplateTest.java
@@ -1,0 +1,90 @@
+package com.linkedin.metadata.aspect.patch.template;
+
+import static com.linkedin.metadata.Constants.ASSERTION_RUN_SUMMARY_ASPECT_NAME;
+
+import com.linkedin.assertion.AssertionRunSummary;
+import com.linkedin.assertion.AssertionStatus;
+import com.linkedin.common.Status;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.aspect.patch.template.assertion.AssertionRunSummaryTemplate;
+import com.linkedin.metadata.models.registry.SnapshotEntityRegistry;
+import jakarta.json.Json;
+import jakarta.json.JsonPatch;
+import java.io.StringReader;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class AssertionRunSummaryTemplateTest {
+
+  private final AssertionRunSummaryTemplate template = new AssertionRunSummaryTemplate();
+
+  @Test
+  public void testGetDefaultReturnsEmptySummary() {
+    AssertionRunSummary defaultSummary = template.getDefault();
+
+    Assert.assertNotNull(defaultSummary);
+    Assert.assertFalse(defaultSummary.hasLastPassedAtMillis());
+    Assert.assertFalse(defaultSummary.hasLastFailedAtMillis());
+    Assert.assertFalse(defaultSummary.hasLastErroredAtMillis());
+    Assert.assertFalse(defaultSummary.hasLastInitializedAtMillis());
+    Assert.assertFalse(defaultSummary.hasAssertionStatus());
+  }
+
+  @Test
+  public void testGetTemplateType() {
+    Assert.assertEquals(template.getTemplateType(), AssertionRunSummary.class);
+  }
+
+  @Test
+  public void testTemplateIsRegisteredInSnapshotEntityRegistry() {
+    SnapshotEntityRegistry registry = new SnapshotEntityRegistry();
+
+    RecordTemplate defaultTemplate =
+        registry.getAspectTemplateEngine().getDefaultTemplate(ASSERTION_RUN_SUMMARY_ASPECT_NAME);
+
+    Assert.assertNotNull(defaultTemplate);
+    Assert.assertTrue(defaultTemplate instanceof AssertionRunSummary);
+  }
+
+  @Test
+  public void testGetSubtypeRejectsForeignRecordTemplate() {
+    Assert.assertThrows(ClassCastException.class, () -> template.getSubtype(new Status()));
+  }
+
+  @Test
+  public void testApplyPatchOntoDefaultSetsFields() throws Exception {
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/lastPassedAtMillis\",\"value\":1700000000000},"
+                            + "{\"op\":\"add\",\"path\":\"/assertionStatus\",\"value\":\"PASSING\"}]"))
+                .readArray());
+
+    AssertionRunSummary result = template.applyPatch(template.getDefault(), patch);
+
+    Assert.assertEquals(result.getLastPassedAtMillis(), Long.valueOf(1700000000000L));
+    Assert.assertEquals(result.getAssertionStatus(), AssertionStatus.PASSING);
+  }
+
+  @Test
+  public void testApplySecondPatchPreservesEarlierFields() throws Exception {
+    AssertionRunSummary existing = new AssertionRunSummary();
+    existing.setLastPassedAtMillis(1700000000000L);
+    existing.setAssertionStatus(AssertionStatus.PASSING);
+
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/lastFailedAtMillis\",\"value\":1600000000000}]"))
+                .readArray());
+
+    AssertionRunSummary result = template.applyPatch(existing, patch);
+
+    Assert.assertEquals(result.getLastFailedAtMillis(), Long.valueOf(1600000000000L));
+    // earlier fields must survive the partial update
+    Assert.assertEquals(result.getLastPassedAtMillis(), Long.valueOf(1700000000000L));
+    Assert.assertEquals(result.getAssertionStatus(), AssertionStatus.PASSING);
+  }
+}

--- a/metadata-io/metadata-io-api/src/test/java/com/linkedin/metadata/entity/ebean/batch/PatchItemImplTest.java
+++ b/metadata-io/metadata-io-api/src/test/java/com/linkedin/metadata/entity/ebean/batch/PatchItemImplTest.java
@@ -1,5 +1,6 @@
 package com.linkedin.metadata.entity.ebean.batch;
 
+import static com.linkedin.metadata.Constants.ASSERTION_RUN_SUMMARY_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.DATASET_ENTITY_NAME;
 import static com.linkedin.metadata.Constants.DATASET_PROPERTIES_ASPECT_NAME;
 import static com.linkedin.metadata.Constants.GLOBAL_TAGS_ASPECT_NAME;
@@ -11,6 +12,8 @@ import static org.testng.Assert.*;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.linkedin.assertion.AssertionRunSummary;
+import com.linkedin.assertion.AssertionStatus;
 import com.linkedin.common.AuditStamp;
 import com.linkedin.common.GlossaryTerms;
 import com.linkedin.common.urn.Urn;
@@ -798,5 +801,66 @@ public class PatchItemImplTest {
             50);
     assertEquals(found.size(), 1);
     assertEquals(found.get(0).kind(), PatchItemImpl.OversizedContent.Kind.VALUE);
+  }
+
+  @Test
+  public void testPatchAssertionRunSummaryWithNoExistingAspect() {
+    Urn assertionUrn = UrnUtils.getUrn("urn:li:assertion:test-assertion");
+
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/lastPassedAtMillis\",\"value\":1700000000000},"
+                            + "{\"op\":\"add\",\"path\":\"/assertionStatus\",\"value\":\"PASSING\"}]"))
+                .readArray());
+
+    PatchItemImpl patchItem =
+        PatchItemImpl.builder()
+            .urn(assertionUrn)
+            .aspectName(ASSERTION_RUN_SUMMARY_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .patch(patch)
+            .build(entityRegistry);
+
+    // No existing aspect: this is the first run event for the assertion.
+    ChangeItemImpl result = patchItem.applyPatch(null, aspectRetriever);
+
+    AssertionRunSummary summary = (AssertionRunSummary) result.getRecordTemplate();
+    assertEquals(summary.getLastPassedAtMillis(), Long.valueOf(1700000000000L));
+    assertEquals(summary.getAssertionStatus(), AssertionStatus.PASSING);
+  }
+
+  @Test
+  public void testPatchAssertionRunSummaryWithExistingAspect() {
+    Urn assertionUrn = UrnUtils.getUrn("urn:li:assertion:test-assertion");
+
+    AssertionRunSummary existing = new AssertionRunSummary();
+    existing.setLastPassedAtMillis(1600000000000L);
+    existing.setAssertionStatus(AssertionStatus.PASSING);
+
+    JsonPatch patch =
+        Json.createPatch(
+            Json.createReader(
+                    new StringReader(
+                        "[{\"op\":\"add\",\"path\":\"/lastFailedAtMillis\",\"value\":1700000000000},"
+                            + "{\"op\":\"add\",\"path\":\"/assertionStatus\",\"value\":\"FAILING\"}]"))
+                .readArray());
+
+    PatchItemImpl patchItem =
+        PatchItemImpl.builder()
+            .urn(assertionUrn)
+            .aspectName(ASSERTION_RUN_SUMMARY_ASPECT_NAME)
+            .auditStamp(auditStamp)
+            .patch(patch)
+            .build(entityRegistry);
+
+    ChangeItemImpl result = patchItem.applyPatch(existing, aspectRetriever);
+
+    AssertionRunSummary summary = (AssertionRunSummary) result.getRecordTemplate();
+    assertEquals(summary.getAssertionStatus(), AssertionStatus.FAILING);
+    assertEquals(summary.getLastFailedAtMillis(), Long.valueOf(1700000000000L));
+    // the earlier field must survive the partial update
+    assertEquals(summary.getLastPassedAtMillis(), Long.valueOf(1600000000000L));
   }
 }


### PR DESCRIPTION
**fix(assertions): register a patch template for `assertionRunSummary` so the summary can be created**

**Problem**

`AssertionRunSummaryHook` updates `assertionRunSummary` with a PATCH. `PatchItemImpl.applyTemplatePatch` requires either an existing aspect value or a registered default template, but `assertionRunSummary` is not registered in `SnapshotEntityRegistry.populateTemplateEngine()`. On the first run event for an assertion there is no existing value either, so the patch throws:

```
UnsupportedOperationException: Patch not supported for aspect with name assertionRunSummary.
Default aspect is required because no aspect currently exists for urn ...
```

`AssertionRunSummaryHook.emitAssertionSummaryPatch` catches this and only logs, so the failure is silent. Since the aspect is never created, there is never an existing value, and every subsequent run event fails the same way — the summary can never be created at all.

Result: `assertionRunSummary` is never populated, `assertionStatus` stays empty, and assertion status neither renders nor filters, even though run events are recorded correctly. Reproduced on a deployment with ~1,500 assertions and valid `COMPLETE`/`SUCCESS` run events: zero summary aspects. Ingesting the identical aspect as an UPSERT works and the status renders, confirming the failure is specific to the PATCH path.

There is a second failure mode with the same root cause: if the aspect is seeded once (so an existing value is present), the patch still fails, this time with a `NullPointerException` inside `AspectTemplateEngine.applyPatch` because `getTemplate` returns null. A seeded summary therefore freezes at its seeded value and never updates — so "just create the aspect once" is not a workaround.

**Why CI did not catch it**

`AssertionRunSummaryHookTest` mocks `AssertionService` and only verifies `patchAssertionRunSummary` was called, so the patch is never actually applied.

**Fix**

Register an `AssertionRunSummaryTemplate`, following the existing `StatusTemplate` pattern (flat record, identity array transforms). All `AssertionRunSummary` fields are optional, so an empty instance is a valid patch base.

**Tests**

- New `PatchItemImplTest` cases patching `assertionRunSummary` with no existing aspect and with an existing aspect — both fail on `master`, both pass with this change.
- New `AssertionRunSummaryTemplateTest` covering default, subtype casting, and incremental field updates.

**Red before green**

On current `master` (064c53e036), the new tests fail exactly as described:

```
com.linkedin.metadata.entity.ebean.batch.PatchItemImplTest testPatchAssertionRunSummaryWithExistingAspect FAILED
java.lang.NullPointerException: Cannot invoke "com.linkedin.metadata.aspect.patch.template.Template.applyPatch(com.linkedin.data.template.RecordTemplate, jakarta.json.JsonPatch)" because "template" is null

com.linkedin.metadata.entity.ebean.batch.PatchItemImplTest testPatchAssertionRunSummaryWithNoExistingAspect FAILED
java.lang.UnsupportedOperationException: Patch not supported for aspect with name assertionRunSummary. Default aspect is required because no aspect currently exists for urn urn:li:assertion:test-assertion.

29 tests completed, 2 failed
BUILD FAILED in 8m 43s
```

After the fix:

```
SUCCESS: Executed 29 tests in 5.4s
BUILD SUCCESSFUL in 23s
```

The surrounding suites pass as well: `AssertionRunSummaryTemplateTest` (5 tests, `BUILD SUCCESSFUL`) and `AssertionRunSummaryHookTest` (12 tests, `BUILD SUCCESSFUL`). `spotlessCheck` is clean.

**Note for maintainers**

`MCPItem.supportsPatch` documents that aspects without templates fall back to generic patching, but `PatchItemImpl.applyPatch` only routes to `applyGenericPatch` when the payload declares `arrayPrimaryKeys` or sets `forceGenericPatch`. Aspects without templates therefore pass validation and then fail at apply time. `applyGenericPatch` already contains the right fallback (`aspectSpec.getDataTemplateClass().getDeclaredConstructor().newInstance()`); `applyTemplatePatch` does not. Happy to follow up with a broader fix if you would prefer that over the targeted registration.

Related: #18935 (PATCH failures surface as opaque 500s on the v3 API) and #19255 (async MCP emission from MCL hooks, touching the same call path).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers a patch template for `assertionRunSummary` so the first PATCH event can create the aspect and later ones can update it. Previously both cases failed — the first with `UnsupportedOperationException` (caught and only logged), later ones with `NullPointerException` — so the summary was never populated and assertion status never rendered or filtered.

**Tests**
- Added unit tests covering the empty default and patching with and without an existing aspect; both PATCH cases fail on `master` and pass with this change.
- The existing `AssertionRunSummaryHookTest` missed this because it mocks `AssertionService` and never applies the patch.

<sup>Written for commit b461c8efc75b8a09b5f912f4c14ad089108f476b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

