### PR TITLE
fix(otel): preserve OTEL_RESOURCE_ATTRIBUTES on factory TracerProvider

### DIFF
--- a/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/OpenTelemetryBaseFactory.java
+++ b/metadata-service/factories/src/main/java/com/linkedin/gms/factory/system_telemetry/OpenTelemetryBaseFactory.java
@@ -124,6 +124,15 @@ public abstract class OpenTelemetryBaseFactory {
 
                   return props;
                 })
+            .addResourceCustomizer(
+                (resource, configProperties) ->
+                    resource.merge(
+                        Resource.create(
+                            Attributes.of(
+                                SERVICE_NAME,
+                                getApplicationComponent() != null
+                                    ? getApplicationComponent()
+                                    : "default-service"))))
             .addTracerProviderCustomizer(
                 (sdkTracerProviderBuilder, configProperties) -> {
                   // Network/heavy exporters use async BatchSpanProcessor so span-end never blocks
@@ -153,17 +162,7 @@ public abstract class OpenTelemetryBaseFactory {
                       .setIdGenerator(
                           SystemTelemetryContext.TRACE_ID_GENERATOR != null
                               ? SystemTelemetryContext.TRACE_ID_GENERATOR
-                              : io.opentelemetry.sdk.trace.IdGenerator
-                                  .random()) // Fallback for ID generator
-                      .setResource(
-                          Resource.getDefault()
-                              .merge(
-                                  Resource.create(
-                                      Attributes.of(
-                                          SERVICE_NAME,
-                                          getApplicationComponent() != null
-                                              ? getApplicationComponent()
-                                              : "default-service"))));
+                              : io.opentelemetry.sdk.trace.IdGenerator.random());
                   if (usageSpanExporter != null) {
                     sdkTracerProviderBuilder.addSpanProcessor(usageSpanExporter);
                   }

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/OpenTelemetryBaseFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/OpenTelemetryBaseFactoryTest.java
@@ -13,7 +13,10 @@ import com.linkedin.metadata.utils.metrics.MetricUtils;
 import io.datahubproject.metadata.context.SystemTelemetryContext;
 import io.datahubproject.metadata.context.kafka.SpanProducerRecordResolver;
 import io.datahubproject.metadata.context.telemetry.EnrichingSpanProcessor;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import java.lang.reflect.Field;
@@ -444,5 +447,42 @@ public class OpenTelemetryBaseFactoryTest {
 
     assertNotNull(context);
     // Should use MetricSpanExporter when OTEL_METRICS_EXPORTER is not set
+  }
+
+  @Test
+  public void testResourceAttributesPreserved() {
+    String propKey = "otel.resource.attributes";
+    String original = System.getProperty(propKey);
+
+    try {
+      System.setProperty(propKey, "k8s.namespace.name=test-tenant,service.namespace=datahub");
+
+      TestOpenTelemetryFactory f = new TestOpenTelemetryFactory("datahub-mae-consumer");
+      SystemTelemetryContext ctx =
+          f.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockPublisher);
+
+      Span span = ctx.getTracer().spanBuilder("test").startSpan();
+      try {
+        assertTrue(span instanceof ReadableSpan, "Span should be a ReadableSpan from the SDK");
+        ReadableSpan readable = (ReadableSpan) span;
+        var resource = readable.toSpanData().getResource();
+
+        assertEquals(
+            resource.getAttribute(AttributeKey.stringKey("service.name")),
+            "datahub-mae-consumer");
+        assertEquals(
+            resource.getAttribute(AttributeKey.stringKey("k8s.namespace.name")), "test-tenant");
+        assertEquals(
+            resource.getAttribute(AttributeKey.stringKey("service.namespace")), "datahub");
+      } finally {
+        span.end();
+      }
+    } finally {
+      if (original != null) {
+        System.setProperty(propKey, original);
+      } else {
+        System.clearProperty(propKey);
+      }
+    }
   }
 }

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/OpenTelemetryBaseFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/OpenTelemetryBaseFactoryTest.java
@@ -16,6 +16,7 @@ import io.datahubproject.metadata.context.telemetry.EnrichingSpanProcessor;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.ReadableSpan;
 import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
@@ -104,6 +105,19 @@ public class OpenTelemetryBaseFactoryTest {
           usageEventPublisher,
           mockSpanProducerRecordResolver,
           mockEnrichingSpanProcessor);
+    }
+
+    public OpenTelemetrySdk testOpenTelemetry(
+        MetricUtils metricUtils, SpanProcessor usageSpanExporter) throws Exception {
+      Method m =
+          OpenTelemetryBaseFactory.class.getDeclaredMethod(
+              "openTelemetry",
+              MetricUtils.class,
+              SpanProcessor.class,
+              EnrichingSpanProcessor.class);
+      m.setAccessible(true);
+      return (OpenTelemetrySdk)
+          m.invoke(this, metricUtils, usageSpanExporter, mockEnrichingSpanProcessor);
     }
   }
 
@@ -450,30 +464,37 @@ public class OpenTelemetryBaseFactoryTest {
   }
 
   @Test
-  public void testResourceAttributesPreserved() {
+  public void testResourceAttributesPreserved() throws Exception {
     String propKey = "otel.resource.attributes";
     String original = System.getProperty(propKey);
 
     try {
       System.setProperty(propKey, "k8s.namespace.name=test-tenant,service.namespace=datahub");
 
+      when(mockEnrichingSpanProcessor.shutdown())
+          .thenReturn(io.opentelemetry.sdk.common.CompletableResultCode.ofSuccess());
+
       TestOpenTelemetryFactory f = new TestOpenTelemetryFactory("datahub-mae-consumer");
-      SystemTelemetryContext ctx =
-          f.testTraceContext(mockMetricUtils, mockConfigurationProvider, mockPublisher);
-
-      Span span = ctx.getTracer().spanBuilder("test").startSpan();
+      OpenTelemetrySdk sdk = f.testOpenTelemetry(mockMetricUtils, null);
       try {
-        assertTrue(span instanceof ReadableSpan, "Span should be a ReadableSpan from the SDK");
-        ReadableSpan readable = (ReadableSpan) span;
-        var resource = readable.toSpanData().getResource();
+        Span span = sdk.getTracer("test").spanBuilder("test").startSpan();
+        try {
+          assertTrue(span instanceof ReadableSpan, "Span should be a ReadableSpan from the SDK");
+          ReadableSpan readable = (ReadableSpan) span;
+          var resource = readable.toSpanData().getResource();
 
-        assertEquals(
-            resource.getAttribute(AttributeKey.stringKey("service.name")), "datahub-mae-consumer");
-        assertEquals(
-            resource.getAttribute(AttributeKey.stringKey("k8s.namespace.name")), "test-tenant");
-        assertEquals(resource.getAttribute(AttributeKey.stringKey("service.namespace")), "datahub");
+          assertEquals(
+              resource.getAttribute(AttributeKey.stringKey("service.name")),
+              "datahub-mae-consumer");
+          assertEquals(
+              resource.getAttribute(AttributeKey.stringKey("k8s.namespace.name")), "test-tenant");
+          assertEquals(
+              resource.getAttribute(AttributeKey.stringKey("service.namespace")), "datahub");
+        } finally {
+          span.end();
+        }
       } finally {
-        span.end();
+        sdk.close();
       }
     } finally {
       if (original != null) {

--- a/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/OpenTelemetryBaseFactoryTest.java
+++ b/metadata-service/factories/src/test/java/com/linkedin/gms/factory/system_telemetry/OpenTelemetryBaseFactoryTest.java
@@ -468,12 +468,10 @@ public class OpenTelemetryBaseFactoryTest {
         var resource = readable.toSpanData().getResource();
 
         assertEquals(
-            resource.getAttribute(AttributeKey.stringKey("service.name")),
-            "datahub-mae-consumer");
+            resource.getAttribute(AttributeKey.stringKey("service.name")), "datahub-mae-consumer");
         assertEquals(
             resource.getAttribute(AttributeKey.stringKey("k8s.namespace.name")), "test-tenant");
-        assertEquals(
-            resource.getAttribute(AttributeKey.stringKey("service.namespace")), "datahub");
+        assertEquals(resource.getAttribute(AttributeKey.stringKey("service.namespace")), "datahub");
       } finally {
         span.end();
       }


### PR DESCRIPTION
## Summary

- `OpenTelemetryBaseFactory.setResource()` replaced the autoconfigured resource (from `OTEL_RESOURCE_ATTRIBUTES`) with one containing only `service.name`, discarding `k8s.namespace.name`, `service.namespace`, and all other resource attributes
- Fix: move `service.name` into `addResourceCustomizer()` which merges into the autoconfigured resource instead of replacing it
- Add regression test that sets `otel.resource.attributes` via system property and asserts `k8s.namespace.name` and `service.namespace` survive into the span resource (verified it fails against pre-fix code with `expected [test-tenant] but found [null]`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `OpenTelemetryBaseFactory` replacing the autoconfigured resource with one holding only `service.name`, which discarded `OTEL_RESOURCE_ATTRIBUTES` entries like `k8s.namespace.name` and `service.namespace`. `service.name` is now merged via `addResourceCustomizer()` so those attributes survive.

- Adds a regression test that sets `otel.resource.attributes`, asserts the span resource keeps those entries, and closes the SDK to avoid leaking its shutdown-hook thread.

<sup>Written for commit e1c5b65cfbf1325ee183c819532bab099341f424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

