### PR TITLE
feat(ingestion/unity): publish Databricks data quality monitors as assertions

### DIFF
--- a/metadata-ingestion/docs/sources/databricks/unity-catalog_post.md
+++ b/metadata-ingestion/docs/sources/databricks/unity-catalog_post.md
@@ -72,6 +72,32 @@ The default preparsed path emits table-level usage only (no column `fieldCounts`
 
 :::
 
+#### Data Quality Monitors (assertions)
+
+DataHub can publish the results of [Databricks data quality monitors](https://docs.databricks.com/aws/en/data-quality-monitoring/) (formerly Lakehouse Monitoring) as DataHub **assertions**. When `data_quality.enabled: true`, for every ingested table that has a monitor the connector reads the monitor's `*_profile_metrics` table over SQL (so a `warehouse_id` is required) and emits a column **completeness** assertion (plus per-run results) for each monitored column — the null count the monitor already computes, published as a check that passes when the column has no nulls in the window.
+
+The data quality checks themselves live in Databricks (the monitor), not in the recipe, so enabling the feature is a single flag:
+
+```yaml
+source:
+  type: unity-catalog
+  config:
+    warehouse_id: "<your-warehouse-id>"
+    data_quality:
+      enabled: true
+      # Optional: restrict which columns get assertions, or widen the window.
+      column_pattern:
+        allow: [".*"]
+      max_window_days: 1
+```
+
+Behavior:
+
+- One completeness assertion is published per monitored column (subject to `column_pattern`); the whole-table summary row is not published.
+- Assertion identity is deterministic (derived from the dataset, column and metric — not the run window), so re-ingesting is idempotent: the same assertion accrues new run events rather than creating duplicates.
+- `max_window_days` bounds how far back monitor windows are evaluated relative to the ingestion `end_time` (default: the most recent day), so each run publishes the latest windows rather than replaying all history.
+- Requires a `databricks-sdk` recent enough to expose the data quality API (>= 0.68.0); on older SDKs data-quality extraction is skipped with a warning.
+
 #### Delta Lake External Tables
 
 When `emit_siblings` is enabled (the default), the connector emits sibling relationships between Unity Catalog external tables and their corresponding `delta-lake` platform entities for tables stored on S3 or other object storage. This means you may see a second dataset entity for each external Delta table — one under the `databricks` platform and one under `delta-lake` — linked as siblings in DataHub. Set `emit_siblings: false` in your recipe to disable this behavior if you don't need cross-platform linkage.

--- a/metadata-ingestion/docs/sources/databricks/unity-catalog_post.md
+++ b/metadata-ingestion/docs/sources/databricks/unity-catalog_post.md
@@ -86,14 +86,14 @@ source:
       # Optional: restrict which columns get assertions, or widen the window.
       column_pattern:
         allow: [".*"]
-      max_window_days: 1
+      max_window_days: 7
 ```
 
 Behavior:
 
 - One completeness assertion is published per monitored column (subject to `column_pattern`); the whole-table summary row is not published.
 - Assertion identity is deterministic (derived from the dataset, column and metric — not the run window), so re-ingesting is idempotent: the same assertion accrues new run events rather than creating duplicates.
-- `max_window_days` bounds how far back monitor windows are evaluated relative to the ingestion `end_time` (default: the most recent day), so each run publishes the latest windows rather than replaying all history.
+- `max_window_days` bounds how far back monitor windows are evaluated relative to the ingestion `end_time` (default: the most recent 7 days), so each run publishes the latest windows rather than replaying all history.
 - Requires a `databricks-sdk` recent enough to expose the data quality API (>= 0.68.0); on older SDKs data-quality extraction is skipped with a warning.
 
 Permissions: the metric tables are read over SQL, so a running SQL warehouse (`warehouse_id`) is required, and the ingesting principal needs `SELECT` on each monitor's `*_profile_metrics` table. If a monitor writes its metrics to a schema that is not otherwise ingested, grant `USE SCHEMA` on that schema as well.

--- a/metadata-ingestion/docs/sources/databricks/unity-catalog_post.md
+++ b/metadata-ingestion/docs/sources/databricks/unity-catalog_post.md
@@ -74,9 +74,7 @@ The default preparsed path emits table-level usage only (no column `fieldCounts`
 
 #### Data Quality Monitors (assertions)
 
-DataHub can publish the results of [Databricks data quality monitors](https://docs.databricks.com/aws/en/data-quality-monitoring/) (formerly Lakehouse Monitoring) as DataHub **assertions**. When `data_quality.enabled: true`, for every ingested table that has a monitor the connector reads the monitor's `*_profile_metrics` table over SQL (so a `warehouse_id` is required) and emits a column **completeness** assertion (plus per-run results) for each monitored column — the null count the monitor already computes, published as a check that passes when the column has no nulls in the window.
-
-The data quality checks themselves live in Databricks (the monitor), not in the recipe, so enabling the feature is a single flag:
+DataHub ingests the results of [Databricks data quality monitors](https://docs.databricks.com/aws/en/data-quality-monitoring/) (formerly Lakehouse Monitoring) as DataHub **assertions**. When `data_quality.enabled: true`, for each ingested table that has a monitor DataHub reads the monitor's `*_profile_metrics` table and emits a column **completeness** assertion, plus a per-run result, for every monitored column. The assertion passes when the column has no nulls in the window.
 
 ```yaml
 source:
@@ -97,6 +95,8 @@ Behavior:
 - Assertion identity is deterministic (derived from the dataset, column and metric — not the run window), so re-ingesting is idempotent: the same assertion accrues new run events rather than creating duplicates.
 - `max_window_days` bounds how far back monitor windows are evaluated relative to the ingestion `end_time` (default: the most recent day), so each run publishes the latest windows rather than replaying all history.
 - Requires a `databricks-sdk` recent enough to expose the data quality API (>= 0.68.0); on older SDKs data-quality extraction is skipped with a warning.
+
+Permissions: the metric tables are read over SQL, so a running SQL warehouse (`warehouse_id`) is required, and the ingesting principal needs `SELECT` on each monitor's `*_profile_metrics` table. If a monitor writes its metrics to a schema that is not otherwise ingested, grant `USE SCHEMA` on that schema as well.
 
 #### Delta Lake External Tables
 

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
@@ -34,10 +34,9 @@ _OPERATOR_SYMBOL = "=="
 
 
 class DataQualityAssertion(BaseModel):
-    # Identity (table, column, metric) drives the assertion URN and excludes the
-    # run window, so re-ingesting the same check is idempotent: same assertion,
-    # new run event.
-    table_qualified_name: str
+    # (dataset, column, metric) drives the assertion URN and excludes the run
+    # window, so re-ingesting the same check is idempotent: same assertion, new
+    # run event.
     column: str
     metric: str
     threshold: float
@@ -52,21 +51,16 @@ class DataQualityAssertion(BaseModel):
         return f"{self.metric} {_OPERATOR_SYMBOL} {self.threshold} on {self.column}"
 
 
-def make_dq_assertion_urn(
-    result: DataQualityAssertion,
-    platform_instance: Optional[str],
-    env: Optional[str],
-) -> str:
+def make_dq_assertion_urn(dataset_urn: str, column: str, metric: str) -> str:
+    # Key off the dataset URN (not the qualified name), so the assertion inherits
+    # the same platform instance, metastore, and env the dataset URN already
+    # encodes — otherwise assertions from different workspaces could collide.
     key = {
         "platform": DATABRICKS_PLATFORM,
-        "table": result.table_qualified_name,
-        "column": result.column,
-        "metric": result.metric,
+        "dataset": dataset_urn,
+        "column": column,
+        "metric": metric,
     }
-    if platform_instance:
-        key["instance"] = platform_instance
-    if env:
-        key["env"] = env
     return make_assertion_urn(datahub_guid(key))
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
@@ -1,0 +1,117 @@
+from typing import Dict, Optional
+
+from pydantic import BaseModel
+
+from datahub.emitter import mce_builder
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.metadata.schema_classes import (
+    AssertionInfoClass,
+    AssertionResultClass,
+    AssertionResultTypeClass,
+    AssertionRunEventClass,
+    AssertionRunStatusClass,
+    AssertionStdOperatorClass,
+    AssertionTypeClass,
+    CustomAssertionInfoClass,
+    DatasetAssertionScopeClass,
+)
+
+# Shown in DataHub as the assertion's origin/type. Databricks data-quality
+# monitors were formerly branded "Lakehouse Monitoring".
+CUSTOM_ASSERTION_TYPE = "Databricks Data Quality"
+
+DATABRICKS_PLATFORM = "databricks"
+
+# Completeness is expressed as "null count == 0"; kept as symbols so the model
+# owns the DataHub-facing representation of its single operator.
+_OPERATOR = AssertionStdOperatorClass.EQUAL_TO
+_OPERATOR_SYMBOL = "=="
+
+
+class DataQualityAssertion(BaseModel):
+    """A normalized column completeness result, independent of its Databricks source.
+
+    This is the seam between where the result came from (a monitor metric table
+    today; a DLT event log or governed result table tomorrow) and how DataHub
+    represents it. Identity fields drive the assertion URN and exclude the run
+    window, so re-ingesting the same check is idempotent: same assertion, new run.
+    """
+
+    table_qualified_name: str
+    column: str
+    metric: str
+    threshold: float
+    observed: Optional[float]
+    passed: bool
+    timestamp_millis: int
+    run_id: str
+    native_results: Dict[str, str] = {}
+
+    @property
+    def logic(self) -> str:
+        return f"{self.metric} {_OPERATOR_SYMBOL} {self.threshold} on {self.column}"
+
+
+def make_dq_assertion_urn(
+    result: DataQualityAssertion,
+    platform_instance: Optional[str],
+    env: Optional[str],
+) -> str:
+    key = {
+        "platform": DATABRICKS_PLATFORM,
+        "table": result.table_qualified_name,
+        "column": result.column,
+        "metric": result.metric,
+    }
+    if platform_instance:
+        key["instance"] = platform_instance
+    if env:
+        key["env"] = env
+    return mce_builder.make_assertion_urn(mce_builder.datahub_guid(key))
+
+
+def build_assertion_info_mcp(
+    result: DataQualityAssertion,
+    assertion_urn: str,
+    dataset_urn: str,
+) -> MetadataChangeProposalWrapper:
+    field_urn = mce_builder.make_schema_field_urn(dataset_urn, result.column)
+    assertion_info = AssertionInfoClass(
+        type=AssertionTypeClass.CUSTOM,
+        customProperties={"metric": result.metric, "threshold": str(result.threshold)},
+        source=mce_builder.make_assertion_source(),
+        description="Completeness",
+        customAssertion=CustomAssertionInfoClass(
+            type=CUSTOM_ASSERTION_TYPE,
+            entity=dataset_urn,
+            field=field_urn,
+            scope=DatasetAssertionScopeClass.DATASET_COLUMN,
+            operator=_OPERATOR,
+            logic=result.logic,
+        ),
+    )
+    return MetadataChangeProposalWrapper(entityUrn=assertion_urn, aspect=assertion_info)
+
+
+def build_assertion_run_event_mcp(
+    result: DataQualityAssertion,
+    assertion_urn: str,
+    dataset_urn: str,
+) -> MetadataChangeProposalWrapper:
+    run_event = AssertionRunEventClass(
+        timestampMillis=result.timestamp_millis,
+        assertionUrn=assertion_urn,
+        asserteeUrn=dataset_urn,
+        runId=result.run_id,
+        status=AssertionRunStatusClass.COMPLETE,
+        result=AssertionResultClass(
+            type=(
+                AssertionResultTypeClass.SUCCESS
+                if result.passed
+                else AssertionResultTypeClass.FAILURE
+            ),
+            actualAggValue=result.observed,
+            nativeResults=result.native_results or None,
+        ),
+    )
+    return MetadataChangeProposalWrapper(entityUrn=assertion_urn, aspect=run_event)

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
@@ -25,13 +25,13 @@ from datahub.metadata.schema_classes import (
     DatasetAssertionScopeClass,
 )
 
-# The assertion "type" shown as its category in DataHub. dbt tags each kind of
-# assertion distinctly (regular tests -> "dbt", freshness -> "dbt Freshness")
-# rather than a single flat label, so we name the Databricks source instead of a
-# generic "Databricks"; the specific check is carried in `nativeType`.
+# Shown as the assertion's category in DataHub. We name the specific source of the
+# check (the monitor) rather than a generic "Databricks" so that different
+# Databricks-sourced checks stay distinguishable; the specific check is carried in
+# `nativeType`.
 LAKEHOUSE_MONITOR_ASSERTION_TYPE = "Databricks Lakehouse Monitor"
 
-# Native check name shown in the assertion details (analogous to a dbt test name).
+# Native check name shown in the assertion details.
 COMPLETENESS_NATIVE_TYPE = "completeness"
 
 # The assertion "name" shown in the DataHub assertions list. The list renders a
@@ -80,11 +80,10 @@ def build_assertion_info_mcp(
     dataset_urn: str,
 ) -> MetadataChangeProposalWrapper:
     field_urn = make_schema_field_urn(dataset_urn, result.column)
-    # Structured custom assertion (matching the dbt connector's shape). The
-    # scope/aggregation/operator/parameters/field are still populated for
-    # future-proofing, but the assertions list renders a custom assertion's name
-    # from `description` and never fetches those structured fields — so we also
-    # set an explicit column-aware `description` to surface the column in the name.
+    # Structured custom assertion. The scope/aggregation/operator/parameters/field
+    # fully describe the check, but the assertions list renders a custom assertion's
+    # name from `description` and never fetches those structured fields — so we also
+    # set a column-aware `description` to surface the column in the name.
     assertion_info = AssertionInfoClass(
         type=AssertionTypeClass.CUSTOM,
         description=COMPLETENESS_ASSERTION_DESCRIPTION.format(

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
@@ -25,13 +25,20 @@ from datahub.metadata.schema_classes import (
     DatasetAssertionScopeClass,
 )
 
-# The provider shown as the assertion's category in DataHub. Mirrors how other
-# native integrations tag their source (dbt -> "dbt", Great Expectations ->
-# "GREAT_EXPECTATIONS"); the specific check is carried in `nativeType` instead.
-DATABRICKS_ASSERTION_PROVIDER = "Databricks"
+# The assertion "type" shown as its category in DataHub. dbt tags each kind of
+# assertion distinctly (regular tests -> "dbt", freshness -> "dbt Freshness")
+# rather than a single flat label, so we name the Databricks source instead of a
+# generic "Databricks"; the specific check is carried in `nativeType`.
+LAKEHOUSE_MONITOR_ASSERTION_TYPE = "Databricks Lakehouse Monitor"
 
 # Native check name shown in the assertion details (analogous to a dbt test name).
 COMPLETENESS_NATIVE_TYPE = "completeness"
+
+# The assertion "name" shown in the DataHub assertions list. The list renders a
+# custom assertion's name from `description` when set, otherwise it falls back to
+# the `type` label; it does not fetch the structured scope/aggregation fields, so
+# the column would never appear in the name unless we put it here.
+COMPLETENESS_ASSERTION_DESCRIPTION = "Null count for column {column} is {threshold}"
 
 DATABRICKS_PLATFORM = "databricks"
 
@@ -73,16 +80,20 @@ def build_assertion_info_mcp(
     dataset_urn: str,
 ) -> MetadataChangeProposalWrapper:
     field_urn = make_schema_field_urn(dataset_urn, result.column)
-    # Structured custom assertion (matching the dbt connector's shape): the
-    # scope/aggregation/operator/parameters/field drive DataHub's column-aware
-    # rendering ("Null count for column X is equal to 0"), rather than a
-    # hand-written description that omits the column.
+    # Structured custom assertion (matching the dbt connector's shape). The
+    # scope/aggregation/operator/parameters/field are still populated for
+    # future-proofing, but the assertions list renders a custom assertion's name
+    # from `description` and never fetches those structured fields — so we also
+    # set an explicit column-aware `description` to surface the column in the name.
     assertion_info = AssertionInfoClass(
         type=AssertionTypeClass.CUSTOM,
+        description=COMPLETENESS_ASSERTION_DESCRIPTION.format(
+            column=result.column, threshold=_format_threshold(result.threshold)
+        ),
         customProperties={"metric": result.metric, "threshold": str(result.threshold)},
         source=make_assertion_source(),
         customAssertion=CustomAssertionInfoClass(
-            type=DATABRICKS_ASSERTION_PROVIDER,
+            type=LAKEHOUSE_MONITOR_ASSERTION_TYPE,
             entity=dataset_urn,
             field=field_urn,
             fields=[field_urn],

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
@@ -15,22 +15,25 @@ from datahub.metadata.schema_classes import (
     AssertionResultTypeClass,
     AssertionRunEventClass,
     AssertionRunStatusClass,
+    AssertionStdAggregationClass,
     AssertionStdOperatorClass,
+    AssertionStdParameterClass,
+    AssertionStdParametersClass,
+    AssertionStdParameterTypeClass,
     AssertionTypeClass,
     CustomAssertionInfoClass,
     DatasetAssertionScopeClass,
 )
 
-# Shown in DataHub as the assertion's origin/type. Databricks data-quality
-# monitors were formerly branded "Lakehouse Monitoring".
-CUSTOM_ASSERTION_TYPE = "Databricks Data Quality"
+# The provider shown as the assertion's category in DataHub. Mirrors how other
+# native integrations tag their source (dbt -> "dbt", Great Expectations ->
+# "GREAT_EXPECTATIONS"); the specific check is carried in `nativeType` instead.
+DATABRICKS_ASSERTION_PROVIDER = "Databricks"
+
+# Native check name shown in the assertion details (analogous to a dbt test name).
+COMPLETENESS_NATIVE_TYPE = "completeness"
 
 DATABRICKS_PLATFORM = "databricks"
-
-# Completeness is expressed as "null count == 0"; kept as symbols so the model
-# owns the DataHub-facing representation of its single operator.
-_OPERATOR = AssertionStdOperatorClass.EQUAL_TO
-_OPERATOR_SYMBOL = "=="
 
 
 class DataQualityAssertion(BaseModel):
@@ -46,9 +49,9 @@ class DataQualityAssertion(BaseModel):
     run_id: str
     native_results: Dict[str, str] = {}
 
-    @property
-    def logic(self) -> str:
-        return f"{self.metric} {_OPERATOR_SYMBOL} {self.threshold} on {self.column}"
+
+def _format_threshold(threshold: float) -> str:
+    return str(int(threshold)) if threshold == int(threshold) else str(threshold)
 
 
 def make_dq_assertion_urn(dataset_urn: str, column: str, metric: str) -> str:
@@ -70,18 +73,29 @@ def build_assertion_info_mcp(
     dataset_urn: str,
 ) -> MetadataChangeProposalWrapper:
     field_urn = make_schema_field_urn(dataset_urn, result.column)
+    # Structured custom assertion (matching the dbt connector's shape): the
+    # scope/aggregation/operator/parameters/field drive DataHub's column-aware
+    # rendering ("Null count for column X is equal to 0"), rather than a
+    # hand-written description that omits the column.
     assertion_info = AssertionInfoClass(
         type=AssertionTypeClass.CUSTOM,
         customProperties={"metric": result.metric, "threshold": str(result.threshold)},
         source=make_assertion_source(),
-        description="Completeness",
         customAssertion=CustomAssertionInfoClass(
-            type=CUSTOM_ASSERTION_TYPE,
+            type=DATABRICKS_ASSERTION_PROVIDER,
             entity=dataset_urn,
             field=field_urn,
+            fields=[field_urn],
             scope=DatasetAssertionScopeClass.DATASET_COLUMN,
-            operator=_OPERATOR,
-            logic=result.logic,
+            aggregation=AssertionStdAggregationClass.NULL_COUNT,
+            operator=AssertionStdOperatorClass.EQUAL_TO,
+            parameters=AssertionStdParametersClass(
+                value=AssertionStdParameterClass(
+                    value=_format_threshold(result.threshold),
+                    type=AssertionStdParameterTypeClass.NUMBER,
+                )
+            ),
+            nativeType=COMPLETENESS_NATIVE_TYPE,
         ),
     )
     return MetadataChangeProposalWrapper(entityUrn=assertion_urn, aspect=assertion_info)

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
@@ -34,14 +34,9 @@ _OPERATOR_SYMBOL = "=="
 
 
 class DataQualityAssertion(BaseModel):
-    """A normalized column completeness result, independent of its Databricks source.
-
-    This is the seam between where the result came from (a monitor metric table
-    today; a DLT event log or governed result table tomorrow) and how DataHub
-    represents it. Identity fields drive the assertion URN and exclude the run
-    window, so re-ingesting the same check is idempotent: same assertion, new run.
-    """
-
+    # Identity (table, column, metric) drives the assertion URN and excludes the
+    # run window, so re-ingesting the same check is idempotent: same assertion,
+    # new run event.
     table_qualified_name: str
     column: str
     metric: str

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/assertion.py
@@ -2,7 +2,12 @@ from typing import Dict, Optional
 
 from pydantic import BaseModel
 
-from datahub.emitter import mce_builder
+from datahub.emitter.mce_builder import (
+    datahub_guid,
+    make_assertion_source,
+    make_assertion_urn,
+    make_schema_field_urn,
+)
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.metadata.schema_classes import (
     AssertionInfoClass,
@@ -67,7 +72,7 @@ def make_dq_assertion_urn(
         key["instance"] = platform_instance
     if env:
         key["env"] = env
-    return mce_builder.make_assertion_urn(mce_builder.datahub_guid(key))
+    return make_assertion_urn(datahub_guid(key))
 
 
 def build_assertion_info_mcp(
@@ -75,11 +80,11 @@ def build_assertion_info_mcp(
     assertion_urn: str,
     dataset_urn: str,
 ) -> MetadataChangeProposalWrapper:
-    field_urn = mce_builder.make_schema_field_urn(dataset_urn, result.column)
+    field_urn = make_schema_field_urn(dataset_urn, result.column)
     assertion_info = AssertionInfoClass(
         type=AssertionTypeClass.CUSTOM,
         customProperties={"metric": result.metric, "threshold": str(result.threshold)},
-        source=mce_builder.make_assertion_source(),
+        source=make_assertion_source(),
         description="Completeness",
         customAssertion=CustomAssertionInfoClass(
             type=CUSTOM_ASSERTION_TYPE,

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -205,11 +205,12 @@ class UnityCatalogDataQualityConfig(ConfigModel):
         "the column name.",
     )
     max_window_days: int = Field(
-        default=1,
+        default=7,
         ge=1,
         description="Only evaluate monitor windows ending within this many days before "
         "the ingestion end_time, so each run publishes the most recent windows rather "
-        "than replaying all monitor history.",
+        "than replaying all monitor history. Defaults to 7 so a daily monitor that "
+        "last refreshed a day or two ago still surfaces its latest results.",
     )
 
 

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/config.py
@@ -192,6 +192,27 @@ class FederationConnectionDetail(ConfigModel):
         return v.upper() if v is not None else v
 
 
+class UnityCatalogDataQualityConfig(ConfigModel):
+    enabled: bool = Field(
+        default=False,
+        description="Publish Databricks data-quality monitor results as DataHub "
+        "column completeness assertions. Requires warehouse_id, since the monitor's "
+        "metric tables are read over SQL. Disabled by default.",
+    )
+    column_pattern: AllowDenyPattern = Field(
+        default=AllowDenyPattern.allow_all(),
+        description="Which columns to publish completeness assertions for, matched on "
+        "the column name.",
+    )
+    max_window_days: int = Field(
+        default=1,
+        ge=1,
+        description="Only evaluate monitor windows ending within this many days before "
+        "the ingestion end_time, so each run publishes the most recent windows rather "
+        "than replaying all monitor history.",
+    )
+
+
 class UnityCatalogSourceConfig(
     UnityCatalogConnectionConfig,
     SQLCommonConfig,
@@ -385,6 +406,15 @@ class UnityCatalogSourceConfig(
             "for columns that are part of the table's partition key. "
             "Partition key information is already present in the tables.list() response "
             "so no additional API calls are made."
+        ),
+    )
+
+    data_quality: UnityCatalogDataQualityConfig = pydantic.Field(
+        default_factory=UnityCatalogDataQualityConfig,
+        description=(
+            "Publish Databricks data-quality monitor results as DataHub assertions. "
+            "Disabled by default; requires warehouse_id since the monitor metric "
+            "tables are queried over SQL."
         ),
     )
 
@@ -593,6 +623,15 @@ class UnityCatalogSourceConfig(
                 "warehouse_id is not set but include_hive_metastore=True. "
                 "Automatically disabling hive metastore extraction since it requires SQL queries. "
                 "Set warehouse_id to enable hive metastore extraction."
+            )
+
+        if self.data_quality.enabled and not self.warehouse_id:
+            self.data_quality.enabled = False
+            logger.warning(
+                "warehouse_id is not set but data_quality.enabled=True. "
+                "Automatically disabling data-quality assertion extraction since it "
+                "requires SQL queries against the monitor metric tables. "
+                "Set warehouse_id to enable it."
             )
 
         # Set private attributes

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/data_quality.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/data_quality.py
@@ -1,0 +1,181 @@
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Dict, Iterable, Optional, Set
+
+from datahub.emitter.mce_builder import make_ts_millis
+from datahub.ingestion.api.workunit import MetadataWorkUnit
+from datahub.ingestion.source.unity.assertion import (
+    DataQualityAssertion,
+    build_assertion_info_mcp,
+    build_assertion_run_event_mcp,
+    make_dq_assertion_urn,
+)
+from datahub.ingestion.source.unity.config import UnityCatalogDataQualityConfig
+from datahub.ingestion.source.unity.proxy import UnityCatalogApiProxy
+from datahub.ingestion.source.unity.proxy_types import Table, TableReference
+from datahub.ingestion.source.unity.report import UnityCatalogReport
+
+logger = logging.getLogger(__name__)
+
+# The monitor's null count for a column; completeness passes when it is zero.
+COMPLETENESS_METRIC = "num_nulls"
+COMPLETENESS_THRESHOLD = 0.0
+
+_TS_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+# `count` is a reserved word and collides with Row.count on the client, so it is
+# backtick-quoted and aliased. `log_type = 'INPUT'` selects the monitored table
+# itself (not the drift baseline); `column_name <> ':table'` drops the whole-table
+# summary row so only per-column completeness is published.
+_PROFILE_METRICS_QUERY = """\
+SELECT window.end AS window_end, column_name, monitor_version,
+       `count` AS row_count, num_nulls, percent_null
+FROM {metrics_table}
+WHERE log_type = 'INPUT' AND slice_key IS NULL AND column_name <> ':table'
+  AND window.end >= TIMESTAMP '{start}' AND window.end <= TIMESTAMP '{end}'
+"""
+
+
+class UnityCatalogDataQualityExtractor:
+    """Publishes Databricks data-quality monitor results as DataHub assertions.
+
+    For each ingested table that has a monitor, reads the profile-metrics table over
+    SQL (windowed on the ingestion end_time) and emits one idempotent completeness
+    assertion per monitored column, plus a per-window run result.
+    """
+
+    def __init__(
+        self,
+        config: UnityCatalogDataQualityConfig,
+        report: UnityCatalogReport,
+        proxy: UnityCatalogApiProxy,
+        dataset_urn_builder: Callable[[TableReference], str],
+        end_time: datetime,
+        platform_instance: Optional[str],
+        env: str,
+    ) -> None:
+        self.config = config
+        self.report = report
+        self.proxy = proxy
+        self.dataset_urn_builder = dataset_urn_builder
+        self.end_time = end_time
+        self.platform_instance = platform_instance
+        self.env = env
+        # Assertion definitions are emitted once; run events are emitted per window.
+        self._emitted_assertion_urns: Set[str] = set()
+
+    def get_workunits(self, tables: Iterable[Table]) -> Iterable[MetadataWorkUnit]:
+        if not self.proxy.data_quality_available():
+            self.report.warning(
+                title="Data quality assertions unavailable",
+                message="The installed databricks-sdk does not expose the data "
+                "quality API (requires databricks-sdk>=0.68.0). Skipping "
+                "data-quality assertion extraction.",
+            )
+            return
+
+        for table in tables:
+            yield from self._process_table(table)
+
+    def _process_table(self, table: Table) -> Iterable[MetadataWorkUnit]:
+        if not table.table_id:
+            return
+
+        monitor = self.proxy.get_quality_monitor(table.table_id)
+        profiling = getattr(monitor, "data_profiling_config", None) if monitor else None
+        metrics_table = (
+            getattr(profiling, "profile_metrics_table_name", None)
+            if profiling
+            else None
+        )
+        if not metrics_table:
+            self.report.num_quality_tables_without_monitor += 1
+            self.report.quality_monitors_missing_metrics.append(
+                table.ref.qualified_table_name
+            )
+            return
+
+        self.report.num_quality_monitors_found += 1
+        dataset_urn = self.dataset_urn_builder(table.ref)
+
+        try:
+            rows = self.proxy.run_sql_query(self._build_query(metrics_table))
+        except Exception as e:
+            self.report.num_quality_metric_query_failures += 1
+            self.report.warning(
+                title="Failed to read data quality metrics",
+                message="Could not query the monitor profile-metrics table.",
+                context=table.ref.qualified_table_name,
+                exc=e,
+            )
+            return
+
+        for row in rows:
+            yield from self._process_column(table.ref, dataset_urn, row.asDict())
+
+    def _process_column(
+        self, ref: TableReference, dataset_urn: str, record: Dict[str, object]
+    ) -> Iterable[MetadataWorkUnit]:
+        column = str(record.get("column_name") or "")
+        num_nulls = record.get(COMPLETENESS_METRIC)
+        if not column or num_nulls is None:
+            return
+        if not self.config.column_pattern.allowed(column):
+            return
+
+        result = self._build_result(ref, column, record, float(num_nulls))  # type: ignore[arg-type]
+        assertion_urn = make_dq_assertion_urn(result, self.platform_instance, self.env)
+
+        if assertion_urn not in self._emitted_assertion_urns:
+            self._emitted_assertion_urns.add(assertion_urn)
+            self.report.num_quality_assertions_emitted += 1
+            yield build_assertion_info_mcp(
+                result, assertion_urn, dataset_urn
+            ).as_workunit()
+
+        self.report.num_quality_run_events_emitted += 1
+        yield build_assertion_run_event_mcp(
+            result, assertion_urn, dataset_urn
+        ).as_workunit()
+
+    def _build_result(
+        self,
+        ref: TableReference,
+        column: str,
+        record: Dict[str, object],
+        num_nulls: float,
+    ) -> DataQualityAssertion:
+        timestamp_millis = self._to_millis(record.get("window_end"))
+        monitor_version = record.get("monitor_version")
+
+        native: Dict[str, str] = {}
+        for key in ("percent_null", "row_count", "monitor_version"):
+            value = record.get(key)
+            if value is not None:
+                native[key] = str(value)
+
+        return DataQualityAssertion(
+            table_qualified_name=ref.qualified_table_name,
+            column=column,
+            metric=COMPLETENESS_METRIC,
+            threshold=COMPLETENESS_THRESHOLD,
+            observed=num_nulls,
+            passed=num_nulls <= COMPLETENESS_THRESHOLD,
+            timestamp_millis=timestamp_millis,
+            run_id=f"{monitor_version}:{timestamp_millis}",
+            native_results=native,
+        )
+
+    def _build_query(self, metrics_table: str) -> str:
+        quoted_table = ".".join(f"`{part}`" for part in metrics_table.split("."))
+        start = self.end_time - timedelta(days=self.config.max_window_days)
+        return _PROFILE_METRICS_QUERY.format(
+            metrics_table=quoted_table,
+            start=start.strftime(_TS_FORMAT),
+            end=self.end_time.strftime(_TS_FORMAT),
+        )
+
+    def _to_millis(self, window_end: object) -> int:
+        if isinstance(window_end, datetime):
+            return make_ts_millis(window_end)
+        return make_ts_millis(self.end_time.astimezone(timezone.utc))

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/data_quality.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/data_quality.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Callable, Dict, Iterable, Optional, Set
+from typing import Callable, Dict, Iterable, Set
 
 from datahub.emitter.mce_builder import make_ts_millis
 from datahub.ingestion.api.workunit import MetadataWorkUnit
@@ -21,7 +21,9 @@ logger = logging.getLogger(__name__)
 COMPLETENESS_METRIC = "num_nulls"
 COMPLETENESS_THRESHOLD = 0.0
 
-_TS_FORMAT = "%Y-%m-%d %H:%M:%S"
+# Keep fractional seconds so a window ending mid-second is not truncated below the
+# query's upper bound (which would drop that window).
+_TS_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
 # `count` is a reserved word and collides with Row.count on the client, so it is
 # backtick-quoted and aliased. `log_type = 'INPUT'` selects the monitored table
@@ -44,16 +46,12 @@ class UnityCatalogDataQualityExtractor:
         proxy: UnityCatalogApiProxy,
         dataset_urn_builder: Callable[[TableReference], str],
         end_time: datetime,
-        platform_instance: Optional[str],
-        env: str,
     ) -> None:
         self.config = config
         self.report = report
         self.proxy = proxy
         self.dataset_urn_builder = dataset_urn_builder
         self.end_time = end_time
-        self.platform_instance = platform_instance
-        self.env = env
         # Assertion definitions are emitted once; run events are emitted per window.
         self._emitted_assertion_urns: Set[str] = set()
 
@@ -74,15 +72,29 @@ class UnityCatalogDataQualityExtractor:
         if not table.table_id:
             return
 
-        monitor = self.proxy.get_quality_monitor(table.table_id)
-        profiling = getattr(monitor, "data_profiling_config", None) if monitor else None
-        metrics_table = (
-            getattr(profiling, "profile_metrics_table_name", None)
-            if profiling
-            else None
-        )
-        if not metrics_table:
+        try:
+            monitor = self.proxy.get_quality_monitor(table.table_id)
+        except Exception as e:
+            # NotFound (no monitor) is already degraded to None inside the proxy; an
+            # exception here is a real API error (auth, rate limit, transient) and
+            # must not be mistaken for an unmonitored table.
+            self.report.num_quality_monitor_errors += 1
+            self.report.warning(
+                title="Failed to fetch data quality monitor",
+                message="Could not determine whether the table has a data quality "
+                "monitor.",
+                context=table.ref.qualified_table_name,
+                exc=e,
+            )
+            return
+
+        if monitor is None:
             self.report.num_quality_tables_without_monitor += 1
+            return
+
+        profiling = monitor.data_profiling_config
+        metrics_table = profiling.profile_metrics_table_name if profiling else None
+        if not metrics_table:
             self.report.quality_monitors_missing_metrics.append(
                 table.ref.qualified_table_name
             )
@@ -104,10 +116,10 @@ class UnityCatalogDataQualityExtractor:
             return
 
         for row in rows:
-            yield from self._process_column(table.ref, dataset_urn, row.asDict())
+            yield from self._process_column(dataset_urn, row.asDict())
 
     def _process_column(
-        self, ref: TableReference, dataset_urn: str, record: Dict[str, object]
+        self, dataset_urn: str, record: Dict[str, object]
     ) -> Iterable[MetadataWorkUnit]:
         column = str(record.get("column_name") or "")
         num_nulls = record.get(COMPLETENESS_METRIC)
@@ -116,8 +128,8 @@ class UnityCatalogDataQualityExtractor:
         if not self.config.column_pattern.allowed(column):
             return
 
-        result = self._build_result(ref, column, record, float(num_nulls))  # type: ignore[arg-type]
-        assertion_urn = make_dq_assertion_urn(result, self.platform_instance, self.env)
+        result = self._build_result(column, record, float(num_nulls))  # type: ignore[arg-type]
+        assertion_urn = make_dq_assertion_urn(dataset_urn, result.column, result.metric)
 
         if assertion_urn not in self._emitted_assertion_urns:
             self._emitted_assertion_urns.add(assertion_urn)
@@ -133,7 +145,6 @@ class UnityCatalogDataQualityExtractor:
 
     def _build_result(
         self,
-        ref: TableReference,
         column: str,
         record: Dict[str, object],
         num_nulls: float,
@@ -148,7 +159,6 @@ class UnityCatalogDataQualityExtractor:
                 native[key] = str(value)
 
         return DataQualityAssertion(
-            table_qualified_name=ref.qualified_table_name,
             column=column,
             metric=COMPLETENESS_METRIC,
             threshold=COMPLETENESS_THRESHOLD,

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/data_quality.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/data_quality.py
@@ -37,13 +37,6 @@ WHERE log_type = 'INPUT' AND slice_key IS NULL AND column_name <> ':table'
 
 
 class UnityCatalogDataQualityExtractor:
-    """Publishes Databricks data-quality monitor results as DataHub assertions.
-
-    For each ingested table that has a monitor, reads the profile-metrics table over
-    SQL (windowed on the ingestion end_time) and emits one idempotent completeness
-    assertion per monitored column, plus a per-window run result.
-    """
-
     def __init__(
         self,
         config: UnityCatalogDataQualityConfig,

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
@@ -1719,6 +1719,38 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
             self._report_sql_query_failure(e, query, params)
             return []
 
+    def run_sql_query(self, query: str) -> List[Row]:
+        """Public entry point for feature extractors to run a small metadata query.
+
+        Thin passthrough to `_execute_sql_query` so modules outside this class (e.g.
+        the data-quality extractor) don't reach into a private method.
+        """
+        return self._execute_sql_query(query)
+
+    def data_quality_available(self) -> bool:
+        """Whether the installed databricks-sdk exposes the data-quality API.
+
+        The `data_quality` client was added in databricks-sdk 0.68.0; the Unity
+        connector supports older SDKs, so callers must feature-detect.
+        """
+        return getattr(self._workspace_client, "data_quality", None) is not None
+
+    def get_quality_monitor(self, table_id: str) -> Optional[Any]:
+        """Return the data-quality monitor for a table, or None if it has none.
+
+        A missing monitor is the common case (most tables are unmonitored) and is
+        surfaced by the SDK as a NotFound error, so we degrade to None rather than
+        raising.
+        """
+        dq = getattr(self._workspace_client, "data_quality", None)
+        if dq is None:
+            return None
+        try:
+            return dq.get_monitor(object_type="table", object_id=table_id)
+        except Exception as e:
+            logger.debug(f"No data quality monitor for table_id={table_id}: {e}")
+            return None
+
     def _execute_sql_query_streaming(
         self,
         query: str,

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/proxy.py
@@ -9,13 +9,25 @@ import os
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 from datetime import datetime
-from typing import Any, Dict, Generator, Iterable, List, Optional, Sequence, Union, cast
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Protocol,
+    Sequence,
+    Union,
+    cast,
+)
 from unittest.mock import patch
 
 import cachetools
 import yaml
 from cachetools import cached
 from databricks.sdk import WorkspaceClient
+from databricks.sdk.errors import NotFound
 from databricks.sdk.service.catalog import (
     CatalogInfo,
     ColumnInfo,
@@ -291,6 +303,14 @@ def _optional_row_field(
             report.num_lineage_row_field_read_errors += 1
         return None
     return value
+
+
+class DataProfilingConfig(Protocol):
+    profile_metrics_table_name: Optional[str]
+
+
+class QualityMonitor(Protocol):
+    data_profiling_config: Optional[DataProfilingConfig]
 
 
 class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
@@ -1720,35 +1740,36 @@ class UnityCatalogApiProxy(UnityCatalogProxyProfilingMixin):
             return []
 
     def run_sql_query(self, query: str) -> List[Row]:
-        """Public entry point for feature extractors to run a small metadata query.
-
-        Thin passthrough to `_execute_sql_query` so modules outside this class (e.g.
-        the data-quality extractor) don't reach into a private method.
-        """
-        return self._execute_sql_query(query)
+        # Unlike _execute_sql_query, this raises on failure instead of returning an
+        # empty list, so the data-quality extractor can tell a query error (missing
+        # SELECT, wrong table) apart from a monitor with no rows in the window.
+        sql_connection_params = get_sql_connection_params(self._workspace_client)
+        with (
+            connect(**sql_connection_params) as connection,
+            connection.cursor() as cursor,
+        ):
+            cursor.execute(query)
+            return cursor.fetchall()
 
     def data_quality_available(self) -> bool:
-        """Whether the installed databricks-sdk exposes the data-quality API.
-
-        The `data_quality` client was added in databricks-sdk 0.68.0; the Unity
-        connector supports older SDKs, so callers must feature-detect.
-        """
+        # The data_quality client was added in databricks-sdk 0.68.0; the Unity
+        # connector supports older SDKs, so callers must feature-detect.
         return getattr(self._workspace_client, "data_quality", None) is not None
 
-    def get_quality_monitor(self, table_id: str) -> Optional[Any]:
-        """Return the data-quality monitor for a table, or None if it has none.
-
-        A missing monitor is the common case (most tables are unmonitored) and is
-        surfaced by the SDK as a NotFound error, so we degrade to None rather than
-        raising.
-        """
+    def get_quality_monitor(self, table_id: str) -> Optional[QualityMonitor]:
+        # A missing monitor is the common case (most tables are unmonitored) and the
+        # SDK surfaces it as NotFound, so we degrade only that to None. Auth, rate
+        # limit, and transient errors propagate so the caller can report them rather
+        # than silently treating the table as unmonitored.
         dq = getattr(self._workspace_client, "data_quality", None)
         if dq is None:
             return None
         try:
-            return dq.get_monitor(object_type="table", object_id=table_id)
-        except Exception as e:
-            logger.debug(f"No data quality monitor for table_id={table_id}: {e}")
+            return cast(
+                QualityMonitor,
+                dq.get_monitor(object_type="table", object_id=table_id),
+            )
+        except NotFound:
             return None
 
     def _execute_sql_query_streaming(

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/report.py
@@ -67,6 +67,13 @@ class UnityCatalogReport(SQLSourceReport):
     num_profile_failed_unsupported_column_type: int = 0
     num_profile_failed_int_casts: int = 0
 
+    num_quality_monitors_found: int = 0
+    num_quality_tables_without_monitor: int = 0
+    num_quality_assertions_emitted: int = 0
+    num_quality_run_events_emitted: int = 0
+    num_quality_metric_query_failures: int = 0
+    quality_monitors_missing_metrics: LossyList[str] = field(default_factory=LossyList)
+
     num_catalogs_missing_name: int = 0
     num_schemas_missing_name: int = 0
     num_tables_missing_name: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/report.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/report.py
@@ -72,6 +72,7 @@ class UnityCatalogReport(SQLSourceReport):
     num_quality_assertions_emitted: int = 0
     num_quality_run_events_emitted: int = 0
     num_quality_metric_query_failures: int = 0
+    num_quality_monitor_errors: int = 0
     quality_monitors_missing_metrics: LossyList[str] = field(default_factory=LossyList)
 
     num_catalogs_missing_name: int = 0

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -87,6 +87,9 @@ from datahub.ingestion.source.unity.config import (
 )
 from datahub.ingestion.source.unity.connection import create_workspace_client
 from datahub.ingestion.source.unity.connection_test import UnityCatalogConnectionTest
+from datahub.ingestion.source.unity.data_quality import (
+    UnityCatalogDataQualityExtractor,
+)
 from datahub.ingestion.source.unity.ge_profiler import UnityCatalogGEProfiler
 from datahub.ingestion.source.unity.hive_metastore_proxy import (
     HIVE_METASTORE,
@@ -671,6 +674,28 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                 else:
                     raise ValueError("Unknown profiling config method")
 
+        if self.config.data_quality.enabled:
+            with self.report.new_stage("Start warehouse"):
+                wait_on_warehouse = self.unity_catalog_api_proxy.start_warehouse()
+                if wait_on_warehouse is None:
+                    self.report.failure(
+                        message="SQL warehouse not found",
+                        context="Data quality assertions require a SQL warehouse",
+                    )
+                else:
+                    wait_on_warehouse.result()
+                    with self.report.new_stage("Ingest data quality"):
+                        dq_extractor = UnityCatalogDataQualityExtractor(
+                            config=self.config.data_quality,
+                            report=self.report,
+                            proxy=self.unity_catalog_api_proxy,
+                            dataset_urn_builder=self.gen_dataset_urn,
+                            end_time=self.config.end_time,
+                            platform_instance=self.config.platform_instance,
+                            env=self.config.env,
+                        )
+                        yield from dq_extractor.get_workunits(self.tables.values())
+
     def build_service_principal_map(self) -> None:
         try:
             for sp in self.unity_catalog_api_proxy.service_principals():
@@ -859,14 +884,19 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                 self.report.tables.dropped(table.id, f"table ({table.table_type})")
                 continue
 
-            if (
+            # Data quality also needs the resolved Table objects (for table_id) at a
+            # later stage, so retain non-view tables when either profiling (table
+            # level) or data-quality extraction is enabled.
+            profiled_here = (
                 self.config.is_profiling_enabled()
                 and self.config.uses_table_level_profiler()
                 and self.config.profiling.pattern.allowed(
                     table.ref.qualified_table_name
                 )
-                and not table.is_view
-            ):
+            )
+            if (
+                profiled_here or self.config.data_quality.enabled
+            ) and not table.is_view:
                 self.tables[table.ref.qualified_table_name] = table
 
             if table.is_view:

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -460,6 +460,10 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
 
         # Global map of tables, for profiling
         self.tables: FileBackedDict[Table] = FileBackedDict()
+        # Separate map for data-quality extraction so enabling it never widens the
+        # set of tables the profiler consumes (the profiler doesn't re-apply
+        # profiling.pattern to this map).
+        self.dq_tables: FileBackedDict[Table] = FileBackedDict()
         if self.ctx.graph:
             self.platform_resource_repository = UnityCatalogPlatformResourceRepository(
                 self.ctx.graph, platform_instance=self.platform_instance_name
@@ -691,10 +695,8 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                             proxy=self.unity_catalog_api_proxy,
                             dataset_urn_builder=self.gen_dataset_urn,
                             end_time=self.config.end_time,
-                            platform_instance=self.config.platform_instance,
-                            env=self.config.env,
                         )
-                        yield from dq_extractor.get_workunits(self.tables.values())
+                        yield from dq_extractor.get_workunits(self.dq_tables.values())
 
     def build_service_principal_map(self) -> None:
         try:
@@ -884,9 +886,6 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                 self.report.tables.dropped(table.id, f"table ({table.table_type})")
                 continue
 
-            # Data quality also needs the resolved Table objects (for table_id) at a
-            # later stage, so retain non-view tables when either profiling (table
-            # level) or data-quality extraction is enabled.
             profiled_here = (
                 self.config.is_profiling_enabled()
                 and self.config.uses_table_level_profiler()
@@ -894,10 +893,12 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                     table.ref.qualified_table_name
                 )
             )
-            if (
-                profiled_here or self.config.data_quality.enabled
-            ) and not table.is_view:
+            if profiled_here and not table.is_view:
                 self.tables[table.ref.qualified_table_name] = table
+            # Data quality needs the resolved Table objects (for table_id) at a later
+            # stage; keep it separate from the profiler's table set above.
+            if self.config.data_quality.enabled and not table.is_view:
+                self.dq_tables[table.ref.qualified_table_name] = table
 
             if table.is_view:
                 self.view_refs.add(table.ref)

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -588,20 +588,12 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
 
     def get_workunits_internal(self) -> Iterable[MetadataWorkUnit]:
         with self.report.new_stage("Ingestion Setup"):
-            wait_on_warehouse = None
             if self.config.include_hive_metastore:
-                with self.report.new_stage("Start warehouse"):
-                    # Can take several minutes, so start now and wait later
-                    wait_on_warehouse = self.unity_catalog_api_proxy.start_warehouse()
-                    if wait_on_warehouse is None:
-                        self.report.failure(
-                            message="SQL warehouse not found",
-                            context=f"SQL warehouse {self.config.profiling.warehouse_id} not found",
-                        )
-                        return
-                    else:
-                        # wait until warehouse is started
-                        wait_on_warehouse.result()
+                # Hive metastore extraction needs a running warehouse.
+                if not self._start_warehouse_or_report(
+                    f"SQL warehouse {self.config.profiling.warehouse_id} not found"
+                ):
+                    return
 
         if self.config.include_ownership:
             with self.report.new_stage("Ingest service principals"):
@@ -637,20 +629,12 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                 )
 
         if self.config.is_profiling_enabled():
-            with self.report.new_stage("Start warehouse"):
-                # Need to start the warehouse again for profiling,
-                # as it may have been stopped after ingestion might take
-                # longer time to complete
-                wait_on_warehouse = self.unity_catalog_api_proxy.start_warehouse()
-                if wait_on_warehouse is None:
-                    self.report.failure(
-                        message="SQL warehouse not found",
-                        context=f"SQL warehouse {self.config.profiling.warehouse_id} not found",
-                    )
-                    return
-                else:
-                    # wait until warehouse is started
-                    wait_on_warehouse.result()
+            # Start the warehouse again for profiling; it may have been stopped after
+            # ingestion if that took a while.
+            if not self._start_warehouse_or_report(
+                f"SQL warehouse {self.config.profiling.warehouse_id} not found"
+            ):
+                return
 
             with self.report.new_stage("Profiling"):
                 if isinstance(self.config.profiling, UnityCatalogAnalyzeProfilerConfig):
@@ -681,16 +665,26 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
         if self.config.data_quality.enabled:
             yield from self._gen_data_quality_workunits()
 
-    def _gen_data_quality_workunits(self) -> Iterable[MetadataWorkUnit]:
+    def _start_warehouse_or_report(self, failure_context: str) -> bool:
+        # Starting the SQL warehouse can take minutes; every warehouse-gated stage
+        # shares this start / not-found-failure / wait sequence. Returns False after
+        # reporting a failure when no warehouse is available, so the caller bails out.
         with self.report.new_stage("Start warehouse"):
             wait_on_warehouse = self.unity_catalog_api_proxy.start_warehouse()
             if wait_on_warehouse is None:
                 self.report.failure(
                     message="SQL warehouse not found",
-                    context="Data quality assertions require a SQL warehouse",
+                    context=failure_context,
                 )
-                return
+                return False
             wait_on_warehouse.result()
+            return True
+
+    def _gen_data_quality_workunits(self) -> Iterable[MetadataWorkUnit]:
+        if not self._start_warehouse_or_report(
+            "Data quality assertions require a SQL warehouse"
+        ):
+            return
 
         with self.report.new_stage("Ingest data quality"):
             dq_extractor = UnityCatalogDataQualityExtractor(

--- a/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
+++ b/metadata-ingestion/src/datahub/ingestion/source/unity/source.py
@@ -679,24 +679,28 @@ class UnityCatalogSource(StatefulIngestionSourceBase, TestableSource):
                     raise ValueError("Unknown profiling config method")
 
         if self.config.data_quality.enabled:
-            with self.report.new_stage("Start warehouse"):
-                wait_on_warehouse = self.unity_catalog_api_proxy.start_warehouse()
-                if wait_on_warehouse is None:
-                    self.report.failure(
-                        message="SQL warehouse not found",
-                        context="Data quality assertions require a SQL warehouse",
-                    )
-                else:
-                    wait_on_warehouse.result()
-                    with self.report.new_stage("Ingest data quality"):
-                        dq_extractor = UnityCatalogDataQualityExtractor(
-                            config=self.config.data_quality,
-                            report=self.report,
-                            proxy=self.unity_catalog_api_proxy,
-                            dataset_urn_builder=self.gen_dataset_urn,
-                            end_time=self.config.end_time,
-                        )
-                        yield from dq_extractor.get_workunits(self.dq_tables.values())
+            yield from self._gen_data_quality_workunits()
+
+    def _gen_data_quality_workunits(self) -> Iterable[MetadataWorkUnit]:
+        with self.report.new_stage("Start warehouse"):
+            wait_on_warehouse = self.unity_catalog_api_proxy.start_warehouse()
+            if wait_on_warehouse is None:
+                self.report.failure(
+                    message="SQL warehouse not found",
+                    context="Data quality assertions require a SQL warehouse",
+                )
+                return
+            wait_on_warehouse.result()
+
+        with self.report.new_stage("Ingest data quality"):
+            dq_extractor = UnityCatalogDataQualityExtractor(
+                config=self.config.data_quality,
+                report=self.report,
+                proxy=self.unity_catalog_api_proxy,
+                dataset_urn_builder=self.gen_dataset_urn,
+                end_time=self.config.end_time,
+            )
+            yield from dq_extractor.get_workunits(self.dq_tables.values())
 
     def build_service_principal_map(self) -> None:
         try:

--- a/metadata-ingestion/tests/integration/unity/test_unity_catalog_ingest.py
+++ b/metadata-ingestion/tests/integration/unity/test_unity_catalog_ingest.py
@@ -731,7 +731,9 @@ def test_data_quality_ingestion(pytestconfig, tmp_path, requests_mock):
     output_file_name = "unity_catalog_data_quality_mcps.json"
 
     # A monitored column with no nulls passes completeness; one with nulls fails.
-    window_end = datetime(2021, 12, 6, tzinfo=timezone.utc)
+    # window_end must fall inside the extractor's query window
+    # [FROZEN_TIME - max_window_days, FROZEN_TIME] so it mirrors a real row.
+    window_end = datetime(2021, 12, 6, 8, tzinfo=timezone.utc)
     metric_rows = [
         _MetricRow(
             {

--- a/metadata-ingestion/tests/integration/unity/test_unity_catalog_ingest.py
+++ b/metadata-ingestion/tests/integration/unity/test_unity_catalog_ingest.py
@@ -1,7 +1,7 @@
 import uuid
 from collections import namedtuple
 from datetime import datetime, timezone
-from typing import Iterable
+from typing import Dict, Iterable
 from unittest import mock
 from unittest.mock import patch
 
@@ -699,6 +699,118 @@ def test_ingestion(pytestconfig, tmp_path, requests_mock):
             output_path=f"/{tmp_path}/{output_file_name}",
             golden_path=f"{test_resources_dir}/{mce_golden_file}",
         )
+
+
+class _DataProfilingConfig:
+    def __init__(self, profile_metrics_table_name: str) -> None:
+        self.profile_metrics_table_name = profile_metrics_table_name
+
+
+class _QualityMonitor:
+    def __init__(self, data_profiling_config: _DataProfilingConfig) -> None:
+        self.data_profiling_config = data_profiling_config
+
+
+class _MetricRow:
+    """Mimics a databricks.sql Row: the extractor only calls asDict()."""
+
+    def __init__(self, values: Dict[str, object]) -> None:
+        self._values = values
+
+    def asDict(self) -> Dict[str, object]:
+        return self._values
+
+
+@time_machine.travel(
+    datetime.fromisoformat(FROZEN_TIME).replace(tzinfo=timezone.utc), tick=False
+)
+def test_data_quality_ingestion(pytestconfig, tmp_path, requests_mock):
+    test_resources_dir = pytestconfig.rootpath / "tests/integration/unity"
+    register_mock_api(request_mock=requests_mock)
+
+    output_file_name = "unity_catalog_data_quality_mcps.json"
+
+    # A monitored column with no nulls passes completeness; one with nulls fails.
+    window_end = datetime(2021, 12, 6, tzinfo=timezone.utc)
+    metric_rows = [
+        _MetricRow(
+            {
+                "window_end": window_end,
+                "column_name": "columnA",
+                "monitor_version": 1,
+                "row_count": 10,
+                "num_nulls": 0,
+                "percent_null": 0.0,
+            }
+        ),
+        _MetricRow(
+            {
+                "window_end": window_end,
+                "column_name": "columnB",
+                "monitor_version": 1,
+                "row_count": 10,
+                "num_nulls": 2,
+                "percent_null": 0.2,
+            }
+        ),
+    ]
+    monitor = _QualityMonitor(
+        _DataProfilingConfig(
+            "quickstart_catalog.quickstart_schema.quickstart_table_profile_metrics"
+        )
+    )
+
+    with (
+        patch(
+            "datahub.ingestion.source.unity.connection.WorkspaceClient"
+        ) as mock_client,
+        patch.object(UnityCatalogApiProxy, "run_sql_query", return_value=metric_rows),
+    ):
+        workspace_client: mock.MagicMock = mock.MagicMock()
+        mock_client.return_value = workspace_client
+        register_mock_data(workspace_client)
+        workspace_client.data_quality.get_monitor.return_value = monitor
+
+        config_dict: dict = {
+            "run_id": "unity-catalog-dq-test",
+            "pipeline_name": "unity-catalog-dq-test-pipeline",
+            "source": {
+                "type": "unity-catalog",
+                "config": {
+                    "workspace_url": "https://dummy.cloud.databricks.com",
+                    "token": "fake",
+                    "warehouse_id": "test",
+                    "include_hive_metastore": False,
+                    "include_ownership": False,
+                    "include_table_lineage": False,
+                    "include_column_lineage": False,
+                    "include_usage_statistics": False,
+                    "include_ml_models": False,
+                    "include_notebooks": False,
+                    "profiling": {"enabled": False},
+                    "catalog_pattern": {"allow": ["quickstart_catalog"]},
+                    "table_pattern": {
+                        "allow": [
+                            r"quickstart_catalog\.quickstart_schema\.quickstart_table$"
+                        ]
+                    },
+                    "data_quality": {"enabled": True, "max_window_days": 1},
+                },
+            },
+            "sink": {
+                "type": "file",
+                "config": {"filename": f"{tmp_path}/{output_file_name}"},
+            },
+        }
+        pipeline = Pipeline.create(config_dict)
+        pipeline.run()
+        pipeline.raise_from_status()
+
+    mce_helpers.check_golden_file(
+        pytestconfig,
+        output_path=f"{tmp_path}/{output_file_name}",
+        golden_path=f"{test_resources_dir}/unity_catalog_data_quality_mces_golden.json",
+    )
 
 
 @time_machine.travel(

--- a/metadata-ingestion/tests/integration/unity/unity_catalog_data_quality_mces_golden.json
+++ b/metadata-ingestion/tests/integration/unity/unity_catalog_data_quality_mces_golden.json
@@ -432,8 +432,8 @@
     "aspectName": "assertionRunEvent",
     "aspect": {
         "json": {
-            "timestampMillis": 1638748800000,
-            "runId": "1:1638748800000",
+            "timestampMillis": 1638777600000,
+            "runId": "1:1638777600000",
             "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
             "status": "COMPLETE",
             "result": {
@@ -512,8 +512,8 @@
     "aspectName": "assertionRunEvent",
     "aspect": {
         "json": {
-            "timestampMillis": 1638748800000,
-            "runId": "1:1638748800000",
+            "timestampMillis": 1638777600000,
+            "runId": "1:1638777600000",
             "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
             "status": "COMPLETE",
             "result": {

--- a/metadata-ingestion/tests/integration/unity/unity_catalog_data_quality_mces_golden.json
+++ b/metadata-ingestion/tests/integration/unity/unity_catalog_data_quality_mces_golden.json
@@ -392,12 +392,22 @@
             },
             "type": "CUSTOM",
             "customAssertion": {
-                "type": "Databricks Data Quality",
+                "type": "Databricks",
                 "entity": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
                 "field": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD),columnA)",
+                "fields": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD),columnA)"
+                ],
                 "scope": "DATASET_COLUMN",
+                "aggregation": "NULL_COUNT",
                 "operator": "EQUAL_TO",
-                "logic": "num_nulls == 0.0 on columnA"
+                "parameters": {
+                    "value": {
+                        "value": "0",
+                        "type": "NUMBER"
+                    }
+                },
+                "nativeType": "completeness"
             },
             "source": {
                 "type": "EXTERNAL",
@@ -405,8 +415,7 @@
                     "time": 1638860400000,
                     "actor": "urn:li:corpuser:__datahub_system"
                 }
-            },
-            "description": "Completeness"
+            }
         }
     },
     "systemMetadata": {
@@ -463,12 +472,22 @@
             },
             "type": "CUSTOM",
             "customAssertion": {
-                "type": "Databricks Data Quality",
+                "type": "Databricks",
                 "entity": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
                 "field": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD),columnB)",
+                "fields": [
+                    "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD),columnB)"
+                ],
                 "scope": "DATASET_COLUMN",
+                "aggregation": "NULL_COUNT",
                 "operator": "EQUAL_TO",
-                "logic": "num_nulls == 0.0 on columnB"
+                "parameters": {
+                    "value": {
+                        "value": "0",
+                        "type": "NUMBER"
+                    }
+                },
+                "nativeType": "completeness"
             },
             "source": {
                 "type": "EXTERNAL",
@@ -476,8 +495,7 @@
                     "time": 1638860400000,
                     "actor": "urn:li:corpuser:__datahub_system"
                 }
-            },
-            "description": "Completeness"
+            }
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/integration/unity/unity_catalog_data_quality_mces_golden.json
+++ b/metadata-ingestion/tests/integration/unity/unity_catalog_data_quality_mces_golden.json
@@ -1,0 +1,575 @@
+[
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:730e95cd0271453376b3c1d9623838d6",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "databricks",
+                "env": "PROD",
+                "catalog": "quickstart_catalog"
+            },
+            "externalUrl": "https://dummy.cloud.databricks.com/explore/data/quickstart_catalog",
+            "name": "quickstart_catalog",
+            "description": "",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:730e95cd0271453376b3c1d9623838d6",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:730e95cd0271453376b3c1d9623838d6",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:databricks"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:730e95cd0271453376b3c1d9623838d6",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Catalog"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:730e95cd0271453376b3c1d9623838d6",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:934b6043df189ef6dc63ac3519be34ac",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:730e95cd0271453376b3c1d9623838d6"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:934b6043df189ef6dc63ac3519be34ac",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "platform": "databricks",
+                "env": "PROD",
+                "catalog": "quickstart_catalog",
+                "unity_schema": "quickstart_schema"
+            },
+            "externalUrl": "https://dummy.cloud.databricks.com/explore/data/quickstart_catalog/quickstart_schema",
+            "name": "quickstart_schema",
+            "description": "A new Unity Catalog schema called quickstart_schema",
+            "env": "PROD"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:934b6043df189ef6dc63ac3519be34ac",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:934b6043df189ef6dc63ac3519be34ac",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:databricks"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:934b6043df189ef6dc63ac3519be34ac",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Schema"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:934b6043df189ef6dc63ac3519be34ac",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:730e95cd0271453376b3c1d9623838d6",
+                    "urn": "urn:li:container:730e95cd0271453376b3c1d9623838d6"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:934b6043df189ef6dc63ac3519be34ac"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "storage_location": "s3://db-02eec1f70bfe4115445be9fdb1aac6ac-s3-root-bucket/metastore/2c983545-d403-4f87-9063-5b7e3b6d3736/tables/cff27aa1-1c6a-4d78-b713-562c660c2896",
+                "data_source_format": "DELTA",
+                "generation": "2",
+                "table_type": "MANAGED",
+                "created_by": "abc@acryl.io",
+                "delta.lastCommitTimestamp": "1666185711000",
+                "delta.lastUpdateVersion": "1",
+                "delta.minReaderVersion": "1",
+                "delta.minWriterVersion": "2",
+                "spark.sql.statistics.numRows": "10",
+                "spark.sql.statistics.totalSize": "512",
+                "table_id": "cff27aa1-1c6a-4d78-b713-562c660c2896",
+                "owner": "account users",
+                "updated_by": "abc@acryl.io",
+                "updated_at": "2022-10-19 13:27:29.633000+00:00",
+                "created_at": "2022-10-19 13:21:38.688000+00:00"
+            },
+            "externalUrl": "https://dummy.cloud.databricks.com/explore/data/quickstart_catalog/quickstart_schema/quickstart_table",
+            "name": "quickstart_table",
+            "qualifiedName": "quickstart_catalog.quickstart_schema.quickstart_table",
+            "created": {
+                "time": 1666185698688,
+                "actor": "urn:li:corpuser:abc@acryl.io"
+            },
+            "lastModified": {
+                "time": 1666186049633,
+                "actor": "urn:li:corpuser:abc@acryl.io"
+            },
+            "tags": []
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "quickstart_catalog.quickstart_schema.quickstart_table",
+            "platform": "urn:li:dataPlatform:databricks",
+            "version": 0,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.MySqlDDL": {
+                    "tableSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "columnA",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "int",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "columnB",
+                    "nullable": true,
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "browsePathsV2",
+    "aspect": {
+        "json": {
+            "path": [
+                {
+                    "id": "urn:li:container:730e95cd0271453376b3c1d9623838d6",
+                    "urn": "urn:li:container:730e95cd0271453376b3c1d9623838d6"
+                },
+                {
+                    "id": "urn:li:container:934b6043df189ef6dc63ac3519be34ac",
+                    "urn": "urn:li:container:934b6043df189ef6dc63ac3519be34ac"
+                }
+            ]
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:19823df694415d5ae41af6c314bdec3a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "metric": "num_nulls",
+                "threshold": "0.0"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Databricks Data Quality",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
+                "field": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD),columnA)",
+                "scope": "DATASET_COLUMN",
+                "operator": "EQUAL_TO",
+                "logic": "num_nulls == 0.0 on columnA"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1638860400000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            },
+            "description": "Completeness"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:19823df694415d5ae41af6c314bdec3a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1638748800000,
+            "runId": "1:1638748800000",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "SUCCESS",
+                "actualAggValue": 0.0,
+                "nativeResults": {
+                    "percent_null": "0.0",
+                    "row_count": "10",
+                    "monitor_version": "1"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:19823df694415d5ae41af6c314bdec3a",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:020cb44dea97a371f62b09a09a164a1a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionInfo",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "metric": "num_nulls",
+                "threshold": "0.0"
+            },
+            "type": "CUSTOM",
+            "customAssertion": {
+                "type": "Databricks Data Quality",
+                "entity": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
+                "field": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD),columnB)",
+                "scope": "DATASET_COLUMN",
+                "operator": "EQUAL_TO",
+                "logic": "num_nulls == 0.0 on columnB"
+            },
+            "source": {
+                "type": "EXTERNAL",
+                "created": {
+                    "time": 1638860400000,
+                    "actor": "urn:li:corpuser:__datahub_system"
+                }
+            },
+            "description": "Completeness"
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:020cb44dea97a371f62b09a09a164a1a",
+    "changeType": "UPSERT",
+    "aspectName": "assertionRunEvent",
+    "aspect": {
+        "json": {
+            "timestampMillis": 1638748800000,
+            "runId": "1:1638748800000",
+            "asserteeUrn": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
+            "status": "COMPLETE",
+            "result": {
+                "type": "FAILURE",
+                "actualAggValue": 2.0,
+                "nativeResults": {
+                    "percent_null": "0.2",
+                    "row_count": "10",
+                    "monitor_version": "1"
+                }
+            },
+            "assertionUrn": "urn:li:assertion:020cb44dea97a371f62b09a09a164a1a",
+            "partitionSpec": {
+                "partition": "FULL_TABLE_SNAPSHOT",
+                "type": "FULL_TABLE"
+            }
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:020cb44dea97a371f62b09a09a164a1a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "assertion",
+    "entityUrn": "urn:li:assertion:19823df694415d5ae41af6c314bdec3a",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "status",
+    "aspect": {
+        "json": {
+            "removed": false
+        }
+    },
+    "systemMetadata": {
+        "lastObserved": 1638860400000,
+        "runId": "unity-catalog-dq-test",
+        "lastRunId": "no-run-id-provided",
+        "pipelineName": "unity-catalog-dq-test-pipeline"
+    }
+}
+]

--- a/metadata-ingestion/tests/integration/unity/unity_catalog_data_quality_mces_golden.json
+++ b/metadata-ingestion/tests/integration/unity/unity_catalog_data_quality_mces_golden.json
@@ -392,7 +392,7 @@
             },
             "type": "CUSTOM",
             "customAssertion": {
-                "type": "Databricks",
+                "type": "Databricks Lakehouse Monitor",
                 "entity": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
                 "field": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD),columnA)",
                 "fields": [
@@ -415,7 +415,8 @@
                     "time": 1638860400000,
                     "actor": "urn:li:corpuser:__datahub_system"
                 }
-            }
+            },
+            "description": "Null count for column columnA is 0"
         }
     },
     "systemMetadata": {
@@ -472,7 +473,7 @@
             },
             "type": "CUSTOM",
             "customAssertion": {
-                "type": "Databricks",
+                "type": "Databricks Lakehouse Monitor",
                 "entity": "urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD)",
                 "field": "urn:li:schemaField:(urn:li:dataset:(urn:li:dataPlatform:databricks,quickstart_catalog.quickstart_schema.quickstart_table,PROD),columnB)",
                 "fields": [
@@ -495,7 +496,8 @@
                     "time": 1638860400000,
                     "actor": "urn:li:corpuser:__datahub_system"
                 }
-            }
+            },
+            "description": "Null count for column columnB is 0"
         }
     },
     "systemMetadata": {

--- a/metadata-ingestion/tests/unit/test_unity_catalog_config.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_config.py
@@ -184,6 +184,22 @@ def test_warehouse_id_auto_disables_tags_when_missing():
     assert config.warehouse_id is None
 
 
+def test_data_quality_auto_disabled_without_warehouse():
+    """data_quality requires a SQL warehouse, so it is auto-disabled when missing."""
+    config = UnityCatalogSourceConfig.model_validate(
+        {
+            "token": "token",
+            "workspace_url": "https://test.databricks.com",
+            "include_hive_metastore": False,
+            "include_tags": False,
+            "data_quality": {"enabled": True},
+            # warehouse_id is missing
+        }
+    )
+    assert config.data_quality.enabled is False
+    assert config.warehouse_id is None
+
+
 def test_warehouse_id_not_required_when_tags_disabled():
     """Test that warehouse_id is not required when include_tags=False."""
     config = UnityCatalogSourceConfig.model_validate(

--- a/metadata-ingestion/tests/unit/test_unity_catalog_data_quality.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_data_quality.py
@@ -7,7 +7,7 @@ from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.unity.assertion import (
     COMPLETENESS_NATIVE_TYPE,
-    DATABRICKS_ASSERTION_PROVIDER,
+    LAKEHOUSE_MONITOR_ASSERTION_TYPE,
     DataQualityAssertion,
     build_assertion_info_mcp,
     build_assertion_run_event_mcp,
@@ -153,10 +153,11 @@ def test_build_info_mcp_sets_column_field_urn() -> None:
     assert ca.field is not None
     assert "c1" in ca.field
     assert info.source is not None and info.source.type == "EXTERNAL"
-    # Structured shape (mirrors the dbt connector) drives DataHub's column-aware
-    # rendering rather than a hand-written description.
-    assert info.description is None
-    assert ca.type == DATABRICKS_ASSERTION_PROVIDER
+    # The assertions list renders the name from `description`, so it must carry the
+    # column (the frontend doesn't fetch the structured scope/aggregation fields).
+    assert info.description is not None
+    assert "c1" in info.description
+    assert ca.type == LAKEHOUSE_MONITOR_ASSERTION_TYPE
     assert ca.nativeType == COMPLETENESS_NATIVE_TYPE
     assert ca.aggregation == "NULL_COUNT"
     assert ca.operator == "EQUAL_TO"

--- a/metadata-ingestion/tests/unit/test_unity_catalog_data_quality.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_data_quality.py
@@ -24,6 +24,8 @@ from datahub.metadata.schema_classes import (
 
 PROFILE_TABLE = "cat.sch.tbl_profile_metrics"
 
+_UNSET = object()
+
 
 def _ref() -> TableReference:
     return TableReference(metastore=None, catalog="cat", schema="sch", table="tbl")
@@ -35,7 +37,6 @@ def _dataset_urn(ref: TableReference) -> str:
 
 def _result(column: str = "c1", num_nulls: float = 0.0) -> DataQualityAssertion:
     return DataQualityAssertion(
-        table_qualified_name=_ref().qualified_table_name,
         column=column,
         metric="num_nulls",
         threshold=0.0,
@@ -44,6 +45,15 @@ def _result(column: str = "c1", num_nulls: float = 0.0) -> DataQualityAssertion:
         timestamp_millis=1,
         run_id="0:1",
     )
+
+
+def _monitor(metrics_table: Optional[str] = PROFILE_TABLE) -> object:
+    profiling = (
+        SimpleNamespace(profile_metrics_table_name=metrics_table)
+        if metrics_table is not None
+        else None
+    )
+    return SimpleNamespace(data_profiling_config=profiling)
 
 
 class _FakeRow:
@@ -55,23 +65,33 @@ class _FakeRow:
 
 
 class _FakeProxy:
-    def __init__(self, rows: List[Dict[str, object]], available: bool = True) -> None:
-        self._rows = rows
+    def __init__(
+        self,
+        rows: Optional[List[Dict[str, object]]] = None,
+        available: bool = True,
+        monitor: object = _UNSET,
+        monitor_error: Optional[Exception] = None,
+        query_error: Optional[Exception] = None,
+    ) -> None:
+        self._rows = rows or []
         self._available = available
+        self._monitor = _monitor() if monitor is _UNSET else monitor
+        self._monitor_error = monitor_error
+        self._query_error = query_error
         self.queries: List[str] = []
 
     def data_quality_available(self) -> bool:
         return self._available
 
-    def get_quality_monitor(self, table_id: str) -> Optional[object]:
-        return SimpleNamespace(
-            data_profiling_config=SimpleNamespace(
-                profile_metrics_table_name=PROFILE_TABLE
-            )
-        )
+    def get_quality_monitor(self, table_id: str) -> object:
+        if self._monitor_error is not None:
+            raise self._monitor_error
+        return self._monitor
 
     def run_sql_query(self, query: str) -> List[_FakeRow]:
         self.queries.append(query)
+        if self._query_error is not None:
+            raise self._query_error
         return [_FakeRow(r) for r in self._rows]
 
 
@@ -88,8 +108,6 @@ def _extractor(
         proxy=proxy,  # type: ignore[arg-type]
         dataset_urn_builder=_dataset_urn,
         end_time=datetime(2026, 9, 12, tzinfo=timezone.utc),
-        platform_instance=None,
-        env="PROD",
     )
 
 
@@ -104,25 +122,27 @@ def _row(column: str, num_nulls: float) -> Dict[str, object]:
     }
 
 
-def test_assertion_urn_is_deterministic_and_stable_across_windows() -> None:
-    # Same identity fields -> same URN even though the run window differs, so
-    # re-ingesting a check is idempotent.
-    a = _result(num_nulls=0.0)
-    b = _result(num_nulls=0.0)
-    b.timestamp_millis = 999
-    assert make_dq_assertion_urn(a, None, "PROD") == make_dq_assertion_urn(
-        b, None, "PROD"
-    )
-    assert make_dq_assertion_urn(a, None, "PROD") != make_dq_assertion_urn(
-        _result(column="c2"), None, "PROD"
-    )
+def test_assertion_urn_is_deterministic_and_namespaced_by_dataset() -> None:
+    dataset_urn = _dataset_urn(_ref())
+    other_dataset_urn = make_dataset_urn("databricks", "cat.sch.other", "PROD")
+    # Same identity -> same URN; column, metric, and dataset each change it, so
+    # assertions from different datasets/workspaces cannot collide.
+    assert make_dq_assertion_urn(
+        dataset_urn, "c1", "num_nulls"
+    ) == make_dq_assertion_urn(dataset_urn, "c1", "num_nulls")
+    assert make_dq_assertion_urn(
+        dataset_urn, "c1", "num_nulls"
+    ) != make_dq_assertion_urn(dataset_urn, "c2", "num_nulls")
+    assert make_dq_assertion_urn(
+        dataset_urn, "c1", "num_nulls"
+    ) != make_dq_assertion_urn(other_dataset_urn, "c1", "num_nulls")
 
 
 def test_build_info_mcp_sets_column_field_urn() -> None:
     ref = _ref()
     dataset_urn = _dataset_urn(ref)
     result = _result()
-    urn = make_dq_assertion_urn(result, None, "PROD")
+    urn = make_dq_assertion_urn(dataset_urn, result.column, result.metric)
     info = build_assertion_info_mcp(result, urn, dataset_urn).aspect
     assert isinstance(info, AssertionInfoClass)
     assert info.customAssertion is not None
@@ -207,3 +227,39 @@ def test_extractor_skips_when_api_unavailable() -> None:
 def test_extractor_skips_table_without_id() -> None:
     proxy = _FakeProxy(rows=[_row("c1", 0.0)])
     assert list(_extractor(proxy).get_workunits([_table(table_id=None)])) == []
+
+
+def test_extractor_counts_table_without_monitor() -> None:
+    proxy = _FakeProxy(monitor=None)
+    extractor = _extractor(proxy)
+    assert list(extractor.get_workunits([_table()])) == []
+    assert extractor.report.num_quality_tables_without_monitor == 1
+    assert extractor.report.num_quality_monitors_found == 0
+
+
+def test_extractor_reports_monitor_without_metrics_table() -> None:
+    proxy = _FakeProxy(monitor=_monitor(metrics_table=None))
+    extractor = _extractor(proxy)
+    assert list(extractor.get_workunits([_table()])) == []
+    assert list(extractor.report.quality_monitors_missing_metrics) == [
+        _ref().qualified_table_name
+    ]
+    assert extractor.report.num_quality_monitors_found == 0
+
+
+def test_extractor_reports_monitor_api_error() -> None:
+    # A real API error must not be mistaken for an unmonitored table.
+    proxy = _FakeProxy(monitor_error=RuntimeError("boom"))
+    extractor = _extractor(proxy)
+    assert list(extractor.get_workunits([_table()])) == []
+    assert extractor.report.num_quality_monitor_errors == 1
+    assert extractor.report.num_quality_tables_without_monitor == 0
+
+
+def test_extractor_reports_metric_query_failure() -> None:
+    # run_sql_query raises on failure, so a broken query is reported rather than
+    # silently looking like a monitor with no rows.
+    proxy = _FakeProxy(rows=[_row("c1", 0.0)], query_error=RuntimeError("no SELECT"))
+    extractor = _extractor(proxy)
+    assert list(extractor.get_workunits([_table()])) == []
+    assert extractor.report.num_quality_metric_query_failures == 1

--- a/metadata-ingestion/tests/unit/test_unity_catalog_data_quality.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_data_quality.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set, cast
 
 from datahub.emitter.mce_builder import make_dataset_urn
+from datahub.emitter.mcp import MetadataChangeProposalWrapper
+from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.unity.assertion import (
     DataQualityAssertion,
     build_assertion_info_mcp,
@@ -11,7 +13,7 @@ from datahub.ingestion.source.unity.assertion import (
 )
 from datahub.ingestion.source.unity.config import UnityCatalogDataQualityConfig
 from datahub.ingestion.source.unity.data_quality import UnityCatalogDataQualityExtractor
-from datahub.ingestion.source.unity.proxy_types import TableReference
+from datahub.ingestion.source.unity.proxy_types import Table, TableReference
 from datahub.ingestion.source.unity.report import UnityCatalogReport
 from datahub.metadata.schema_classes import (
     AssertionInfoClass,
@@ -73,8 +75,8 @@ class _FakeProxy:
         return [_FakeRow(r) for r in self._rows]
 
 
-def _table(table_id: Optional[str] = "table-uuid") -> SimpleNamespace:
-    return SimpleNamespace(table_id=table_id, ref=_ref())
+def _table(table_id: Optional[str] = "table-uuid") -> Table:
+    return cast(Table, SimpleNamespace(table_id=table_id, ref=_ref()))
 
 
 def _extractor(
@@ -130,22 +132,38 @@ def test_build_info_mcp_sets_column_field_urn() -> None:
     assert info.source is not None and info.source.type == "EXTERNAL"
 
 
+def _run_event_type(result: DataQualityAssertion) -> str:
+    aspect = build_assertion_run_event_mcp(
+        result, "urn:li:assertion:x", _dataset_urn(_ref())
+    ).aspect
+    assert isinstance(aspect, AssertionRunEventClass)
+    assert aspect.result is not None
+    return str(aspect.result.type)
+
+
 def test_build_run_event_result_types() -> None:
-    dataset_urn = _dataset_urn(_ref())
-    urn = "urn:li:assertion:x"
-    passed = build_assertion_run_event_mcp(
-        _result(num_nulls=0.0), urn, dataset_urn
-    ).aspect
-    failed = build_assertion_run_event_mcp(
-        _result(num_nulls=5.0), urn, dataset_urn
-    ).aspect
-    assert isinstance(passed, AssertionRunEventClass)
-    assert passed.result.type == AssertionResultTypeClass.SUCCESS
-    assert failed.result.type == AssertionResultTypeClass.FAILURE
+    assert _run_event_type(_result(num_nulls=0.0)) == AssertionResultTypeClass.SUCCESS
+    assert _run_event_type(_result(num_nulls=5.0)) == AssertionResultTypeClass.FAILURE
 
 
-def _aspect_names(workunits) -> List[str]:
-    return [wu.metadata.aspectName for wu in workunits]
+def _aspect_names(workunits: List[MetadataWorkUnit]) -> List[str]:
+    names = []
+    for wu in workunits:
+        assert isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        assert wu.metadata.aspectName is not None
+        names.append(wu.metadata.aspectName)
+    return names
+
+
+def _run_event_types(workunits: List[MetadataWorkUnit]) -> Set[str]:
+    types: Set[str] = set()
+    for wu in workunits:
+        assert isinstance(wu.metadata, MetadataChangeProposalWrapper)
+        aspect = wu.metadata.aspect
+        if isinstance(aspect, AssertionRunEventClass):
+            assert aspect.result is not None
+            types.add(str(aspect.result.type))
+    return types
 
 
 def test_extractor_emits_assertion_and_run_event_per_column() -> None:
@@ -160,12 +178,7 @@ def test_extractor_emits_assertion_and_run_event_per_column() -> None:
     assert report.num_quality_assertions_emitted == 2
     assert report.num_quality_run_events_emitted == 2
     # c1 passes (0 nulls), c2 fails (10 nulls > 0).
-    results = {
-        wu.metadata.aspect.result.type
-        for wu in wus
-        if wu.metadata.aspectName == "assertionRunEvent"
-    }
-    assert results == {
+    assert _run_event_types(wus) == {
         AssertionResultTypeClass.SUCCESS,
         AssertionResultTypeClass.FAILURE,
     }

--- a/metadata-ingestion/tests/unit/test_unity_catalog_data_quality.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_data_quality.py
@@ -1,0 +1,196 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Dict, List, Optional
+
+from datahub.emitter.mce_builder import make_dataset_urn
+from datahub.ingestion.source.unity.assertion import (
+    DataQualityAssertion,
+    build_assertion_info_mcp,
+    build_assertion_run_event_mcp,
+    make_dq_assertion_urn,
+)
+from datahub.ingestion.source.unity.config import UnityCatalogDataQualityConfig
+from datahub.ingestion.source.unity.data_quality import UnityCatalogDataQualityExtractor
+from datahub.ingestion.source.unity.proxy_types import TableReference
+from datahub.ingestion.source.unity.report import UnityCatalogReport
+from datahub.metadata.schema_classes import (
+    AssertionInfoClass,
+    AssertionResultTypeClass,
+    AssertionRunEventClass,
+    DatasetAssertionScopeClass,
+)
+
+PROFILE_TABLE = "cat.sch.tbl_profile_metrics"
+
+
+def _ref() -> TableReference:
+    return TableReference(metastore=None, catalog="cat", schema="sch", table="tbl")
+
+
+def _dataset_urn(ref: TableReference) -> str:
+    return make_dataset_urn("databricks", ref.qualified_table_name, "PROD")
+
+
+def _result(column: str = "c1", num_nulls: float = 0.0) -> DataQualityAssertion:
+    return DataQualityAssertion(
+        table_qualified_name=_ref().qualified_table_name,
+        column=column,
+        metric="num_nulls",
+        threshold=0.0,
+        observed=num_nulls,
+        passed=num_nulls <= 0.0,
+        timestamp_millis=1,
+        run_id="0:1",
+    )
+
+
+class _FakeRow:
+    def __init__(self, data: Dict[str, object]) -> None:
+        self._data = data
+
+    def asDict(self) -> Dict[str, object]:
+        return self._data
+
+
+class _FakeProxy:
+    def __init__(self, rows: List[Dict[str, object]], available: bool = True) -> None:
+        self._rows = rows
+        self._available = available
+        self.queries: List[str] = []
+
+    def data_quality_available(self) -> bool:
+        return self._available
+
+    def get_quality_monitor(self, table_id: str) -> Optional[object]:
+        return SimpleNamespace(
+            data_profiling_config=SimpleNamespace(
+                profile_metrics_table_name=PROFILE_TABLE
+            )
+        )
+
+    def run_sql_query(self, query: str) -> List[_FakeRow]:
+        self.queries.append(query)
+        return [_FakeRow(r) for r in self._rows]
+
+
+def _table(table_id: Optional[str] = "table-uuid") -> SimpleNamespace:
+    return SimpleNamespace(table_id=table_id, ref=_ref())
+
+
+def _extractor(
+    proxy: _FakeProxy, config: Optional[UnityCatalogDataQualityConfig] = None
+) -> UnityCatalogDataQualityExtractor:
+    return UnityCatalogDataQualityExtractor(
+        config=config or UnityCatalogDataQualityConfig(enabled=True),
+        report=UnityCatalogReport(),
+        proxy=proxy,  # type: ignore[arg-type]
+        dataset_urn_builder=_dataset_urn,
+        end_time=datetime(2026, 9, 12, tzinfo=timezone.utc),
+        platform_instance=None,
+        env="PROD",
+    )
+
+
+def _row(column: str, num_nulls: float) -> Dict[str, object]:
+    return {
+        "window_end": datetime(2026, 9, 11, tzinfo=timezone.utc),
+        "column_name": column,
+        "monitor_version": 0,
+        "row_count": 100,
+        "num_nulls": num_nulls,
+        "percent_null": num_nulls,
+    }
+
+
+def test_assertion_urn_is_deterministic_and_stable_across_windows() -> None:
+    # Same identity fields -> same URN even though the run window differs, so
+    # re-ingesting a check is idempotent.
+    a = _result(num_nulls=0.0)
+    b = _result(num_nulls=0.0)
+    b.timestamp_millis = 999
+    assert make_dq_assertion_urn(a, None, "PROD") == make_dq_assertion_urn(
+        b, None, "PROD"
+    )
+    assert make_dq_assertion_urn(a, None, "PROD") != make_dq_assertion_urn(
+        _result(column="c2"), None, "PROD"
+    )
+
+
+def test_build_info_mcp_sets_column_field_urn() -> None:
+    ref = _ref()
+    dataset_urn = _dataset_urn(ref)
+    result = _result()
+    urn = make_dq_assertion_urn(result, None, "PROD")
+    info = build_assertion_info_mcp(result, urn, dataset_urn).aspect
+    assert isinstance(info, AssertionInfoClass)
+    assert info.customAssertion is not None
+    assert info.customAssertion.scope == DatasetAssertionScopeClass.DATASET_COLUMN
+    assert info.customAssertion.field is not None
+    assert "c1" in info.customAssertion.field
+    assert info.source is not None and info.source.type == "EXTERNAL"
+
+
+def test_build_run_event_result_types() -> None:
+    dataset_urn = _dataset_urn(_ref())
+    urn = "urn:li:assertion:x"
+    passed = build_assertion_run_event_mcp(
+        _result(num_nulls=0.0), urn, dataset_urn
+    ).aspect
+    failed = build_assertion_run_event_mcp(
+        _result(num_nulls=5.0), urn, dataset_urn
+    ).aspect
+    assert isinstance(passed, AssertionRunEventClass)
+    assert passed.result.type == AssertionResultTypeClass.SUCCESS
+    assert failed.result.type == AssertionResultTypeClass.FAILURE
+
+
+def _aspect_names(workunits) -> List[str]:
+    return [wu.metadata.aspectName for wu in workunits]
+
+
+def test_extractor_emits_assertion_and_run_event_per_column() -> None:
+    proxy = _FakeProxy(rows=[_row("c1", 0.0), _row("c2", 10.0)])
+    extractor = _extractor(proxy)
+    wus = list(extractor.get_workunits([_table()]))
+    names = _aspect_names(wus)
+    assert names.count("assertionInfo") == 2  # one per column, emitted once
+    assert names.count("assertionRunEvent") == 2
+    report = extractor.report
+    assert report.num_quality_monitors_found == 1
+    assert report.num_quality_assertions_emitted == 2
+    assert report.num_quality_run_events_emitted == 2
+    # c1 passes (0 nulls), c2 fails (10 nulls > 0).
+    results = {
+        wu.metadata.aspect.result.type
+        for wu in wus
+        if wu.metadata.aspectName == "assertionRunEvent"
+    }
+    assert results == {
+        AssertionResultTypeClass.SUCCESS,
+        AssertionResultTypeClass.FAILURE,
+    }
+
+
+def test_extractor_column_pattern_filters_columns() -> None:
+    config = UnityCatalogDataQualityConfig(enabled=True)
+    config.column_pattern.deny.append("c2")
+    proxy = _FakeProxy(rows=[_row("c1", 0.0), _row("c2", 0.0)])
+    wus = list(_extractor(proxy, config).get_workunits([_table()]))
+    assert _aspect_names(wus).count("assertionInfo") == 1
+
+
+def test_extractor_skips_rows_without_null_metric() -> None:
+    row = _row("c1", 0.0)
+    row["num_nulls"] = None
+    wus = list(_extractor(_FakeProxy(rows=[row])).get_workunits([_table()]))
+    assert wus == []
+
+
+def test_extractor_skips_when_api_unavailable() -> None:
+    proxy = _FakeProxy(rows=[_row("c1", 0.0)], available=False)
+    assert list(_extractor(proxy).get_workunits([_table()])) == []
+
+
+def test_extractor_skips_table_without_id() -> None:
+    proxy = _FakeProxy(rows=[_row("c1", 0.0)])
+    assert list(_extractor(proxy).get_workunits([_table(table_id=None)])) == []

--- a/metadata-ingestion/tests/unit/test_unity_catalog_data_quality.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_data_quality.py
@@ -6,6 +6,8 @@ from datahub.emitter.mce_builder import make_dataset_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.api.workunit import MetadataWorkUnit
 from datahub.ingestion.source.unity.assertion import (
+    COMPLETENESS_NATIVE_TYPE,
+    DATABRICKS_ASSERTION_PROVIDER,
     DataQualityAssertion,
     build_assertion_info_mcp,
     build_assertion_run_event_mcp,
@@ -146,10 +148,20 @@ def test_build_info_mcp_sets_column_field_urn() -> None:
     info = build_assertion_info_mcp(result, urn, dataset_urn).aspect
     assert isinstance(info, AssertionInfoClass)
     assert info.customAssertion is not None
-    assert info.customAssertion.scope == DatasetAssertionScopeClass.DATASET_COLUMN
-    assert info.customAssertion.field is not None
-    assert "c1" in info.customAssertion.field
+    ca = info.customAssertion
+    assert ca.scope == DatasetAssertionScopeClass.DATASET_COLUMN
+    assert ca.field is not None
+    assert "c1" in ca.field
     assert info.source is not None and info.source.type == "EXTERNAL"
+    # Structured shape (mirrors the dbt connector) drives DataHub's column-aware
+    # rendering rather than a hand-written description.
+    assert info.description is None
+    assert ca.type == DATABRICKS_ASSERTION_PROVIDER
+    assert ca.nativeType == COMPLETENESS_NATIVE_TYPE
+    assert ca.aggregation == "NULL_COUNT"
+    assert ca.operator == "EQUAL_TO"
+    assert ca.parameters is not None and ca.parameters.value is not None
+    assert ca.parameters.value.value == "0"
 
 
 def _run_event_type(result: DataQualityAssertion) -> str:

--- a/metadata-ingestion/tests/unit/test_unity_catalog_proxy.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_proxy.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+from databricks.sdk.errors import NotFound
 
 from datahub.ingestion.source.unity.proxy import (
     ExternalUpstream,
@@ -2017,3 +2018,63 @@ class TestQueryFilterWithStatementTypesSerialisation:
 
         result_types = f.as_dict()["statement_types"]
         assert result_types == [t.value for t in types_in]
+
+
+class TestUnityCatalogDataQualityProxy:
+    """Direct tests for the data-quality proxy seams: only NotFound degrades to
+    None, and run_sql_query raises (rather than returning []) on failure."""
+
+    @pytest.fixture
+    def mock_proxy(self):
+        from databricks.sdk import WorkspaceClient
+
+        mock_workspace_client = MagicMock(spec=WorkspaceClient)
+        mock_workspace_client.config.host = "https://test.databricks.com"
+        mock_workspace_client.config.token = "test_token"
+        mock_workspace_client.config.warehouse_id = "test_warehouse"
+        return UnityCatalogApiProxy(
+            workspace_client=mock_workspace_client,
+            report=UnityCatalogReport(),
+        )
+
+    def test_get_quality_monitor_returns_monitor(self, mock_proxy):
+        monitor = object()
+        mock_proxy._workspace_client.data_quality.get_monitor.return_value = monitor
+        assert mock_proxy.get_quality_monitor("table-id") is monitor
+
+    def test_get_quality_monitor_missing_api_returns_none(self, mock_proxy):
+        # Older databricks-sdk without the data_quality client.
+        mock_proxy._workspace_client.data_quality = None
+        assert mock_proxy.get_quality_monitor("table-id") is None
+
+    def test_get_quality_monitor_not_found_returns_none(self, mock_proxy):
+        mock_proxy._workspace_client.data_quality.get_monitor.side_effect = NotFound(
+            "no monitor"
+        )
+        assert mock_proxy.get_quality_monitor("table-id") is None
+
+    def test_get_quality_monitor_other_error_raises(self, mock_proxy):
+        mock_proxy._workspace_client.data_quality.get_monitor.side_effect = (
+            RuntimeError("boom")
+        )
+        with pytest.raises(RuntimeError):
+            mock_proxy.get_quality_monitor("table-id")
+
+    def test_run_sql_query_returns_rows(self, mock_proxy):
+        with patch("datahub.ingestion.source.unity.proxy.connect") as mock_connect:
+            cursor = MagicMock()
+            cursor.fetchall.return_value = ["row-a", "row-b"]
+            connection = MagicMock()
+            connection.cursor.return_value.__enter__.return_value = cursor
+            mock_connect.return_value.__enter__.return_value = connection
+
+            assert mock_proxy.run_sql_query("SELECT 1") == ["row-a", "row-b"]
+            cursor.execute.assert_called_once_with("SELECT 1")
+
+    def test_run_sql_query_raises_on_failure(self, mock_proxy):
+        with patch(
+            "datahub.ingestion.source.unity.proxy.connect",
+            side_effect=RuntimeError("db down"),
+        ):
+            with pytest.raises(RuntimeError):
+                mock_proxy.run_sql_query("SELECT 1")

--- a/metadata-ingestion/tests/unit/test_unity_catalog_proxy.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_proxy.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound
 
 from datahub.ingestion.source.unity.proxy import (
@@ -17,23 +18,20 @@ from datahub.ingestion.source.unity.proxy_patch import _basic_proxy_auth_header
 from datahub.ingestion.source.unity.report import UnityCatalogReport
 
 
+@pytest.fixture
+def mock_proxy():
+    """A UnityCatalogApiProxy backed by a mocked WorkspaceClient."""
+    mock_workspace_client = MagicMock(spec=WorkspaceClient)
+    mock_workspace_client.config.host = "https://test.databricks.com"
+    mock_workspace_client.config.token = "test_token"
+    mock_workspace_client.config.warehouse_id = "test_warehouse"
+    return UnityCatalogApiProxy(
+        workspace_client=mock_workspace_client,
+        report=UnityCatalogReport(),
+    )
+
+
 class TestUnityCatalogProxy:
-    @pytest.fixture
-    def mock_proxy(self):
-        """Create a mock UnityCatalogApiProxy for testing."""
-        from databricks.sdk import WorkspaceClient
-
-        mock_workspace_client = MagicMock(spec=WorkspaceClient)
-        mock_workspace_client.config.host = "https://test.databricks.com"
-        mock_workspace_client.config.token = "test_token"
-        mock_workspace_client.config.warehouse_id = "test_warehouse"
-
-        proxy = UnityCatalogApiProxy(
-            workspace_client=mock_workspace_client,
-            report=UnityCatalogReport(),
-        )
-        return proxy
-
     def test_build_datetime_where_conditions_empty(self, mock_proxy):
         """Test datetime conditions with no start/end time."""
         result = mock_proxy._build_datetime_where_conditions()
@@ -1659,22 +1657,6 @@ class TestUnityCatalogProxyAuthentication:
 class TestUnityCatalogProxyUsageSystemTables:
     """Test suite for system tables query history functionality."""
 
-    @pytest.fixture
-    def mock_proxy(self):
-        """Create a mock UnityCatalogApiProxy for testing."""
-        from databricks.sdk import WorkspaceClient
-
-        mock_workspace_client = MagicMock(spec=WorkspaceClient)
-        mock_workspace_client.config.host = "https://test.databricks.com"
-        mock_workspace_client.config.token = "test_token"
-        mock_workspace_client.config.warehouse_id = "test_warehouse"
-
-        proxy = UnityCatalogApiProxy(
-            workspace_client=mock_workspace_client,
-            report=UnityCatalogReport(),
-        )
-        return proxy
-
     @patch(
         "datahub.ingestion.source.unity.proxy.UnityCatalogApiProxy._execute_sql_query_streaming"
     )
@@ -2023,19 +2005,6 @@ class TestQueryFilterWithStatementTypesSerialisation:
 class TestUnityCatalogDataQualityProxy:
     """Direct tests for the data-quality proxy seams: only NotFound degrades to
     None, and run_sql_query raises (rather than returning []) on failure."""
-
-    @pytest.fixture
-    def mock_proxy(self):
-        from databricks.sdk import WorkspaceClient
-
-        mock_workspace_client = MagicMock(spec=WorkspaceClient)
-        mock_workspace_client.config.host = "https://test.databricks.com"
-        mock_workspace_client.config.token = "test_token"
-        mock_workspace_client.config.warehouse_id = "test_warehouse"
-        return UnityCatalogApiProxy(
-            workspace_client=mock_workspace_client,
-            report=UnityCatalogReport(),
-        )
 
     def test_get_quality_monitor_returns_monitor(self, mock_proxy):
         monitor = object()

--- a/metadata-ingestion/tests/unit/test_unity_catalog_source.py
+++ b/metadata-ingestion/tests/unit/test_unity_catalog_source.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, Mock, patch
 
 import pytest
 from databricks.sdk.service.catalog import TableType
@@ -164,6 +164,56 @@ class TestUnityCatalogSource:
             usage_data_source=config.usage_data_source,
             databricks_api_page_size=200,
         )
+
+    @staticmethod
+    def _dq_source(mock_unity_proxy):
+        config = UnityCatalogSourceConfig.model_validate(
+            {
+                "token": "test_token",
+                "workspace_url": "https://test.databricks.com",
+                "warehouse_id": "test_warehouse",
+                "include_hive_metastore": False,
+                "data_quality": {"enabled": True},
+            }
+        )
+        source = UnityCatalogSource.create(config, PipelineContext(run_id="test_run"))
+        source.dq_tables = {"my_catalog.my_schema.my_table": object()}  # type: ignore[assignment]
+        return source
+
+    @patch("datahub.ingestion.source.unity.source.UnityCatalogDataQualityExtractor")
+    @patch("datahub.ingestion.source.unity.source.UnityCatalogApiProxy")
+    @patch("datahub.ingestion.source.unity.source.HiveMetastoreProxy")
+    def test_data_quality_stage_runs_extractor_when_warehouse_starts(
+        self, mock_hive_proxy, mock_unity_proxy, mock_extractor
+    ):
+        source = self._dq_source(mock_unity_proxy)
+        source.unity_catalog_api_proxy.start_warehouse.return_value = Mock()
+        sentinel = Mock()
+        mock_extractor.return_value.get_workunits.return_value = [sentinel]
+
+        workunits = list(source._gen_data_quality_workunits())
+
+        assert workunits == [sentinel]
+        source.unity_catalog_api_proxy.start_warehouse.return_value.result.assert_called_once()
+        mock_extractor.return_value.get_workunits.assert_called_once()
+        (passed_tables,) = mock_extractor.return_value.get_workunits.call_args.args
+        assert list(passed_tables) == list(source.dq_tables.values())
+        assert not source.report.failures
+
+    @patch("datahub.ingestion.source.unity.source.UnityCatalogDataQualityExtractor")
+    @patch("datahub.ingestion.source.unity.source.UnityCatalogApiProxy")
+    @patch("datahub.ingestion.source.unity.source.HiveMetastoreProxy")
+    def test_data_quality_stage_reports_failure_when_no_warehouse(
+        self, mock_hive_proxy, mock_unity_proxy, mock_extractor
+    ):
+        source = self._dq_source(mock_unity_proxy)
+        source.unity_catalog_api_proxy.start_warehouse.return_value = None
+
+        workunits = list(source._gen_data_quality_workunits())
+
+        assert workunits == []
+        mock_extractor.assert_not_called()
+        assert len(list(source.report.failures)) == 1
 
     def test_test_connection_with_page_size_config(self):
         """Test that test_connection properly handles databricks_api_page_size."""


### PR DESCRIPTION
## Summary

Adds an opt-in `data_quality` extractor to the Unity Catalog source that surfaces Databricks **data quality monitors** (formerly Lakehouse Monitoring) in DataHub as native **assertions**.

For each ingested table that has a monitor, the connector reads the monitor's `*_profile_metrics` table over SQL and publishes a **column completeness** assertion (plus a per-run result) for every monitored column — the null count the monitor already computes, published as a check that passes when the column has no nulls in the window.

The data quality checks live in Databricks (the monitor), not in the recipe, so enabling the feature is a single flag:

```yaml
source:
  type: unity-catalog
  config:
    warehouse_id: "<your-warehouse-id>"
    data_quality:
      enabled: true
```

### Behavior

- One completeness assertion per monitored column (subject to `column_pattern`); the whole-table summary row is not published.
- Assertion identity is deterministic (dataset + column + metric, excluding the run window), so re-ingesting is idempotent — the same assertion accrues new run events rather than duplicating.
- Assertions are emitted as `CUSTOM` with an `EXTERNAL` source, so they render as externally-sourced checks in the UI.
- Each assertion is categorized as **Databricks Lakehouse Monitor** and named for the column it checks (e.g. `Null count for column amount is 0`), so columns are distinguishable in the assertions list.
- `max_window_days` bounds how far back monitor windows are evaluated relative to the ingestion `end_time` (default: the most recent 7 days).
- Requires `warehouse_id` (metric tables are queried over SQL) and a `databricks-sdk` exposing the data quality API (>= 0.68.0). Both are feature-detected and degrade with a warning; `data_quality.enabled` auto-disables (with a warning) when `warehouse_id` is unset.

### Implementation

- `assertion.py` — a normalized `DataQualityAssertion` model plus pure builders for the `assertionInfo` / `assertionRunEvent` MCPs. This is the seam between where a DQ result comes from and how DataHub represents it, so other Databricks DQ sources can reuse the same publication path later.
- `data_quality.py` — the extractor: discovers a table's monitor, queries the profile-metrics table (windowed), and maps each column's null count to a completeness assertion.
- `proxy.py` — feature-detects the data quality API and exposes helpers to fetch a monitor and run a SQL query.
- `config.py` / `source.py` / `report.py` — config block, wiring into a dedicated ingestion stage, and report counters.

## Checklist

- [x] The PR conforms to DataHub's Contributing Guideline (particularly [Commit Message Format](https://datahubproject.io/docs/contributing/#commit-message-format))
- [x] Tests added/updated (unit tests for the builders and the extractor, using a fake proxy — no live calls)
- [x] Docs updated (`metadata-ingestion/docs/sources/databricks/unity-catalog_post.md`)
- [ ] No breaking changes (feature is opt-in and disabled by default)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `data_quality` extractor to the Unity Catalog source that publishes Databricks data quality monitor results as column completeness assertions in DataHub. When enabled, the connector starts the SQL warehouse, reads each monitored table's profile-metrics table over SQL, and emits per-column completeness assertions with per-run results; assertions are structured custom checks labeled "Databricks Lakehouse Monitor" and named "Null count for column X is equal to 0", and their URNs exclude the run window so re-ingestion is idempotent.

**Requirements**

- Requires `warehouse_id`; the connector starts and waits on the warehouse before extracting, and reports a failure if the warehouse isn't found.
- The ingesting principal needs `SELECT` on each monitor's `*_profile_metrics` table; grant `USE SCHEMA` if that schema isn't otherwise ingested.
- Requires `databricks-sdk` >= 0.68.0 for the data quality API; older SDKs skip extraction with a warning.
- Only monitor windows within `max_window_days` of the ingestion end time are published (default 7, so a daily monitor that refreshed a day or two ago still surfaces results).
- If `warehouse_id` is missing, the feature auto-disables with a warning.
- Disabled by default; no breaking changes.

<sup>Written for commit c4de2579be6c654dabde1a7bf368d41ed11e1334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/datahub-project/datahub/pull/19754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

