### PR TITLE
fix(ingest/tests): prune each module's docker images after its compose suites

### DIFF
--- a/metadata-ingestion/src/datahub/testing/docker_utils.py
+++ b/metadata-ingestion/src/datahub/testing/docker_utils.py
@@ -77,6 +77,13 @@ def wait_for_port(
         subprocess.run(f"docker logs {container_name}", shell=True, check=True)
 
 
+# Ceiling on the teardown image removal. Deleting several multi-GB stacks is
+# genuinely slow on a loaded runner, so this is deliberately generous -- it
+# exists only so a wedged daemon cannot hang the session, not to bound normal
+# work.
+_PRUNE_TIMEOUT = 300.0
+
+
 def _project_image_ids(
     compose: pytest_docker.plugin.DockerComposeExecutor,
 ) -> Set[str]:
@@ -121,18 +128,44 @@ def _prune_images(image_ids: Set[str]) -> None:
     logger.info(f"Pruning {len(image_ids)} docker image(s) used by this module")
     # `-f` for two reasons: an image carrying several tags is removed rather
     # than merely untagged, and an image a previous module already pruned (the
-    # same base image is shared by several suites) is a no-op instead of an
-    # error. Docker's per-layer "Deleted:" chatter is captured, not logged --
-    # writing it to the job log would feed the very problem this fixes.
-    result = subprocess.run(
-        ["docker", "image", "rm", "-f", *sorted(image_ids)],
-        capture_output=True,
-        text=True,
-    )
+    # same base image is shared by several suites) exits 0 rather than failing.
+    # Docker's per-layer "Deleted:" chatter is captured, not logged -- writing
+    # it to the job log would feed the very problem this fixes.
+    try:
+        result = subprocess.run(
+            ["docker", "image", "rm", "-f", *sorted(image_ids)],
+            capture_output=True,
+            text=True,
+            timeout=_PRUNE_TIMEOUT,
+        )
+    except OSError as e:
+        # No docker on PATH, fork failure, etc. Pruning is an optimization, so
+        # a module whose tests passed must not fail in teardown over it.
+        logger.warning(f"Could not run docker image rm: {e}")
+        return
+    except subprocess.TimeoutExpired:
+        # Without a timeout a wedged daemon blocks teardown forever and stalls
+        # every module after this one. Leaking the images is the lesser cost.
+        logger.warning(
+            f"Timed out after {_PRUNE_TIMEOUT}s pruning docker images; "
+            "leaving them on disk"
+        )
+        return
+
     if result.returncode != 0:
         # Best-effort by design. An image still held by a container outside
         # this project can't be removed, and that must not fail a green module.
-        logger.warning(f"Failed to prune docker image(s): {result.stderr.strip()}")
+        # Absent images alone exit 0, but a run that genuinely fails for one
+        # image still reports the absent ones on stderr -- drop those so a real
+        # conflict is not buried in benign noise, as the stale-container
+        # removal above does for "No such container".
+        real_errors = [
+            line
+            for line in result.stderr.splitlines()
+            if line.strip() and "No such image" not in line
+        ]
+        if real_errors:
+            logger.warning(f"Failed to prune docker image(s): {' '.join(real_errors)}")
 
 
 DOCKER_DEFAULT_UNLIMITED_PARALLELISM = -1

--- a/metadata-ingestion/src/datahub/testing/docker_utils.py
+++ b/metadata-ingestion/src/datahub/testing/docker_utils.py
@@ -2,11 +2,13 @@ import contextlib
 import logging
 import os
 import subprocess
-from typing import Callable, Iterator, List, Optional, Union
+from typing import Callable, Iterator, List, Optional, Set, Union
 
 import pytest
 import pytest_docker.plugin
 import yaml
+
+from datahub.configuration.env_vars import is_ci
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +77,64 @@ def wait_for_port(
         subprocess.run(f"docker logs {container_name}", shell=True, check=True)
 
 
+def _project_image_ids(
+    compose: pytest_docker.plugin.DockerComposeExecutor,
+) -> Set[str]:
+    """Image IDs backing a compose project's containers.
+
+    Must be called while the containers still exist: `docker compose images`
+    enumerates the project's *containers*, so once `down` has removed them it
+    reports nothing and there is no longer any record of what to prune.
+    """
+    try:
+        output = compose.execute("images -q", ignore_stderr=True)
+    except Exception as e:
+        # Never fail a module that passed just because the prune bookkeeping
+        # failed -- the images are leaked instead, which is the status quo.
+        logger.warning(f"Failed to list compose images for pruning: {e}")
+        return set()
+    return {
+        line.strip() for line in output.decode("utf-8").splitlines() if line.strip()
+    }
+
+
+def _prune_images(image_ids: Set[str]) -> None:
+    """Delete the images a module's compose suites pulled.
+
+    `docker compose down -v` removes containers, networks and volumes but never
+    images, so on CI every connector suite leaves its whole stack on disk for
+    the rest of the job -- several GB each for Spark/Iceberg, Hadoop/Hive or
+    Informix. That is invisible until the test-weight bot packs a few such
+    suites onto one runner, at which point the job dies with ENOSPC mid-run.
+    Reclaiming per module keeps peak disk proportional to the largest single
+    suite rather than to the sum of everything in the batch.
+    """
+    if not image_ids:
+        return
+
+    if not is_ci():
+        # Locally these images are a cache worth keeping: re-pulling a stack on
+        # every test run costs far more than the disk it occupies.
+        logger.debug("Not pruning docker images to speed up local development")
+        return
+
+    logger.info(f"Pruning {len(image_ids)} docker image(s) used by this module")
+    # `-f` for two reasons: an image carrying several tags is removed rather
+    # than merely untagged, and an image a previous module already pruned (the
+    # same base image is shared by several suites) is a no-op instead of an
+    # error. Docker's per-layer "Deleted:" chatter is captured, not logged --
+    # writing it to the job log would feed the very problem this fixes.
+    result = subprocess.run(
+        ["docker", "image", "rm", "-f", *sorted(image_ids)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        # Best-effort by design. An image still held by a container outside
+        # this project can't be removed, and that must not fail a green module.
+        logger.warning(f"Failed to prune docker image(s): {result.stderr.strip()}")
+
+
 DOCKER_DEFAULT_UNLIMITED_PARALLELISM = -1
 
 
@@ -82,6 +142,12 @@ DOCKER_DEFAULT_UNLIMITED_PARALLELISM = -1
 def docker_compose_runner(
     docker_compose_command, docker_compose_project_name, docker_setup, docker_cleanup
 ):
+    # Images used by every compose suite this module ran, pruned together when
+    # the module finishes rather than at each teardown: several suites bring
+    # the same stack up once per test (iceberg, ldap, postgres, mssql), and
+    # pruning between those runs would re-pull the image each time.
+    module_image_ids: Set[str] = set()
+
     def _as_commands(commands: Union[List[str], str]) -> List[str]:
         return [commands] if isinstance(commands, str) else list(commands or [])
 
@@ -145,7 +211,14 @@ def docker_compose_runner(
                 compose.execute(command)
             yield pytest_docker.plugin.Services(compose)
         finally:
+            if cleanup_commands:
+                # Enumerate before `down` removes the containers compose reads
+                # the image list from. Skipped when the caller opted out of
+                # cleanup: those containers stay up, so their images must too.
+                module_image_ids.update(_project_image_ids(compose))
             for command in cleanup_commands:
                 compose.execute(command)
 
-    return run
+    yield run
+
+    _prune_images(module_image_ids)

--- a/metadata-ingestion/src/datahub/testing/docker_utils.py
+++ b/metadata-ingestion/src/datahub/testing/docker_utils.py
@@ -128,9 +128,12 @@ def _prune_images(image_ids: Set[str]) -> None:
     logger.info(f"Pruning {len(image_ids)} docker image(s) used by this module")
     # `-f` for two reasons: an image carrying several tags is removed rather
     # than merely untagged, and an image a previous module already pruned (the
-    # same base image is shared by several suites) exits 0 rather than failing.
-    # Docker's per-layer "Deleted:" chatter is captured, not logged -- writing
-    # it to the job log would feed the very problem this fixes.
+    # same base image is shared by several suites) is reported as absent rather
+    # than aborting the removal of the others. Whether docker exits nonzero for
+    # a merely-absent id has differed between versions, so the handling below
+    # keys off stderr rather than the exit status. Docker's per-layer "Deleted:"
+    # chatter is captured, not logged -- writing it to the job log would feed
+    # the very problem this fixes.
     try:
         result = subprocess.run(
             ["docker", "image", "rm", "-f", *sorted(image_ids)],
@@ -155,10 +158,10 @@ def _prune_images(image_ids: Set[str]) -> None:
     if result.returncode != 0:
         # Best-effort by design. An image still held by a container outside
         # this project can't be removed, and that must not fail a green module.
-        # Absent images alone exit 0, but a run that genuinely fails for one
-        # image still reports the absent ones on stderr -- drop those so a real
-        # conflict is not buried in benign noise, as the stale-container
-        # removal above does for "No such container".
+        # An id that was merely absent (already pruned by an earlier module) is
+        # benign noise -- drop those lines so a real conflict is not buried in
+        # them, as the stale-container removal above does for "No such
+        # container".
         real_errors = [
             line
             for line in result.stderr.splitlines()
@@ -166,6 +169,14 @@ def _prune_images(image_ids: Set[str]) -> None:
         ]
         if real_errors:
             logger.warning(f"Failed to prune docker image(s): {' '.join(real_errors)}")
+        elif not result.stderr.strip():
+            # Nonzero with nothing to show for it. Suppressing this would make
+            # a wholly failed cleanup indistinguishable from a clean one, so
+            # report the exit status itself.
+            logger.warning(
+                f"docker image rm exited {result.returncode} with no output; "
+                "images may still be on disk"
+            )
 
 
 DOCKER_DEFAULT_UNLIMITED_PARALLELISM = -1

--- a/metadata-ingestion/tests/integration/cube/test_cube.py
+++ b/metadata-ingestion/tests/integration/cube/test_cube.py
@@ -21,7 +21,7 @@ from datahub.ingestion.source.cube.constants import (
 )
 from datahub.ingestion.source.cube.cube_api import CubeAPIClient
 from datahub.testing import mce_helpers
-from tests.test_helpers.docker_helpers import cleanup_image, wait_for_port
+from tests.test_helpers.docker_helpers import wait_for_port
 
 pytestmark = pytest.mark.integration_batch_4
 
@@ -100,7 +100,6 @@ def loaded_cube(docker_compose_runner, test_resources_dir: Path, cube_token: str
         cube_port = docker_services.port_for("test-cube", 4000)
         _wait_for_cube_model(f"http://localhost:{cube_port}/cubejs-api", cube_token)
         yield cube_port
-    cleanup_image("cubejs/cube")
 
 
 def test_cube_core_ingest(

--- a/metadata-ingestion/tests/integration/grafana/test_grafana.py
+++ b/metadata-ingestion/tests/integration/grafana/test_grafana.py
@@ -13,7 +13,7 @@ from urllib3.util.retry import Retry
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.testing import mce_helpers
 from tests.test_helpers import fs_helpers
-from tests.test_helpers.docker_helpers import cleanup_image, wait_for_port
+from tests.test_helpers.docker_helpers import wait_for_port
 
 pytestmark = pytest.mark.integration_batch_5
 
@@ -167,8 +167,6 @@ def loaded_grafana(docker_compose_runner, test_resources_dir):
         verify_grafana_entities_provisioned(timeout=180)
 
         yield docker_services
-
-    cleanup_image("grafana/grafana")
 
 
 def verify_grafana_api_ready(docker_services: pytest_docker.plugin.Services) -> None:

--- a/metadata-ingestion/tests/integration/iceberg/test_iceberg.py
+++ b/metadata-ingestion/tests/integration/iceberg/test_iceberg.py
@@ -7,7 +7,7 @@ import time_machine
 
 from datahub.testing import mce_helpers
 from tests.test_helpers.click_helpers import run_datahub_cmd
-from tests.test_helpers.docker_helpers import cleanup_image, wait_for_port
+from tests.test_helpers.docker_helpers import wait_for_port
 from tests.test_helpers.state_helpers import (
     get_current_checkpoint_from_pipeline,
     run_and_get_pipeline,
@@ -27,14 +27,6 @@ PATHS_IN_GOLDEN_FILE_TO_IGNORE = [
     r"root\[\d+\].+\['customProperties'\]\['snapshot-id'\]",
     r"root\[\d+\].+\['customProperties'\]\['manifest-list'\]",
 ]
-
-
-@pytest.fixture(autouse=True, scope="module")
-def remove_docker_image():
-    yield
-
-    # The tabulario/spark-iceberg image is pretty large, so we remove it after the test.
-    cleanup_image("tabulario/spark-iceberg")
 
 
 def spark_submit(file_path: str, args: str = "") -> None:

--- a/metadata-ingestion/tests/integration/metabase/test_metabase.py
+++ b/metadata-ingestion/tests/integration/metabase/test_metabase.py
@@ -19,7 +19,7 @@ from tests.integration.metabase.metabase_setup_utils import (  # type: ignore[im
     verify_metabase_api_ready,
 )
 from tests.test_helpers.click_helpers import run_datahub_cmd
-from tests.test_helpers.docker_helpers import cleanup_image, wait_for_port
+from tests.test_helpers.docker_helpers import wait_for_port
 from tests.test_helpers.state_helpers import (
     get_current_checkpoint_from_pipeline,
     run_and_get_pipeline,
@@ -715,8 +715,6 @@ def loaded_metabase(docker_compose_runner, metabase_credentials):
         logger.info("Metabase test data setup complete")
 
         yield docker_services
-
-    cleanup_image("metabase/metabase")
 
 
 @time_machine.travel(DOCKER_FROZEN_TIME)

--- a/metadata-ingestion/tests/integration/mssql/test_sql_server.py
+++ b/metadata-ingestion/tests/integration/mssql/test_sql_server.py
@@ -13,7 +13,7 @@ from datahub.ingestion.source.sql.stored_procedures.base import (
 from datahub.sql_parsing.schema_resolver import SchemaResolver
 from datahub.testing import mce_helpers
 from tests.test_helpers.click_helpers import run_datahub_cmd
-from tests.test_helpers.docker_helpers import cleanup_image, wait_for_port
+from tests.test_helpers.docker_helpers import wait_for_port
 
 
 @pytest.fixture(scope="module")
@@ -50,9 +50,6 @@ def mssql_runner(docker_compose_runner, pytestconfig, request):
             )
 
         yield docker_services
-
-    # The image is pretty large, so we remove it after the test.
-    cleanup_image("mcr.microsoft.com/mssql/server")
 
 
 SOURCE_FILES_PATH = "./tests/integration/mssql/source_files"

--- a/metadata-ingestion/tests/integration/nifi/test_nifi.py
+++ b/metadata-ingestion/tests/integration/nifi/test_nifi.py
@@ -8,7 +8,7 @@ import time_machine
 from datahub.ingestion.run.pipeline import Pipeline
 from datahub.testing import mce_helpers
 from tests.test_helpers import fs_helpers
-from tests.test_helpers.docker_helpers import cleanup_image, wait_for_port
+from tests.test_helpers.docker_helpers import wait_for_port
 
 pytestmark = pytest.mark.integration_batch_3
 
@@ -50,9 +50,6 @@ def loaded_nifi(docker_compose_runner, test_resources_dir):
             timeout=60,
         )
         yield docker_services
-
-    # The nifi image is pretty large, so we remove it after the test.
-    cleanup_image("apache/nifi")
 
 
 @time_machine.travel(FROZEN_TIME, tick=True)

--- a/metadata-ingestion/tests/integration/vertica/test_vertica.py
+++ b/metadata-ingestion/tests/integration/vertica/test_vertica.py
@@ -6,7 +6,7 @@ import time_machine
 
 from datahub.testing import mce_helpers
 from tests.test_helpers.click_helpers import run_datahub_cmd
-from tests.test_helpers.docker_helpers import cleanup_image, wait_for_port
+from tests.test_helpers.docker_helpers import wait_for_port
 
 pytestmark = [
     pytest.mark.integration_batch_3,
@@ -63,9 +63,6 @@ def vertica_runner(docker_compose_runner, test_resources_dir, request):
         assert ret.returncode == 0
 
         yield docker_services
-
-    # The image is pretty large, so we remove it after the test.
-    cleanup_image("vertica/vertica-ce")
 
 
 @time_machine.travel(FROZEN_TIME, tick=False)

--- a/metadata-ingestion/tests/test_helpers/docker_helpers.py
+++ b/metadata-ingestion/tests/test_helpers/docker_helpers.py
@@ -1,16 +1,10 @@
-import logging
-import subprocess
-
 import pytest
 
-from datahub.configuration.env_vars import is_ci
 from datahub.testing.docker_utils import (
     docker_compose_runner as docker_compose_runner,
     is_responsive as is_responsive,
     wait_for_port as wait_for_port,
 )
-
-logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session")
@@ -20,30 +14,3 @@ def docker_compose_command():
     v2."""
 
     return "docker compose"
-
-
-def cleanup_image(image_name: str) -> None:
-    assert ":" not in image_name, "image_name should not contain a tag"
-
-    if not is_ci():
-        logger.debug("Not cleaning up images to speed up local development")
-        return
-
-    images_proc = subprocess.run(
-        f"docker image ls --filter 'reference={image_name}*' -q",
-        shell=True,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-
-    if not images_proc.stdout:
-        logger.debug(f"No images to cleanup for {image_name}")
-        return
-
-    image_ids = images_proc.stdout.splitlines()
-    subprocess.run(
-        f"docker image rm {' '.join(image_ids)}",
-        shell=True,
-        check=True,
-    )

--- a/metadata-ingestion/tests/unit/testing/test_docker_utils.py
+++ b/metadata-ingestion/tests/unit/testing/test_docker_utils.py
@@ -1,0 +1,87 @@
+from typing import Any, List, Optional, Tuple
+from unittest.mock import patch
+
+from datahub.testing.docker_utils import _project_image_ids, _prune_images
+
+
+class _FakeCompose:
+    """Stands in for pytest_docker's DockerComposeExecutor.
+
+    Only ``execute`` is ever called by the prune helpers, and it returns bytes
+    (or raises) exactly as the real executor does.
+    """
+
+    def __init__(self, output: bytes = b"", error: Optional[Exception] = None) -> None:
+        self.output = output
+        self.error = error
+        self.calls: List[str] = []
+
+    def execute(self, subcommand: str, **kwargs: Any) -> bytes:
+        self.calls.append(subcommand)
+        if self.error:
+            raise self.error
+        return self.output
+
+
+def test_project_image_ids_parses_ids() -> None:
+    compose = _FakeCompose(output=b"aaa111\nbbb222\n")
+    assert _project_image_ids(compose) == {"aaa111", "bbb222"}  # type: ignore[arg-type]
+    assert compose.calls == ["images -q"]
+
+
+def test_project_image_ids_ignores_blank_lines() -> None:
+    # A project whose containers are all gone prints nothing but a newline.
+    compose = _FakeCompose(output=b"\n  \naaa111\n")
+    assert _project_image_ids(compose) == {"aaa111"}  # type: ignore[arg-type]
+
+
+def test_project_image_ids_survives_compose_failure() -> None:
+    # Bookkeeping must never fail a module whose tests passed; leaking the
+    # images (the old behavior) is the acceptable degradation.
+    compose = _FakeCompose(error=Exception("compose exploded"))
+    assert _project_image_ids(compose) == set()  # type: ignore[arg-type]
+
+
+def _run_prune(
+    image_ids: set, *, ci: bool, returncode: int = 0
+) -> List[Tuple[Any, ...]]:
+    calls: List[Tuple[Any, ...]] = []
+
+    class _Result:
+        def __init__(self) -> None:
+            self.returncode = returncode
+            self.stdout = ""
+            self.stderr = "boom"
+
+    def fake_run(cmd: Any, **kwargs: Any) -> Any:
+        calls.append(tuple(cmd))
+        return _Result()
+
+    with (
+        patch("datahub.testing.docker_utils.is_ci", return_value=ci),
+        patch("datahub.testing.docker_utils.subprocess.run", side_effect=fake_run),
+    ):
+        _prune_images(image_ids)
+    return calls
+
+
+def test_prune_images_removes_in_ci() -> None:
+    calls = _run_prune({"bbb222", "aaa111"}, ci=True)
+    # Sorted so the command is deterministic and easy to read in job logs.
+    assert calls == [("docker", "image", "rm", "-f", "aaa111", "bbb222")]
+
+
+def test_prune_images_skipped_outside_ci() -> None:
+    # Locally the images are a cache: re-pulling costs more than the disk.
+    assert _run_prune({"aaa111"}, ci=False) == []
+
+
+def test_prune_images_noop_without_images() -> None:
+    assert _run_prune(set(), ci=True) == []
+
+
+def test_prune_images_tolerates_removal_failure() -> None:
+    # An image another container still holds cannot be removed; that must be a
+    # warning, not an exception raised from a passing module's teardown.
+    calls = _run_prune({"aaa111"}, ci=True, returncode=1)
+    assert calls == [("docker", "image", "rm", "-f", "aaa111")]

--- a/metadata-ingestion/tests/unit/testing/test_docker_utils.py
+++ b/metadata-ingestion/tests/unit/testing/test_docker_utils.py
@@ -1,3 +1,4 @@
+import subprocess
 from typing import Any, List, Optional, Tuple
 from unittest.mock import patch
 
@@ -43,7 +44,12 @@ def test_project_image_ids_survives_compose_failure() -> None:
 
 
 def _run_prune(
-    image_ids: set, *, ci: bool, returncode: int = 0
+    image_ids: set,
+    *,
+    ci: bool,
+    returncode: int = 0,
+    stderr: str = "boom",
+    raises: Optional[Exception] = None,
 ) -> List[Tuple[Any, ...]]:
     calls: List[Tuple[Any, ...]] = []
 
@@ -51,10 +57,12 @@ def _run_prune(
         def __init__(self) -> None:
             self.returncode = returncode
             self.stdout = ""
-            self.stderr = "boom"
+            self.stderr = stderr
 
     def fake_run(cmd: Any, **kwargs: Any) -> Any:
         calls.append(tuple(cmd))
+        if raises is not None:
+            raise raises
         return _Result()
 
     with (
@@ -85,3 +93,71 @@ def test_prune_images_tolerates_removal_failure() -> None:
     # warning, not an exception raised from a passing module's teardown.
     calls = _run_prune({"aaa111"}, ci=True, returncode=1)
     assert calls == [("docker", "image", "rm", "-f", "aaa111")]
+
+
+def test_prune_images_survives_missing_docker_binary() -> None:
+    # No docker on PATH raises FileNotFoundError from subprocess.run. Pruning
+    # is an optimization, so teardown must swallow it rather than fail a module
+    # whose tests all passed.
+    calls = _run_prune(
+        {"aaa111"}, ci=True, raises=FileNotFoundError(2, "No such file: 'docker'")
+    )
+    assert calls == [("docker", "image", "rm", "-f", "aaa111")]
+
+
+def test_prune_images_survives_timeout() -> None:
+    # A wedged daemon must not block teardown forever and stall every module
+    # after this one.
+    calls = _run_prune(
+        {"aaa111"},
+        ci=True,
+        raises=subprocess.TimeoutExpired(cmd="docker image rm", timeout=300.0),
+    )
+    assert calls == [("docker", "image", "rm", "-f", "aaa111")]
+
+
+def test_prune_images_passes_a_timeout() -> None:
+    kwargs: List[Any] = []
+
+    def fake_run(cmd: Any, **kw: Any) -> Any:
+        kwargs.append(kw)
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _R()
+
+    with (
+        patch("datahub.testing.docker_utils.is_ci", return_value=True),
+        patch("datahub.testing.docker_utils.subprocess.run", side_effect=fake_run),
+    ):
+        _prune_images({"aaa111"})
+
+    assert kwargs[0].get("timeout"), "removal must be bounded"
+
+
+def test_prune_images_ignores_benign_missing_image_lines() -> None:
+    # A genuine failure still reports the ids another module already pruned.
+    # Those lines must not be logged alongside the real conflict.
+    import logging
+
+    with patch.object(
+        logging.getLogger("datahub.testing.docker_utils"), "warning"
+    ) as warn:
+        _run_prune(
+            {"aaa111", "bbb222"},
+            ci=True,
+            returncode=1,
+            stderr=(
+                "Error response from daemon: conflict: unable to delete aaa111 "
+                "(cannot be forced) - image is being used by running container x\n"
+                "Error response from daemon: No such image: sha256:bbb222\n"
+            ),
+        )
+
+    assert warn.call_count == 1
+    logged = warn.call_args[0][0]
+    assert "conflict" in logged
+    assert "No such image" not in logged

--- a/metadata-ingestion/tests/unit/testing/test_docker_utils.py
+++ b/metadata-ingestion/tests/unit/testing/test_docker_utils.py
@@ -161,3 +161,30 @@ def test_prune_images_ignores_benign_missing_image_lines() -> None:
     logged = warn.call_args[0][0]
     assert "conflict" in logged
     assert "No such image" not in logged
+
+
+def _warnings_from_prune(**kwargs: Any) -> List[str]:
+    import logging
+
+    with patch.object(
+        logging.getLogger("datahub.testing.docker_utils"), "warning"
+    ) as warn:
+        _run_prune({"aaa111"}, ci=True, **kwargs)
+    return [call[0][0] for call in warn.call_args_list]
+
+
+def test_prune_images_warns_when_failure_has_no_output() -> None:
+    # A nonzero exit with empty stderr must not be silent: suppressing it would
+    # make a wholly failed cleanup look identical to a clean one.
+    logged = _warnings_from_prune(returncode=1, stderr="   \n")
+    assert len(logged) == 1
+    assert "exited 1" in logged[0]
+
+
+def test_prune_images_silent_when_all_lines_are_benign() -> None:
+    # Every id was already pruned by an earlier module. Nothing went wrong, so
+    # this must stay quiet even if docker chose a nonzero exit status.
+    logged = _warnings_from_prune(
+        returncode=1, stderr="Error response from daemon: No such image: sha256:aaa111"
+    )
+    assert logged == []


### PR DESCRIPTION
## Summary

`docker compose down -v` removes containers, networks and volumes but **never images**, so on CI every connector suite left its whole stack on disk for the rest of the job — several GB each for Spark/Iceberg, Hadoop/Hive or the Informix developer image. Image disk usage across an integration batch was monotonically increasing: peak equalled the *sum* of every suite in the batch, and nothing was ever released.

That stayed invisible until the weekly test-weight bot rebalanced batch membership and packed several multi-GB compose stacks onto one runner, at which point `testIntegrationBatch3` died mid-run with `No space left on device`.

Only 7 of ~50 compose suites had any image cleanup at all, via hand-written `cleanup_image` fixtures — and each named a single image of its stack. For one recent batch-3 packing, 19 distinct images were pulled and 2 were ever removed.

## What changed

`docker_compose_runner` now records the image IDs backing each compose project's containers and removes them when the module that used them ends, so peak disk tracks the largest single suite instead of the sum of everything in the batch — a fixed ceiling that survives the weights bot reshuffling membership.

Two mechanics worth noting:

- **Collection happens before `down`.** `docker compose images` enumerates the project's *containers*, so once teardown removes them there is no record left of what to prune.
- **Accumulated per module, not pruned at each teardown.** Several suites bring their stack up once per test (iceberg, ldap, postgres, mssql); pruning between those runs would re-pull the image every time.

Pruning is gated on `is_ci()` — locally the images are a cache worth far more than the disk they occupy. Removal is best-effort: `-f` so a multi-tagged or already-pruned image is a no-op, and a failure warns rather than failing a module whose tests passed.

This replaces the seven `cleanup_image` fixtures, so the remaining ~45 compose suites are now covered too. `cleanup_image` had no callers left and is removed; it also ran `docker image rm` under `check=True`, which turned an in-use or already-gone image into a teardown failure on a green module.

### Known trade-off

Four directories have multiple test modules sharing one compose file (`hive-metastore`, `mssql`, `ldap`, `postgres`). Those re-pull once per extra module — `mssql` (~1.5 GB) is the only material one. Package-scoped pruning would avoid it, but `hive-metastore` cannot be a Python package (the dash) and the pytest floor is 6.2.2, so module scope is the deliberate choice.

### Scope

This lowers the disk ceiling; it does not address the other contributors to the same failure — `wait_for_port` still dumps full container logs on *healthy* startups, `free-disk-space` is still a no-op on Depot runners, and the bin packer still balances on duration only. Those are follow-ups.

## Testing

7 unit tests cover ID parsing, the CI gate, and best-effort failure handling.

Verified against a live throwaway compose suite, all four paths:

- pruned at module end under `CI=true`
- kept when `CI` is unset
- survives between two suites in the same module (no re-pull)
- still pruned when a test fails

`./gradlew :metadata-ingestion:lint` passes (ruff check, ruff format, mypy over 2728 files).

## Checklist

- [x] PR conforms to the Contributing Guideline (PR Title Format)
- [x] Tests added
- [ ] Docs — n/a (test infrastructure)
- [ ] Breaking changes — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI disk exhaustion by pruning each test module's docker images after its compose suites finish.

Old: compose teardown never removed images, so each suite left several GB on disk and integration batch 3 died with "No space left on device". New: `docker_compose_runner` records the image IDs backing each project's containers before teardown and removes them at module end, so peak disk tracks the largest suite instead of the sum of the batch.

- Pruning is CI-only and best-effort: failures, a missing docker binary, or a 300s removal timeout warn rather than fail a passing module; "No such image" stderr lines are filtered so real conflicts surface, and a silent nonzero exit warns with its status so a failed cleanup is never mistaken for a clean one.
- Replaces the seven hand-written `cleanup_image` fixtures and covers the remaining ~45 compose suites; `cleanup_image` is removed.
- Modules sharing a compose file (mssql, ldap, postgres, hive-metastore) may re-pull once per module.

<sup>Written for commit be8cbcee491fe68d66b52e9f730d1555a31f5bd8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

