### PR TITLE
docs(managed-datahub): release notes for v2.1.6

### DIFF
--- a/docs/managed-datahub/release-notes/v_2_1_0.md
+++ b/docs/managed-datahub/release-notes/v_2_1_0.md
@@ -6,6 +6,39 @@ description: "DataHub Cloud v2.1.0 release notes — Metrics and Semantic Models
 
 ## Release Changelog
 
+### v2.1.6
+
+This release rolls up hotfixes on top of v2.1.5. There are no breaking changes or deprecations.
+
+#### Release Availability Date
+
+11-Sep-2026
+
+#### Recommended Versions
+
+- **CLI/SDK**: 1.6.0.16
+- **Remote Executor**: v2.1.6-cloud, v2.1.5-cloud, v2.1.4-cloud, v2.1.3-cloud, v2.1.2-cloud, v2.1.1-cloud, v2.1.0-cloud, v2.0.4-cloud, v2.0.3-cloud, v2.0.2-cloud, v2.0.1-cloud, v1.1.4-cloud
+- **On-Prem Versions**:
+  - **Helm**: 1.6.233
+  - **API Gateway**: v0.7.3
+
+#### Product
+
+- **Structured property filters in the View builder** — the redesigned View builder now includes your instance's structured properties (nested under a **Structured Property** group), so you can create and edit Views filtered by those properties. Value inputs follow the property definition (entity search for URN-valued, allowed-value multi-select, numeric for number/date, text otherwise). Filters use the same `structuredProperties.<qualifiedName>` fields as search facets.
+
+#### Platform
+
+- **AWS IRSA credential providers (follow-up)** — S3, STS, SQS, and presigner clients no longer allocate an implicit IRSA `StsAssumeRoleWithWebIdentityCredentialsProvider` when a credentials provider is omitted. GMS, MAE, and system-update reuse the shared default AWS credentials bean, so remaining IRSA token-refresh leaks after v2.1.5 stay closed.
+- **OpenTelemetry resource attributes** — `OTEL_RESOURCE_ATTRIBUTES` (for example `k8s.namespace.name` and `service.namespace`) are merged into the factory `TracerProvider` instead of being replaced by `service.name` alone.
+
+#### Bug Fixes
+
+- Fixed ingest-time domain writes requiring **Edit Entity** even when GraphQL already allowed the same change with **Edit Domain**. Setting or clearing a domain on an existing entity now accepts **Edit Domain** or **Edit Entity**; creating a new entity still requires Create/Edit Entity, so **Edit Domain** alone cannot mint entities.
+
+#### Security / Dependencies
+
+- **Java / Python dependency floors** — Netty 4.2.17 (CVE-2026-59902), PostgreSQL JDBC 42.7.12 (CVE-2026-54291), jackson-databind 2.21.5 (GHSA-mhm7-754m-9p8w), lz4-java 1.11.1 (CVE-2026-59949), Log4j 2.25.5 (CVE-2026-49844), mariadb-java-client 2.7.14 (CVE-2026-55856, CVE-2026-55857, CVE-2026-55858), httpclient5 5.6.3 (CVE-2026-64607), Spring Boot 4.0.7 (CVE-2026-41001), OpenTelemetry Java agent 2.28.0 (CVE-2026-54704), and transformers 5.17.0 (CVE-2026-9856). Unused Wolfi system `setuptools` is removed from Python images (CVE-2025-47273); application venvs remain pinned to a patched setuptools.
+
 ### v2.1.5
 
 This release rolls up hotfixes on top of v2.1.4.


### PR DESCRIPTION
## Summary
- Adds DataHub Cloud **v2.1.6** hotfix notes (from [v2.1.5-cloud...v2.1.6-cloud](https://github.com/acryldata/datahub-fork/compare/v2.1.5-cloud...v2.1.6-cloud)) at the top of the v2.1.0 changelog.
- Covers View-builder structured-property filters, IRSA credential-provider leak follow-up, OpenTelemetry resource-attribute preservation, Edit Domain ingest authorization, and Java/Python CVE floors. No breaking changes.

## Test plan
- [ ] `### v2.1.6` appears at the top of the Release Changelog (above v2.1.5)
- [ ] `markdown_format / markdown_format_check (pull_request)` passes
- [ ] Release Availability Date and Recommended Versions look correct for this cut


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the v2.1.6 hotfix release notes to the top of the v2.1.0 changelog. Covers View-builder structured-property filters, AWS IRSA credential provider follow-up, OpenTelemetry resource attribute preservation, Edit Domain ingest authorization, and Java/Python CVE dependency floors. No breaking changes.

<sup>Written for commit b3131d2f2a906425b335df359fd09c9531426deb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

