### PR TITLE
ci: default GitHub Actions Python to 3.11

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Test packages are correct
         run: |
           cd datahub-actions;

--- a/.github/workflows/agent-context.yml
+++ b/.github/workflows/agent-context.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Test packages are correct
         run: |
           cd datahub-agent-context;

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -114,7 +114,7 @@ jobs:
         uses: ./.github/actions/free-disk-space
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       # Restore-only: this job barely populates the uv cache (~20MB observed), and its
       # save used to race the dependency-heavy jobs for the shared key and poison it.
       # GitHub-hosted master copies are written by documentation.yml /
@@ -274,7 +274,7 @@ jobs:
         uses: ./.github/actions/free-disk-space
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       # Restore-only: this job barely populates the uv cache (~20MB observed), and its
       # save used to race the dependency-heavy jobs for the shared key and poison it.
       # GitHub-hosted master copies are written by documentation.yml /
@@ -349,7 +349,7 @@ jobs:
         uses: ./.github/actions/free-disk-space
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       # No python deps here: :datahub-web-react:yarnTest depends only on yarnInstall/yarnGenerate/
       # generateLazyIconStubs (no :metadata-ingestion:connectorRegistry, which is frontend-build's
       # concern). install_deps.sh + the ~/.cache/uv cache were dead weight — removed. setup-python
@@ -494,7 +494,7 @@ jobs:
         uses: ./.github/actions/free-disk-space
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Guard — shard discovery is non-empty
         # Fail loudly if the globs/excludes discover far too few backend test modules, instead
         # of silently sharding a near-empty suite (green CI that tested nothing). Keep the
@@ -602,7 +602,7 @@ jobs:
         uses: ./.github/actions/free-disk-space
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Configure fast APT mirror
         if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror
@@ -734,7 +734,7 @@ jobs:
         uses: ./.github/actions/free-disk-space
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Configure fast APT mirror
         if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}
         uses: ./.github/actions/configure-fast-apt-mirror

--- a/.github/workflows/check-datahub-jars.yml
+++ b/.github/workflows/check-datahub-jars.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       # Restore always; save only from master (below) so PR runs stop minting per-PR
       # copies of this shared key. Key hashes the manifests that actually determine the
       # uv cache contents — the old '**/requirements.txt' matched 13 unrelated files and

--- a/.github/workflows/docker-quickstart-ai.yml
+++ b/.github/workflows/docker-quickstart-ai.yml
@@ -86,7 +86,7 @@ jobs:
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       # -----------------------------------------------------------------------
       # Build DataHub Docker images from source

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       # Restore always; save only from master (below) so PR runs stop minting per-PR
       # copies of this shared key. Key hashes the manifests that actually determine the
       # uv cache contents — the old '**/requirements.txt' matched 13 unrelated files and

--- a/.github/workflows/lint-jobs.yml
+++ b/.github/workflows/lint-jobs.yml
@@ -181,7 +181,7 @@ jobs:
       - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
@@ -219,7 +219,7 @@ jobs:
       - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: run check
         run: python .github/scripts/check_event_type.py
 
@@ -232,7 +232,7 @@ jobs:
       - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: run check
         run: python .github/scripts/check_policies.py
 
@@ -245,7 +245,7 @@ jobs:
       - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: run check
         run: python .github/scripts/check_gradle_lockfiles.py
 

--- a/.github/workflows/metadata-model.yml
+++ b/.github/workflows/metadata-model.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
       - name: Configure fast APT mirror
         if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}

--- a/.github/workflows/oauth-smoke.yml
+++ b/.github/workflows/oauth-smoke.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install datahub CLI
         run: |

--- a/.github/workflows/publish-datahub-jars.yml
+++ b/.github/workflows/publish-datahub-jars.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
       - name: checkout upstream repo
         run: |
@@ -208,7 +208,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
       - name: checkout upstream repo
         run: |

--- a/.github/workflows/python-build-pages.yml
+++ b/.github/workflows/python-build-pages.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: acryldata/sane-checkout-action@186e92cc5948a9c3e1cc7a96eaff9f776f3fc8e3 # v7
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
       # Restore-only: wheel building populates a much narrower uv cache than the
       # installDev-based jobs sharing this key family; if this job won the first save

--- a/.github/workflows/quickstart-test.yml
+++ b/.github/workflows/quickstart-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: install older datahub cli
         run: |
           pip install acryl-datahub==1.0
@@ -178,7 +178,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: install datahub cli
         run: |
           pip install acryl-datahub
@@ -220,7 +220,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: install datahub cli
         run: |
           pip install acryl-datahub
@@ -253,7 +253,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: install datahub cli
         run: |
           pip install acryl-datahub==${{ matrix.datahub_version }}
@@ -391,7 +391,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/spark-smoke-test.yml
+++ b/.github/workflows/spark-smoke-test.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: "pip"
       - name: Configure fast APT mirror
         if: ${{ vars.CI_USE_FAST_API_MIRROR == 'true' }}

--- a/datahub-actions/build.gradle
+++ b/datahub-actions/build.gradle
@@ -38,7 +38,7 @@ def pip_install_command = "VIRTUAL_ENV=${venv_name} ${venv_name}/bin/uv pip inst
 
 task checkPythonVersion(type: Exec) {
   commandLine python_executable, '-c',
-          'import sys; sys.version_info >= (3, 9), f"Python version {sys.version_info[:2]} not allowed"'
+          'import sys; assert sys.version_info >= (3, 10), f"Python version {sys.version_info[:2]} is too old"'
 }
 
 task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {

--- a/datahub-agent-context/build.gradle
+++ b/datahub-agent-context/build.gradle
@@ -30,7 +30,7 @@ def pip_install_command = "VIRTUAL_ENV=${venv_name} ${venv_name}/bin/uv pip inst
 
 task checkPythonVersion(type: Exec) {
   commandLine python_executable, '-c',
-          'import sys; sys.version_info >= (3, 9), f"Python version {sys.version_info[:2]} not allowed"'
+          'import sys; assert sys.version_info >= (3, 10), f"Python version {sys.version_info[:2]} is too old"'
 }
 
 task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {

--- a/metadata-ingestion-modules/dagster-plugin/build.gradle
+++ b/metadata-ingestion-modules/dagster-plugin/build.gradle
@@ -17,7 +17,7 @@ if (!project.hasProperty("extra_pip_requirements")) {
 def pip_install_command = "VIRTUAL_ENV=${venv_name} ${venv_name}/bin/uv pip install -e ../../metadata-ingestion"
 
 task checkPythonVersion(type: Exec) {
-  commandLine python_executable, '-c', 'import sys; assert sys.version_info >= (3, 9)'
+  commandLine python_executable, '-c', 'import sys; assert sys.version_info >= (3, 10), f"Python version {sys.version_info[:2]} is too old"'
 }
 
 task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {

--- a/metadata-ingestion-modules/gx-plugin/build.gradle
+++ b/metadata-ingestion-modules/gx-plugin/build.gradle
@@ -20,7 +20,7 @@ if (!project.hasProperty("extra_pip_requirements")) {
 def pip_install_command = "VIRTUAL_ENV=${venv_name} ${venv_name}/bin/uv pip install -e ../../metadata-ingestion"
 
 task checkPythonVersion(type: Exec) {
-  commandLine python_executable, '-c', 'import sys; assert sys.version_info >= (3, 9)'
+  commandLine python_executable, '-c', 'import sys; assert sys.version_info >= (3, 10), f"Python version {sys.version_info[:2]} is too old"'
 }
 
 task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {

--- a/metadata-ingestion-modules/prefect-plugin/build.gradle
+++ b/metadata-ingestion-modules/prefect-plugin/build.gradle
@@ -17,7 +17,7 @@ if (!project.hasProperty("extra_pip_requirements")) {
 def pip_install_command = "VIRTUAL_ENV=${venv_name} ${venv_name}/bin/uv pip install -e ../../metadata-ingestion"
 
 task checkPythonVersion(type: Exec) {
-  commandLine python_executable, '-c', 'import sys; assert sys.version_info >= (3, 9)'
+  commandLine python_executable, '-c', 'import sys; assert sys.version_info >= (3, 10), f"Python version {sys.version_info[:2]} is too old"'
 }
 
 task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {

--- a/metadata-ingestion/build.gradle
+++ b/metadata-ingestion/build.gradle
@@ -20,7 +20,7 @@ if (!project.hasProperty("extra_pip_requirements")) {
 
 task checkPythonVersion(type: Exec) {
   commandLine python_executable, '-c',
-    'import sys; sys.version_info >= (3, 9), f"Python version {sys.version_info[:2]} not allowed"'
+    'import sys; assert sys.version_info >= (3, 10), f"Python version {sys.version_info[:2]} is too old"'
 }
 
 task environmentSetup(type: Exec, dependsOn: checkPythonVersion) {

--- a/python-build/build.gradle
+++ b/python-build/build.gradle
@@ -8,7 +8,7 @@ ext {
 
 task checkPythonVersion(type: Exec) {
   commandLine python_executable, '-c',
-    'import sys; sys.version_info >= (3, 9), f"Python version {sys.version_info} is too old"'
+    'import sys; assert sys.version_info >= (3, 10), f"Python version {sys.version_info[:2]} is too old"'
 }
 
 task buildWheels(type: Exec, dependsOn: [


### PR DESCRIPTION
## Summary
- Default `setup-python` jobs now use Python 3.11 instead of 3.10, matching local `mise.toml`.
- Explicit version matrices are unchanged (ingestion `testQuick` 3.10/3.12, prefect/dagster/gx 3.10, Airflow 3.12, and non-matrix 3.12 script jobs).
- Gradle `checkPythonVersion` now asserts `>= 3.10` (previously a no-op 3.9 check). Venvs still follow PATH `python3` from `setup-python`.

Linear: https://linear.app/acryl-data/issue/PFP-6168/update-ci-to-use-python-311-as-default

## Test plan
- [ ] Confirm remaining `"3.10"` / `"3.12"` pins in workflows are only matrix/compat rows
- [ ] CI green on this PR, especially `build-and-test`, `quickstart-test`, `lint`, `actions`, and `agent-context`
- [ ] Ingestion and plugin matrix jobs still run on 3.10/3.12 where configured